### PR TITLE
Kill email notifications

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,3 +11,6 @@ branches:
   only:
     - gh-pages
     - /.*/
+
+notifications:
+  email: false


### PR DESCRIPTION
Support doesn't want these emails, and ones to @gjtorikian are going to his github anon email.
