### PR TITLE
Licenses/ should link to the no-license license, not to /no-license

### DIFF
--- a/licenses/no-license.html
+++ b/licenses/no-license.html
@@ -1,6 +1,6 @@
 ---
 layout: license
-permalink: /no-license/
+permalink: /licenses/no-license/
 class: license-types
 title: No License
 


### PR DESCRIPTION
When you click the "no license" license from /licenses/ it should go to the license text, not to the /no-license/ meta page linked from the index.

This is a result of a permalink conflict, now resolved.
