### PR TITLE
Add license property 'include-copyright-binary'.

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ The licenses on choosealicense.com are regularly imported to GitHub.com to be us
 
 # Rules 
 
-* Rules (the license's properties) are stored as a bulleted list within the licenses YAML front matter. A full list of rules can be found in the repository's `_config.yml` file. Each rule has a name e.g., `include-copyright`, a human-readable label, e.g., `Copyright inclusion`, and a description `Include the original copyright with the code`. To add a new rule, simply add it to config.yml and reference it in the appropriate license. 
+* Rules (the license's properties) are stored as a bulleted list within the licenses YAML front matter. A full list of rules can be found in the repository's `_config.yml` file. Each rule has a name e.g., `include-copyright-source`, a human-readable label, e.g., `Copyright inclusion`, and a description `Include the original copyright with the code`. To add a new rule, simply add it to config.yml and reference it in the appropriate license. 
 
 # License
 

--- a/_config.yml
+++ b/_config.yml
@@ -5,9 +5,12 @@ markdown: redcarpet
 rules:
 
   required:
-    include-copyright:
-      description: Include a copy of the license and copyright notice with the code.
-      label:  License and copyright notice
+    include-copyright-source:
+      description: Include a copy of the license and copyright notice with the source code.
+      label: License and copyright notice with source
+    include-copyright-binary:
+      description: Include a copy of the license and copyright notice with any binaries.
+      label: Notice in binary distribution 
     document-changes: 
       description: Indicate significant changes made to the code.
       label: State Changes

--- a/licenses/agpl.txt
+++ b/licenses/agpl.txt
@@ -9,7 +9,7 @@ note: The Free Software Foundation recommends taking the additional step of addi
 how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file.
 
 required:
-  - include-copyright
+  - include-copyright-source
   - document-changes
   - disclose-source
 

--- a/licenses/apache.txt
+++ b/licenses/apache.txt
@@ -14,7 +14,7 @@ how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of 
 source: http://www.apache.org/licenses/LICENSE-2.0.html
 
 required:
-  - include-copyright
+  - include-copyright-source
   - document-changes
 
 permitted:

--- a/licenses/artistic.txt
+++ b/licenses/artistic.txt
@@ -10,7 +10,7 @@ description: A license that&#8217;s heavily favored by the Perl community.
 how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file. Replace [year] with the current year and [fullname] with the name (or names) of the copyright holders.
 
 required:
-  - include-copyright
+  - include-copyright-source
   - document-changes
   - disclose-source
 permitted:

--- a/licenses/bsd-3-clause.txt
+++ b/licenses/bsd-3-clause.txt
@@ -8,7 +8,7 @@ how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of 
 source: http://opensource.org/licenses/BSD-3-Clause
 
 required:
-  - include-copyright
+  - include-copyright-source
 
 permitted:
   - commercial-use

--- a/licenses/bsd.txt
+++ b/licenses/bsd.txt
@@ -10,7 +10,7 @@ how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of 
 source: http://opensource.org/licenses/BSD-2-Clause
 
 required:
-  - include-copyright
+  - include-copyright-source
 
 permitted:
   - commercial-use

--- a/licenses/eclipse.txt
+++ b/licenses/eclipse.txt
@@ -11,7 +11,7 @@ source: http://www.eclipse.org/legal/epl-v10.html
 
 required:
   - disclose-source
-  - include-copyright
+  - include-copyright-source
 
 permitted:
   - commercial-use

--- a/licenses/gpl-v2.txt
+++ b/licenses/gpl-v2.txt
@@ -10,7 +10,7 @@ how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of 
 note: The Free Software Foundation recommends taking the additional step of adding a boilerplate notice to the top of each file. The boilerplate can be found at the end of the license.
 
 required:
-  - include-copyright
+  - include-copyright-source
   - document-changes
   - disclose-source
 

--- a/licenses/gpl-v3.txt
+++ b/licenses/gpl-v3.txt
@@ -10,7 +10,7 @@ how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of 
 note: The Free Software Foundation recommends taking the additional step of adding a boilerplate notice to the top of each file. The boilerplate can be found at the end of the license.
 
 required:
-  - include-copyright
+  - include-copyright-source
   - document-changes
   - disclose-source
 

--- a/licenses/lgpl-v2.1.txt
+++ b/licenses/lgpl-v2.1.txt
@@ -10,7 +10,7 @@ how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of 
 note: The Free Software Foundation recommends taking the additional step of adding a boilerplate notice to the top of each file. The boilerplate can be found at the end of the license.
 
 required:
-  - include-copyright
+  - include-copyright-source
   - library-usage
   - disclose-source
 

--- a/licenses/lgpl-v3.txt
+++ b/licenses/lgpl-v3.txt
@@ -10,7 +10,7 @@ how: This license is an additional set of permissions to the <a href="/licenses/
 note: The Free Software Foundation recommends taking the additional step of adding a boilerplate notice to the top of each file. The boilerplate can be found at the end of the license.
 
 required:
-  - include-copyright
+  - include-copyright-source
   - library-usage
   - disclose-source
 

--- a/licenses/mit.txt
+++ b/licenses/mit.txt
@@ -10,7 +10,7 @@ description:  A permissive license that is short and to the point. It lets peopl
 how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file. Replace [year] with the current year and [fullname] with the name (or names) of the copyright holders.
 
 required:
-  - include-copyright
+  - include-copyright-source
 
 permitted:
   - commercial-use

--- a/licenses/mozilla.txt
+++ b/licenses/mozilla.txt
@@ -9,7 +9,7 @@ how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of 
 
 required:
   - disclose-source
-  - include-copyright
+  - include-copyright-source
 
 permitted:
   - commercial-use

--- a/licenses/no-license.html
+++ b/licenses/no-license.html
@@ -11,7 +11,7 @@ note: This option may be subject to the Terms Of Use of the site where you publi
 how: Simply do nothing, though including a copyright notice is recommended.
 
 required: 
-  - include-copyright
+  - include-copyright-source
 
 permitted:
   - private-use


### PR DESCRIPTION
Add an additional license property: "Must this license be part of a binary distribution?"

To make this clear, rename 'include-copyright' to 'include-copyright-source', so that we
can call the new property 'include-copyright-binary'.

Note that this commit does not yet set this property for the existing licenses-- that requires actually reading them. :-)

Background: In the course of my work it is very useful to know whether the binary form of someone else's product actually must be accompanied by a license, or whether it may be redistributed without.
