### PR TITLE
Don't ignore all '#' URLs when running HTML::Proofer

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -3,5 +3,5 @@ require "html/proofer"
 task :test do
   sh "bundle exec jekyll build --trace"
   # ignore href="#" for the "Copy to clipboard" button
-  HTML::Proofer.new("./_site", :href_ignore => ["#"]).run
+  HTML::Proofer.new("./_site").run
 end

--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -1,6 +1,6 @@
 <div class="sidebar">
 
-  <a href="#" data-clipboard-target="license-text" class="js-clipboard-button button">Copy license text to clipboard</a>
+  <a href="#" data-clipboard-target="license-text" data-proofer-ignore="true" class="js-clipboard-button button">Copy license text to clipboard</a>
   <div class="how-to-apply">
     <h5>How to apply this license</h5>
     <p>


### PR DESCRIPTION
Explicitly ignore the clipboard button from proofing, which was why the `:href_ignore` was there in the first place.  Per https://github.com/github/choosealicense.com/pull/104/files#r7311111.

/cc @gjtorikian @benbalter 
