### PR TITLE
point out weak file-based copyleft of MPL

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -12,7 +12,7 @@ rules:
       description: Indicate significant changes made to the code.
       label: State Changes
     disclose-source:
-      description: Source code must be made available when distributing the software. In the case of LGPL, the source for the library (and not the entire program) must be made available.
+      description: Source code must be made available when distributing the software. In the case of LGPL, the source for the library (and not the entire program) must be made available. In the case of the MPL, only files explicitly placed under the MPL and changes to them must be made available, not new files added to the project nor the entire program.
       label: Disclose Source
     library-usage:
       description: The library may be used within a non-open-source application. 


### PR DESCRIPTION
The current description makes the MPL come off as if it had GPL-strength copyleft, which it doesn't.

http://www.mozilla.org/MPL/2.0/FAQ.html#virality
