### PR TITLE
Added zlib license

### DIFF
--- a/licenses/zlib.txt
+++ b/licenses/zlib.txt
@@ -1,0 +1,45 @@
+---
+layout: license
+title: ZLib License
+permalink: /licenses/zlib/
+
+featured: false
+
+description:  A permissive license, similar to MIT and BSD, but which states the rules around attribution and misrepresentation more explicitly.
+
+how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file. Replace [year] with the current year and [name] with the name (or names) of the copyright holders.
+
+required:
+  - include-copyright
+
+permitted:
+  - commercial-use
+  - modifications
+  - distribution
+  - sublicense
+
+forbidden:
+  - no-liability
+
+---
+
+Copyright (c) [year] [name]
+
+This software is provided 'as-is', without any express or implied
+warranty. In no event will the authors be held liable for any damages
+arising from the use of this software.
+
+Permission is granted to anyone to use this software for any purpose,
+including commercial applications, and to alter it and redistribute it
+freely, subject to the following restrictions:
+
+   1. The origin of this software must not be misrepresented; you must not
+   claim that you wrote the original software. If you use this software
+   in a product, an acknowledgment in the product documentation would be
+   appreciated but is not required.
+
+   2. Altered source versions must be plainly marked as such, and must not be
+   misrepresented as being the original software.
+
+   3. This notice may not be removed or altered from any source
+   distribution.


### PR DESCRIPTION
The zlib license is another concise, permissive license that is similar to MIT and BSD. I appreciate that the aim of the site is not to catalog all such licenses, and you may not consider the zlib license to be sufficiently differentiated from MIT, in which case feel free to reject this pull request.

The reason I feel that it's worth including is that the short bullet points are more readable than the MIT "wall of text", and it also mentions explicitly that attribution in binary forms is "appreciated, but not required", which is a nice and friendly way to word it, and sets it apart from the stern legalise of other licenses IMHO.
