### PR TITLE
Build gh-pages branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,8 @@ script: "./script/cibuild"
 language: ruby
 rvm: 
   - 2.0.0
+
+branches:
+  only:
+    - gh-pages
+    - /.*/

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Choose a License Web Site
+# Choose a License Web Site [![Build Status](https://travis-ci.org/github/choosealicense.com.png?branch=gh-pages)](https://travis-ci.org/github/choosealicense.com)
 
 Like a Choose Your Own Adventure site, but only much less interesting.
 


### PR DESCRIPTION
As noted [here](http://stackoverflow.com/a/17119658/358804), the `gh-pages` branch isn't built unless it's explicitly enabled. This also adds the build status badge to the README.
