### PR TITLE
GPLv2 description could do with comma about its variants

### DIFF
--- a/licenses/gpl-v2.txt
+++ b/licenses/gpl-v2.txt
@@ -7,7 +7,7 @@ layout: license
 permalink: /licenses/gpl-v2/
 source: http://www.gnu.org/licenses/gpl-2.0.txt
 
-description: GPL is the most widely used free software license and has a strong copyleft requirement. When distributing derived works, the source code of the work must be made available under the same license. There are multiple variants of the GPL each with different requirements.
+description: GPL is the most widely used free software license and has a strong copyleft requirement. When distributing derived works, the source code of the work must be made available under the same license. There are multiple variants of the GPL, each with different requirements.
 
 featured: true
 


### PR DESCRIPTION
>  There are multiple variants of the GPL each with different requirements

Without a comma, this passage has no break where it would be used to add the hint of nuance between GPL versions.

It may read better with a comma before you get to the last half of the sentence.

>  There are multiple variants of the GPL, each with different requirements
