### PR TITLE
Leave out dev things.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -61,3 +61,7 @@ rules:
       description: You may not grant a sublicense to modify and distribute this software to third parties not included in the license.
       label: Sublicensing
 
+exclude:
+  - CNAME
+  - Gemfile*
+  - script


### PR DESCRIPTION
In #27, I noticed that `script/*` ended up [on the built site](http://choosealicense.com/script/cibuild). This removes them from the published site.
