### PR TITLE
Add link to the Open Source Software Collaboration Counseling

### DIFF
--- a/about.md
+++ b/about.md
@@ -19,6 +19,7 @@ This site is not a comprehensive directory of open source licenses.  We think th
 * [Comparison of free and open-source software licenses](http://en.wikipedia.org/wiki/Comparison_of_free_and_open-source_software_licenses) on Wikipedia
 * [License differentiator](http://www.oss-watch.ac.uk/apps/licdiff/) from [OSS Watch](http://www.oss-watch.ac.uk/)
 * [TLDRLegal](http://www.tldrlegal.com/)
+* [The Open Source Software Collaboration Counseling](http://www.osscc.net/)
 {: .bullets}
 
 ### Tools


### PR DESCRIPTION
The Open Source Software Collaboration Counseling exists since 2010. The OSSCC tries to serve the same purpose as CAL:

> To simplify license selection, we provide the OSSCC license interoperability guide together with a commented list of preferred OSS licenses.
> 
> The OSSCC also tries to provide a platform to support collaboration between existing currently separate OSS entities and to politically support OSS.
> 
> The OSSCC is currently a group of volunteering people located in Germany and Norway but we are looking for more contributors and staff members worldwide.
