### PR TITLE
Add ISC license.

### DIFF
--- a/licenses/isc.txt
+++ b/licenses/isc.txt
@@ -1,0 +1,42 @@
+---
+layout: license
+title: ISC license
+permalink: /licenses/isc/
+
+description: A permissive license written by the Internet Systems Consortium (ISC).  It is functionally equivalent to the <a href="/license/bsd">BSD 2-Clause</a> with the language that was made unnecessary by the Berne convention removed.
+
+how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file. Replace [year] with the current year, [fullname] with the name (or names) of the copyright holders, and [email] with the copyright holders' email address(es).
+note: Because of the general brevity and simplicity of the ISC license it is generally recommended to copy the entire text of the license into a comment at the top of every file.
+
+filename: LICENSE
+
+source: http://opensource.org/licenses/isc-license
+
+required:
+  - include-copyright
+
+permitted:
+  - commercial-use
+  - distribution
+  - modifications
+  - private-use
+  - sublicense
+
+forbidden:
+  - no-liability
+
+---
+
+Copyright (c) [year], [fullname] <[email]>
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.


### PR DESCRIPTION
The ISC license is functionally equivalent to the 2-clause BSD
license, but is simpler and easier to understand.  It was written
by the Internet Systems Consortium (ISC), and is the license used
by BIND, DHCP and INN, and is the preferred license of the OpenBSD
project.
