### PR TITLE
Remove "private-use" rule

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -34,9 +34,6 @@ rules:
     sublicense: 
       description: You may grant a sublicense to modify and distribute this software to third parties not included in the license.
       label: Sublicensing
-    private-use: 
-      description: You may use and modify the software without distributing it.
-      label: Private Use
     patent-grant:
       description: This license provides an express grant of patent rights from the contributor to the recipient.
       label: Patent Grant
@@ -60,7 +57,4 @@ rules:
     sublicense:
       description: You may not grant a sublicense to modify and distribute this software to third parties not included in the license.
       label: Sublicensing
-    private-use:
-      description: You may not use or modify the software without distributing it.
-      label: Private Use
 

--- a/_config.yml
+++ b/_config.yml
@@ -60,4 +60,7 @@ rules:
     sublicense:
       description: You may not grant a sublicense to modify and distribute this software to third parties not included in the license.
       label: Sublicensing
+    private-use:
+      description: You may not use or modify the software without distributing it.
+      label: Private Use
 

--- a/licenses/agpl.txt
+++ b/licenses/agpl.txt
@@ -21,6 +21,7 @@ permitted:
 forbidden:
   - no-liability
   - no-sublicense
+  - private-use
 
 using:
   Some Project: "#"

--- a/licenses/agpl.txt
+++ b/licenses/agpl.txt
@@ -21,7 +21,6 @@ permitted:
 forbidden:
   - no-liability
   - no-sublicense
-  - private-use
 
 using:
   Some Project: "#"

--- a/licenses/artistic.txt
+++ b/licenses/artistic.txt
@@ -18,7 +18,6 @@ permitted:
   - modifications
   - distribution
   - sublicense
-  - private-use
 forbidden:
   - no-liability
   - trademark-use

--- a/licenses/no-license.html
+++ b/licenses/no-license.html
@@ -14,7 +14,6 @@ required:
   - include-copyright
 
 permitted:
-  - private-use
   - commercial-use
 
 forbidden:

--- a/licenses/public-domain.txt
+++ b/licenses/public-domain.txt
@@ -11,7 +11,6 @@ how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of 
 required: 
 
 permitted:
-  - private-use
   - commercial-use
   - modifications
   - distribution


### PR DESCRIPTION
All licenses permit private use, so this information doesn't help in choosing a license. See #1 for more discussion.
