### PR TITLE
Link cleanup

### DIFF
--- a/_layouts/license.html
+++ b/_layouts/license.html
@@ -4,7 +4,7 @@
         <div class='license-body'>
           <pre id="license-text">
 
-{{ content | replace:"<<","[" | replace:">>","]" }}
+{{ content }}
         
           </pre><!-- /license-text -->
         </div><!-- /license-body -->

--- a/licenses/agpl.txt
+++ b/licenses/agpl.txt
@@ -30,7 +30,7 @@ using:
                     GNU AFFERO GENERAL PUBLIC LICENSE
                        Version 3, 19 November 2007
 
- Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
+ Copyright (C) 2007 Free Software Foundation, Inc. [http://fsf.org/]
  Everyone is permitted to copy and distribute verbatim copies
  of this license document, but changing it is not allowed.
 
@@ -672,7 +672,7 @@ the "copyright" line and a pointer to where the full notice is found.
     GNU Affero General Public License for more details.
 
     You should have received a copy of the GNU Affero General Public License
-    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    along with this program.  If not, see [http://www.gnu.org/licenses/].
 
 Also add information on how to contact you by electronic and paper mail.
 
@@ -687,4 +687,4 @@ specific requirements.
   You should also get your employer (if you work as a programmer) or school,
 if any, to sign a "copyright disclaimer" for the program, if necessary.
 For more information on this, and how to apply and follow the GNU AGPL, see
-<http://www.gnu.org/licenses/>.
+[http://www.gnu.org/licenses/].

--- a/licenses/artistic.txt
+++ b/licenses/artistic.txt
@@ -7,7 +7,7 @@ source: http://opensource.org/licenses/Artistic-2.0
 
 description: A license that&#8217;s heavily favored by the Perl community.
 
-how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file. Replace <<year>> with the current year and <<copyright holders>> with the name (or names) of the copyright holders.
+how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file. Replace [year] with the current year and [copyright holders] with the name (or names) of the copyright holders.
 
 required:
   - include-copyright

--- a/licenses/bsd-3-clause.txt
+++ b/licenses/bsd-3-clause.txt
@@ -3,7 +3,7 @@ layout: license
 title: BSD (3-Clause) License
 permalink: /licenses/bsd-3-clause/
 
-how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file. Replace <<year>> with the current year and <<fullname>> with the name (or names) of the copyright holders. Replace {organization} with the organization, if any, that sponsors this work.
+how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file. Replace [year] with the current year and [fullname] with the name (or names) of the copyright holders. Replace {organization} with the organization, if any, that sponsors this work.
 
 source: http://opensource.org/licenses/BSD-3-Clause
 
@@ -22,7 +22,7 @@ forbidden:
 
 ---
 
-Copyright (c) <<year>>, <<fullname>>
+Copyright (c) [year], [fullname]
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification,

--- a/licenses/bsd-3-clause.txt
+++ b/licenses/bsd-3-clause.txt
@@ -3,7 +3,7 @@ layout: license
 title: BSD (3-Clause) License
 permalink: /licenses/bsd-3-clause/
 
-how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file. Replace [year] with the current year and [fullname] with the name (or names) of the copyright holders. Replace {organization} with the organization, if any, that sponsors this work.
+how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file. Replace [year] with the current year and [fullname] with the name (or names) of the copyright holders. Replace [organization] with the organization, if any, that sponsors this work.
 
 source: http://opensource.org/licenses/BSD-3-Clause
 
@@ -35,7 +35,7 @@ are permitted provided that the following conditions are met:
   list of conditions and the following disclaimer in the documentation and/or
   other materials provided with the distribution.
 
-  Neither the name of the {organization} nor the names of its
+  Neither the name of the [organization] nor the names of its
   contributors may be used to endorse or promote products derived from
   this software without specific prior written permission.
 

--- a/licenses/bsd.txt
+++ b/licenses/bsd.txt
@@ -5,7 +5,7 @@ permalink: /licenses/bsd/
 
 description: A permissive license that comes in two variants, the <a href="/licenses/bsd">BSD 2-Clause</a> and <a href="/licenses/bsd-3-clause">BSD 3-Clause</a>. Both have very minute differences to the MIT license.
 
-how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file. Replace <<year>> with the current year and <<fullname>> with the name (or names) of the copyright holders.
+how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file. Replace [year] with the current year and [fullname] with the name (or names) of the copyright holders.
 
 source: http://opensource.org/licenses/BSD-2-Clause
 
@@ -23,7 +23,7 @@ forbidden:
 
 ---
 
-Copyright (c) <<year>>, <<fullname>>
+Copyright (c) [year], [fullname]
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification,

--- a/licenses/gpl-v2.txt
+++ b/licenses/gpl-v2.txt
@@ -318,8 +318,8 @@ to attach them to the start of each source file to most effectively
 convey the exclusion of warranty; and each file should have at least
 the "copyright" line and a pointer to where the full notice is found.
 
-    <<description>>
-    Copyright (C) <<year>>  <<fullname>>
+    [description]
+    Copyright (C) [year]  [fullname]
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/licenses/gpl-v3.txt
+++ b/licenses/gpl-v3.txt
@@ -28,7 +28,7 @@ forbidden:
                     GNU GENERAL PUBLIC LICENSE
                        Version 3, 29 June 2007
 
- Copyright (C) 2007 Free Software Foundation, Inc. {http://fsf.org/}
+ Copyright (C) 2007 Free Software Foundation, Inc. [http://fsf.org/]
  Everyone is permitted to copy and distribute verbatim copies
  of this license document, but changing it is not allowed.
 
@@ -672,7 +672,7 @@ the "copyright" line and a pointer to where the full notice is found.
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with this program.  If not, see {http://www.gnu.org/licenses/}.
+    along with this program.  If not, see [http://www.gnu.org/licenses/].
 
 Also add information on how to contact you by electronic and paper mail.
 
@@ -691,11 +691,11 @@ might be different; for a GUI interface, you would use an "about box".
   You should also get your employer (if you work as a programmer) or school,
 if any, to sign a "copyright disclaimer" for the program, if necessary.
 For more information on this, and how to apply and follow the GNU GPL, see
-{http://www.gnu.org/licenses/}.
+[http://www.gnu.org/licenses/].
 
   The GNU General Public License does not permit incorporating your program
 into proprietary programs.  If your program is a subroutine library, you
 may consider it more useful to permit linking proprietary applications with
 the library.  If this is what you want to do, use the GNU Lesser General
 Public License instead of this License.  But first, please read
-{http://www.gnu.org/philosophy/why-not-lgpl.html}.
+[http://www.gnu.org/philosophy/why-not-lgpl.html].

--- a/licenses/gpl-v3.txt
+++ b/licenses/gpl-v3.txt
@@ -679,7 +679,7 @@ Also add information on how to contact you by electronic and paper mail.
   If the program does terminal interaction, make it output a short
 notice like this when it starts in an interactive mode:
 
-    <<project>>  Copyright (C) <<year>>  <<fullname>>
+    [project]  Copyright (C) [year]  [fullname]
     This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
     This is free software, and you are welcome to redistribute it
     under certain conditions; type `show c' for details.

--- a/licenses/lgpl-v2.1.txt
+++ b/licenses/lgpl-v2.1.txt
@@ -498,8 +498,8 @@ safest to attach them to the start of each source file to most effectively
 convey the exclusion of warranty; and each file should have at least the
 "copyright" line and a pointer to where the full notice is found.
 
-    <<description>>
-    Copyright (C) <<year>>  <<fullname>>
+    [description]
+    Copyright (C) [year]  [fullname]
 
     This library is free software; you can redistribute it and/or
     modify it under the terms of the GNU Lesser General Public

--- a/licenses/lgpl-v3.txt
+++ b/licenses/lgpl-v3.txt
@@ -28,7 +28,7 @@ forbidden:
                    GNU LESSER GENERAL PUBLIC LICENSE
                        Version 3, 29 June 2007
 
- Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
+ Copyright (C) 2007 Free Software Foundation, Inc. [http://fsf.org/]
  Everyone is permitted to copy and distribute verbatim copies
  of this license document, but changing it is not allowed.
 

--- a/licenses/mit.txt
+++ b/licenses/mit.txt
@@ -7,7 +7,7 @@ featured: true
 
 description:  A permissive license that is short and to the point. It lets people do anything with your code with proper attribution and without warranty.
 
-how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file. Replace <<year>> with the current year and <<fullname>> with the name (or names) of the copyright holders.
+how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file. Replace [year] with the current year and [fullname] with the name (or names) of the copyright holders.
 
 required:
   - include-copyright
@@ -25,7 +25,7 @@ forbidden:
 
 The MIT License (MIT)
 
-Copyright (c) <<year>> <<fullname>>
+Copyright (c) [year] [fullname]
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/licenses/no-license.html
+++ b/licenses/no-license.html
@@ -24,4 +24,4 @@ forbidden:
 
 ---
 
-Copyright <<year>> <<fullname>>	
+Copyright [year] [fullname]	

--- a/licenses/public-domain.txt
+++ b/licenses/public-domain.txt
@@ -3,6 +3,7 @@ layout: license
 permalink: /licenses/public-domain/
 class: license-types
 title: Public Domain (Unlicense)
+filename: UNLICENSE
 
 description: Because copyright is automatic in most countries, the Unlicense is a template to waive interest in software you've written and dedicate it to the public domain. Use the Unlicense to opt out of copyright entirely. It also includes the no-warranty statement from the MIT/X11 license.
 

--- a/licenses/public-domain.txt
+++ b/licenses/public-domain.txt
@@ -44,4 +44,4 @@ OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
 ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 OTHER DEALINGS IN THE SOFTWARE.
 
-For more information, please refer to <<http://unlicense.org/>>
+For more information, please refer to http://unlicense.org

--- a/licenses/public-domain.txt
+++ b/licenses/public-domain.txt
@@ -5,7 +5,7 @@ class: license-types
 title: Public Domain (Unlicense)
 filename: UNLICENSE
 
-description: Because copyright is automatic in most countries, the Unlicense is a template to waive interest in software you've written and dedicate it to the public domain. Use the Unlicense to opt out of copyright entirely. It also includes the no-warranty statement from the MIT/X11 license.
+description: Because copyright is automatic in most countries, <a href="http://unlicense.org">the Unlicense</a> is a template to waive copyright interest in software you've written and dedicate it to the public domain. Use the Unlicense to opt out of copyright entirely. It also includes the no-warranty statement from the MIT/X11 license.
 
 how: Create a text file (typically named UNLICENSE or UNLICENSE.txt) in the root of your source code and copy the text of the license disclaimer into the file.
 


### PR DESCRIPTION
Don't use `<<url>>` escaping for links in licenses as it's not compatible with how .com parses them. Standardizes on `[url]` for embedded links, and a tiny bit of unlicense copy.
