### PR TITLE
Fix 'using' display in sidebar

### DIFF
--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -36,10 +36,8 @@
     <div class="projects-with-license">
       <h3>Who's using this license?</h3>
       <ul>
-        {% for using_hash in page.using %}
-          {% for using in using_hash %}
-            <li><a href="{{ using[1] }}" target="_blank">{{ using[0] }}</a></li>
-          {% endfor %}
+        {% for using in page.using %}
+          <li><a href="{{ using[1] }}" target="_blank">{{ using[0] }}</a></li>
         {% endfor %}
       </ul>
     </div>

--- a/licenses/agpl.txt
+++ b/licenses/agpl.txt
@@ -22,9 +22,6 @@ forbidden:
   - no-liability
   - no-sublicense
 
-using:
-  Some Project: "#"
-
 ---
 
                     GNU AFFERO GENERAL PUBLIC LICENSE


### PR DESCRIPTION
Not any licenses currently using it, but there was an unnecessary loop that was causing the list to not appear.
