### PR TITLE
put license text in lighter container for better contrast

### DIFF
--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -1,7 +1,7 @@
 <div class='sidebar'>
 
   <a href="#" data-clipboard-target="license-text" class="js-clipboard-button button">Copy license text to clipboard</a>
-    <div class='how-to-apply callout'>
+    <div class='how-to-apply'>
       <h5>How to apply this license</h5>
       <p>
         {{ page.how }}
@@ -42,5 +42,5 @@
       </ul>
     </div>
     {% endif %}
-    
+
   </div><!-- /sidebar -->

--- a/css/application.css
+++ b/css/application.css
@@ -161,7 +161,7 @@ strong {
 
 .container {
   margin: 40px auto;
-  width: 900px;
+  width: 940px;
 }
 
 .home {
@@ -232,7 +232,6 @@ strong {
   -webkit-border-radius: 3px;
   -moz-border-radius: 3px;
   -ms-border-radius: 3px;
-  -o-border-radius: 3px;
   border-radius: 3px;
   color: #5c5855;
   padding: 16px;
@@ -316,12 +315,19 @@ strong {
 .license-body {
   font-size: 15px;
   float: left;
-  width: 660px;
+  width: 700px;
 }
 
 .license-body pre {
   font-family: Consolas, Monaco, Courier, monospace;
   font-size: 14px;
+  background-color: rgba(255, 255, 255, 0.8);
+  border: 1px solid #e9e6e1;
+  -webkit-border-radius: 3px;
+  -moz-border-radius: 3px;
+  -ms-border-radius: 3px;
+  border-radius: 3px;
+  padding: 20px;
 }
 
 .sidebar {
@@ -350,6 +356,7 @@ strong {
 
 .sidebar .source {
   margin-top: 4px;
+  margin-bottom: 30px;
 }
 .sidebar .source a {
   padding-left: 20px;


### PR DESCRIPTION
This addresses the color contrast part (but not the font stack part) of #85.

I've put the license text in a lighter container as @cobyism mentioned. I needed to add some padding to this container, so I've widened the overall page container to account for this.

I also unboxed the sidebar "How to apply this license" callout. since it looked a bit cluttered with the new license text box.

![screen shot 2013-09-25 at 8 57 22 am](https://f.cloud.github.com/assets/6104/1209185/9b253738-25e3-11e3-9498-8263bc082fbb.png)

/cc @Haacked @anshin
