### PR TITLE
"Public Domain" is not the name of a license, the title of "Unlicense" should be something else

### DIFF
--- a/licenses/unlicense.txt
+++ b/licenses/unlicense.txt
@@ -1,8 +1,8 @@
 ---
 layout: license
-permalink: /licenses/public-domain/
+permalink: /licenses/unlicense/
 class: license-types
-title: Public Domain (Unlicense)
+title: Public Domain Dedication (Unlicense)
 filename: UNLICENSE
 
 source: http://unlicense.org/UNLICENSE


### PR DESCRIPTION
"Public Domain Dedication (Unlicense)" is a better title for the Unlicense than just "Public Domain". The "public domain" per se is not a license, it's... a... domain.

Also changes the permalink from "public-domain" to "unlicense" to distinguish it from other methods of making a public domain dedication. This brings it in line with other licenses for which the permalink is the name of the license not some concept (like "/licenses/opensource").
