### PR TITLE
Mark Unlicense as non-sublicensable

### DIFF
--- a/licenses/unlicense.txt
+++ b/licenses/unlicense.txt
@@ -19,11 +19,11 @@ permitted:
   - commercial-use
   - modifications
   - distribution
-  - sublicense
   - private-use
 
 forbidden:
   - no-liability
+  - sublicense
 
 ---
 This is free and unencumbered software released into the public domain.


### PR DESCRIPTION
Per the discussion in #132, material released under the Unlicense should be marked as non-sublicensable, since the public domain is non-sublicensable.
