### PR TITLE
Add private-use to every license

### DIFF
--- a/licenses/agpl.txt
+++ b/licenses/agpl.txt
@@ -17,6 +17,7 @@ permitted:
   - commercial-use
   - modifications
   - distribution
+  - private-use
 
 forbidden:
   - no-liability

--- a/licenses/apache.txt
+++ b/licenses/apache.txt
@@ -23,6 +23,7 @@ permitted:
   - distribution
   - sublicense
   - patent-grant
+  - private-use
   
 forbidden:
   - trademark-use

--- a/licenses/artistic.txt
+++ b/licenses/artistic.txt
@@ -11,12 +11,14 @@ how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of 
 required:
   - include-copyright
   - document-changes
+
 permitted:
   - commercial-use
   - modifications
   - distribution
   - sublicense
   - private-use
+
 forbidden:
   - no-liability
   - trademark-use

--- a/licenses/bsd-3-clause.txt
+++ b/licenses/bsd-3-clause.txt
@@ -15,6 +15,7 @@ permitted:
   - modifications
   - distribution
   - sublicense
+  - private-use
 
 forbidden:
   - no-liability

--- a/licenses/bsd.txt
+++ b/licenses/bsd.txt
@@ -17,6 +17,7 @@ permitted:
   - modifications
   - distribution
   - sublicense
+  - private-use
 
 forbidden:
   - no-liability

--- a/licenses/eclipse.txt
+++ b/licenses/eclipse.txt
@@ -27,6 +27,7 @@ permitted:
   - modifications
   - sublicense
   - patent-grant
+  - private-use
 
 forbidden:
   - no-liability

--- a/licenses/gpl-v2.txt
+++ b/licenses/gpl-v2.txt
@@ -20,6 +20,7 @@ permitted:
   - modifications
   - distribution
   - patent-grant
+  - private-use
 
 forbidden:
   - no-liability

--- a/licenses/gpl-v3.txt
+++ b/licenses/gpl-v3.txt
@@ -20,6 +20,7 @@ permitted:
   - modifications
   - distribution
   - patent-grant
+  - private-use
 
 forbidden:
   - no-liability

--- a/licenses/lgpl-v2.1.txt
+++ b/licenses/lgpl-v2.1.txt
@@ -21,6 +21,7 @@ permitted:
   - distribution
   - sublicense
   - patent-grant
+  - private-use
 
 forbidden:
   - no-liability

--- a/licenses/lgpl-v3.txt
+++ b/licenses/lgpl-v3.txt
@@ -21,6 +21,7 @@ permitted:
   - distribution
   - sublicense
   - patent-grant
+  - private-use
 
 forbidden:
   - no-liability

--- a/licenses/mit.txt
+++ b/licenses/mit.txt
@@ -18,6 +18,7 @@ permitted:
   - modifications
   - distribution
   - sublicense
+  - private-use
 
 forbidden:
   - no-liability

--- a/licenses/mozilla.txt
+++ b/licenses/mozilla.txt
@@ -18,6 +18,7 @@ permitted:
   - distribution
   - sublicense
   - patent-grant
+  - private-use
 
 forbidden:
   - no-liability

--- a/licenses/no-license.html
+++ b/licenses/no-license.html
@@ -14,8 +14,8 @@ required:
   - include-copyright
 
 permitted:
-  - private-use
   - commercial-use
+  - private-use
 
 forbidden:
   - modifications

--- a/licenses/public-domain.txt
+++ b/licenses/public-domain.txt
@@ -14,11 +14,11 @@ how: Create a text file (typically named UNLICENSE or UNLICENSE.txt) in the root
 required: 
 
 permitted:
-  - private-use
   - commercial-use
   - modifications
   - distribution
   - sublicense
+  - private-use
 
 forbidden:
   - no-liability


### PR DESCRIPTION
There is no license that prohibits private use.

This closes #25 

Per @benbalter's comment:

> It looks like AGPL doesn't have a blurb, a simple, "This is GPL, but distribution also includes hosted services" or similar should be enough to disambiguate IMHO, but I'd move that to a different issue.

We should do this as a separate PR.
