### PR TITLE
make notations of no-license more coherent

### DIFF
--- a/licenses/no-license.html
+++ b/licenses/no-license.html
@@ -4,7 +4,7 @@ permalink: /licenses/no-license/
 class: license-types
 title: No License
 
-description: You retain all rights and do not permit distribution, reproduction, or derivative works. You may grant some rights in cases where you publish your source code to a site that requires accepting terms of service. For example, publishing to GitHub requires you allow others to view and fork your code.
+description: You retain all rights and do not permit distribution, reproduction, or derivative works. You may grant some rights in cases where you publish your source code to a site that requires accepting terms of service. For example, publishing code in a public repository on GitHub requires you allow others to view and fork your code.
 
 note: This option may be subject to the Terms Of Use of the site where you publish your source code.
 

--- a/no-license.md
+++ b/no-license.md
@@ -8,6 +8,6 @@ You're under no obligation to choose a license and it's your right not to includ
 
 You'll have to check with your own legal counsel regarding your particular project, but generally speaking, the absence of a license means that default copyright laws apply. This means that you retain all rights to your source code and that nobody else may reproduce, distribute, or create derivative works from your work. This might not be what you intend.
 
-Even in the absence of a license file, if you publish your source code in a public repository on GitHub, you have accepted the [Terms of Service](https://help.github.com/articles/github-terms-of-service) which do allow other GitHub users some rights. Specifically, you allow others to view and fork your repository. 
+Even in the absence of a license file, you may grant some rights in cases where you publish your source code to a site that requires accepting terms of service. For example, if you publish your source code in a public repository on GitHub, you have accepted the [Terms of Service](https://help.github.com/articles/github-terms-of-service) which do allow other GitHub users some rights. Specifically, you allow others to view and fork your repository. 
 
 If you want to share your work with others, please consider choosing an open source license.


### PR DESCRIPTION
- make notations of /no-license.md and licenses/no-license.html
  more coherent
- clarify only publishing code on a _public_ repo on github grants
  others the right to view and fork your code in
  licenses/no-license.html
