### PR TITLE
Exclude vendor from Jekyll

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -65,3 +65,4 @@ exclude:
   - CNAME
   - Gemfile*
   - script
+  - vendor


### PR DESCRIPTION
This will tell Jekyll not to look at the `vendor` folder, preventing build errors and allowing CI to pass.

![screen shot 2013-08-12 at 1 20 03 pm](https://f.cloud.github.com/assets/282759/948957/725977e8-0373-11e3-85f8-4fe71da8c2db.png)
