### PR TITLE
Added Note About Affero GPL to Disclose Source message.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -12,7 +12,7 @@ rules:
       description: Indicate significant changes made to the code.
       label: State Changes
     disclose-source:
-      description: Source code must be made available when distributing the software. In the case of LGPL, the source for the library (and not the entire program) must be made available.
+      description: Source code must be made available when distributing the software. In the case of LGPL, the source for the library (and not the entire program) must be made available. In the case of the Affero GPL (AGPL), the definition of distributing is expanded to include networked access.
       label: Disclose Source
     library-usage:
       description: The library may be used within a non-open-source application. 


### PR DESCRIPTION
#8 adds a description of the AGPL license. This goes with that by adding a note about the AGPL (similar to the one for the LGPL) inside the Disclose Source info message.
