### PR TITLE
Users should be warned of Apache/GPLv2 compatibility concerns

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,7 +29,7 @@ description: A site to provide non-judgmental guidance on choosing a license for
       The <a href="licenses/apache/">Apache License</a> is a permissive license similar to the MIT License, but also provides an express grant of patent rights from contributors to users.
     </p>
     <p>
-      As the Apache license is not compatible with the GPLv2 license, some open source projects cannot use software under the Apache license.
+      Some "GPLv2 only" open source projects refuse to include code under the Apache license, as they consider the two licenses to be incompatible.
     </p>
     <p>
       <strong>Apache</strong>, <strong>SVN</strong>, and <strong>NuGet</strong> use the Apache&nbsp;License.

--- a/index.html
+++ b/index.html
@@ -29,6 +29,9 @@ description: A site to provide non-judgmental guidance on choosing a license for
       The <a href="licenses/apache/">Apache License</a> is a permissive license similar to the MIT License, but also provides an express grant of patent rights from contributors to users.
     </p>
     <p>
+      As the Apache license is not compatible with the GPLv2 license, some open source projects cannot use software under the Apache license.
+    </p>
+    <p>
       <strong>Apache</strong>, <strong>SVN</strong>, and <strong>NuGet</strong> use the Apache&nbsp;License.
     </p>
   </li>


### PR DESCRIPTION
Choosing to use the Apache license instead of MIT means that some "GPLv2 only" projects may choose not to use the software. This is rarely something that users of a permissive license actually want.

While the legal situation is murky (the ASF and FSF disagree about whether the licenses are actually incompatible), this is not just a theoretical problem from a social perspective: https://github.com/twitter/bootstrap/issues/2054
