### PR TITLE
Use travis for ci to verify builds work before merging

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+#bootstrap and build
+before_script: "./script/bootstrap"
+script: "./script/cibuild"
+
+#environment
+language: ruby
+rvm: 
+  - 1.9.3

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -3,6 +3,7 @@
 set -e
 
 echo "bundling installin'"
+gem install bundler
 bundle install
 
 echo "npm installin'"

--- a/script/cibuild
+++ b/script/cibuild
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+set -e
+
+echo "compiling javascript..."
+./node_modules/.bin/coffee -c javascripts/app.coffee
+
+echo "building the site..."
+bundle exec jekyll build --trace


### PR DESCRIPTION
This will alert us via the Merge API if pull requests fail to build either due to Jekyll or CoffeeScript errors.
