### PR TITLE
Strip html from description when displaying in meta tag

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -8,7 +8,7 @@
     <meta content='IE=edge,chrome=1' http-equiv='X-UA-Compatible'>
     
     {% if page.description %}
-    <meta name="description" content="{{ page.description }}">
+    <meta name="description" content="{{ page.description | strip_html }}">
     {% endif %}
 
     <link href='/favicon.ico' rel='shortcut icon' type='image/x-icon'>


### PR DESCRIPTION
This fixes the issue of description of the BSD license (which includes links) showing at top of: http://choosealicense.com/licenses/bsd/
