### PR TITLE
Add license sources where missing

### DIFF
--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -12,9 +12,11 @@
       </p>
       {% endif %}
     </div>
+    {% if page.source %}
     <div class="source">
-      <a href="{{ page.source}}">Source</a>
+      <a href="{{ page.source }}">Source</a>
     </div>
+    {% endif %}
 
      <div class="license-rules license-rules-sidebar">
 

--- a/licenses/gpl-v2.txt
+++ b/licenses/gpl-v2.txt
@@ -2,6 +2,7 @@
 title: GPL v2
 layout: license
 permalink: /licenses/gpl-v2/
+source: http://www.gnu.org/licenses/gpl-2.0.txt
 
 featured: true
 

--- a/licenses/gpl-v3.txt
+++ b/licenses/gpl-v3.txt
@@ -2,6 +2,7 @@
 title: GPL v3
 layout: license
 permalink: /licenses/gpl-v3/
+source: http://www.gnu.org/licenses/gpl-3.0.txt
 
 description: GPL is the most widely used free software license and has a strong copyleft requirement. When distributing derived works, the source code of the work must be made available under the same license.
 

--- a/licenses/lgpl-v2.1.txt
+++ b/licenses/lgpl-v2.1.txt
@@ -2,6 +2,7 @@
 layout: license
 title: LGPL v2.1
 permalink: /licenses/lgpl-v2.1/
+source: http://www.gnu.org/licenses/lgpl-2.1.txt
 
 description: Primarily used for software libraries, LGPL requires that derived works be licensed under the same license, but works that only link to it do not fall under this restriction.
 

--- a/licenses/lgpl-v3.txt
+++ b/licenses/lgpl-v3.txt
@@ -2,6 +2,7 @@
 layout: license
 title: LGPL v3
 permalink: /licenses/lgpl-v3/
+source: http://www.gnu.org/licenses/lgpl-3.0.txt
 
 description: Version 3 of the LGPL is an additional set of permissions to the <a href="/licenses/gpl-v3">GPL v3 license</a> that requires that derived works be licensed under the same license, but works that only link to it do not fall under this restriction.
 

--- a/licenses/mit.txt
+++ b/licenses/mit.txt
@@ -2,6 +2,7 @@
 layout: license
 title: MIT License
 permalink: /licenses/mit/
+source: http://opensource.org/licenses/MIT
 
 featured: true
 

--- a/licenses/mozilla.txt
+++ b/licenses/mozilla.txt
@@ -2,6 +2,7 @@
 layout: license
 title: Mozilla Public License Version 2.0
 permalink: /licenses/mozilla/
+source: http://www.mozilla.org/MPL/2.0/
 
 description: The Mozilla Public License (MPL 2.0) is maintained by the Mozilla foundation. This license attempts to be a compromise between the permissive BSD license and the reciprocal GPL license.
 

--- a/licenses/public-domain.txt
+++ b/licenses/public-domain.txt
@@ -5,6 +5,8 @@ class: license-types
 title: Public Domain (Unlicense)
 filename: UNLICENSE
 
+source: http://unlicense.org/UNLICENSE
+
 description: Because copyright is automatic in most countries, <a href="http://unlicense.org">the Unlicense</a> is a template to waive copyright interest in software you've written and dedicate it to the public domain. Use the Unlicense to opt out of copyright entirely. It also includes the no-warranty statement from the MIT/X11 license.
 
 how: Create a text file (typically named UNLICENSE or UNLICENSE.txt) in the root of your source code and copy the text of the license disclaimer into the file.


### PR DESCRIPTION
Not all of the licenses have a link to their original sources, they have been added where needed. I found the original sources for all of them except `No licence` which obviously didn't need one.

One commit also prevents the `Source` link from appearing if none is defined in the frontmatter (right now it just shows `<a href="">Source</a>`, which isn't bad, it's just not all that helpful).
