### PR TITLE
Add license name to MIT license

### DIFF
--- a/licenses/mit.txt
+++ b/licenses/mit.txt
@@ -23,6 +23,8 @@ forbidden:
 
 ---
 
+The MIT License (MIT)
+
 Copyright (c) <<year>> <<fullname>>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of


### PR DESCRIPTION
It's very helpful/timesaving to people considering making use of a project for the license text to have the title, so they don't have to do a search to confirm what the license is. Therefore, the portion of the MIT license that gets copied to clipboard should have the license title.
