### PR TITLE
Update eclipse.txt - include disclose-source

### DIFF
--- a/licenses/eclipse.txt
+++ b/licenses/eclipse.txt
@@ -10,6 +10,7 @@ how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of 
 source: http://www.eclipse.org/legal/epl-v10.html
 
 required:
+  - disclose-source
   - include-copyright
 
 permitted:


### PR DESCRIPTION
I think this was a mistake removal in 3c29d5da87e560c3cc39c36753c58a60e79664ce. I'm not a legal expert though.
