### PR TITLE
Cleaning up description of GNU GPL in the index.html and changing the note in the gplv2 and gplv3 license pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -42,7 +42,11 @@ description: A site to provide non-judgmental guidance on choosing a license for
       <h3>I care about sharing improvements.</h3>
     </a>
     <p>
-      The GPL (<a href="licenses/gpl-v2">V2</a> or <a href="licenses/gpl-v3">V3</a>) is a copyleft license that requires anyone who distributes your code or a derivative work to make the source available under the same terms. V3 is similar to V2, but further restricts use in hardware that forbids software alterations.
+      The GNU GPL (<a href="licenses/gpl-v2">v2</a>
+      or <a href="licenses/gpl-v3">v3</a>) is a copyleft license that
+      protects free code from being turned into proprietary
+      software. Version 3 is international and protects better against
+      DRM, lockdown and patents; it's compatible with Apache 2.0.
     </p>
     <p>
       <strong>Linux</strong>, <strong>Git</strong>, and <strong>WordPress</strong> use the GPL.

--- a/index.html
+++ b/index.html
@@ -42,11 +42,7 @@ description: A site to provide non-judgmental guidance on choosing a license for
       <h3>I care about sharing improvements.</h3>
     </a>
     <p>
-      The GNU GPL (<a href="licenses/gpl-v2">v2</a>
-      or <a href="licenses/gpl-v3">v3</a>) is a copyleft license that
-      protects free code from being turned into proprietary
-      software. Version 3 is international and protects better against
-      DRM, lockdown and patents; it's compatible with Apache 2.0.
+      The GNU GPL (<a href="licenses/gpl-v2">v2</a> or <a href="licenses/gpl-v3">v3</a>) is a copyleft license that protects free code from being turned into proprietary software. Version 3 is international and protects better against DRM, lockdown and patents; it's compatible with Apache 2.0.
     </p>
     <p>
       <strong>Linux</strong>, <strong>Git</strong>, and <strong>WordPress</strong> use the GPL.

--- a/licenses/gpl-v2.txt
+++ b/licenses/gpl-v2.txt
@@ -13,7 +13,11 @@ featured: true
 
 how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file.
 
-note: The Free Software Foundation recommends taking the additional step of adding a boilerplate notice to the top of each file. The boilerplate can be found at the end of the license.
+note: As with any free license, you should put near the top of each source
+file a copyright notice and a license notice for the license you are
+using.  Without this, the code can get disconnected from its license
+when someone copies it into another program or another file; then people
+will not know how they can use that code.
 
 required:
   - include-copyright

--- a/licenses/gpl-v2.txt
+++ b/licenses/gpl-v2.txt
@@ -13,11 +13,7 @@ featured: true
 
 how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file.
 
-note: As with any free license, you should put near the top of each source
-file a copyright notice and a license notice for the license you are
-using.  Without this, the code can get disconnected from its license
-when someone copies it into another program or another file; then people
-will not know how they can use that code.
+note: As with any free license, you should put near the top of each source file a copyright notice and a license notice for the license you are using.  Without this, the code can get disconnected from its license when someone copies it into another program or another file; then people will not know how they can use that code.
 
 required:
   - include-copyright

--- a/licenses/gpl-v3.txt
+++ b/licenses/gpl-v3.txt
@@ -9,7 +9,12 @@ source: http://www.gnu.org/licenses/gpl-3.0.txt
 
 how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file.
 
-note: The Free Software Foundation recommends taking the additional step of adding a boilerplate notice to the top of each file. The boilerplate can be found at the end of the license.
+note: As with any free license, you should put near the top of each source
+file a copyright notice and a license notice for the license you are
+using.  Without this, the code can get disconnected from its license
+when someone copies it into another program or another file; then people
+will not know how they can use that code.
+
 
 required:
   - include-copyright

--- a/licenses/gpl-v3.txt
+++ b/licenses/gpl-v3.txt
@@ -9,12 +9,7 @@ source: http://www.gnu.org/licenses/gpl-3.0.txt
 
 how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file.
 
-note: As with any free license, you should put near the top of each source
-file a copyright notice and a license notice for the license you are
-using.  Without this, the code can get disconnected from its license
-when someone copies it into another program or another file; then people
-will not know how they can use that code.
-
+note: As with any free license, you should put near the top of each source file a copyright notice and a license notice for the license you are using.  Without this, the code can get disconnected from its license when someone copies it into another program or another file; then people will not know how they can use that code.
 
 required:
   - include-copyright


### PR DESCRIPTION
I made some minor changes to how the GNU GPL is described in the index.html page as well a change to the note on the GPLv2 and GPLv3 license pages stating that all source code files should state their copyright and licensing terms, which I think could make sense for all other licensing pages as well. 
