### PR TITLE
Added WordPress to list of GPL repos on homepage.

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,7 +39,7 @@ description: A site to provide non-judgmental guidance on choosing a license for
       The GPL (<a href="licenses/gpl-v2">V2</a> or <a href="licenses/gpl-v3">V3</a>) is a copyleft license that requires others who modify your code to disclose their changes if they redistribute it in source or binary form. V3 is similar to V2, but further restricts use in hardware that forbids software alterations.
     </p>
     <p>
-      <strong>Linux</strong> and <strong>Git</strong> use the GPL.
+      <strong>Linux</strong>, <strong>Git</strong> and <strong>WordPress</strong> use the GPL.
     </p>
   </li>
 </ul>


### PR DESCRIPTION
WordPress is a very popular, very public facing open source project that uses GPL.
