### PR TITLE
Generate sitemap.xml and add robots.txt.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -2,6 +2,7 @@
 title: ChooseALicense.com
 relative_permalinks: false
 markdown: kramdown
+url: "http://choosealicense.com"
 
 rules:
 

--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@ class: home
 hide_breadcrumbs: true
 title: Choosing an OSS license doesn’t need to be scary
 description: A site to provide non-judgmental guidance on choosing a license for your open source project
+permalink: /
 ---
 
 <h2>

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,10 @@
+---
+layout: nil
+---
+
+# www.robotstxt.org/
+
+# Allow crawling of all content
+User-agent: *
+Disallow:
+Sitemap: {{ site.url }}/sitemap.xml

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -11,12 +11,14 @@ layout: nil
     <priority>1.0</priority>
   </url>
   {% for page in site.pages %}
+  {% if page.layout != "nil" %}
   <url>
     <loc>{{ site.url }}{{ page.url }}</loc>
     <lastmod>{{ site.time | date_to_xmlschema }}</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
+  {% endif %}
   {% endfor %}
   {% for post in site.posts %}
   <url>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,0 +1,29 @@
+---
+layout: nil
+---
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet type="text/xsl" href="/sitemap.xsl"?>
+<urlset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd" xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>{{ site.url }}/</loc>
+    <lastmod>{{ site.time | date_to_xmlschema }}</lastmod>
+    <changefreq>daily</changefreq>
+    <priority>1.0</priority>
+  </url>
+  {% for page in site.pages %}
+  <url>
+    <loc>{{ site.url }}{{ page.url }}</loc>
+    <lastmod>{{ site.time | date_to_xmlschema }}</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  {% endfor %}
+  {% for post in site.posts %}
+  <url>
+    <loc>{{ site.url }}{{ post.url }}</loc>
+    <lastmod>{{ post.date | date_to_xmlschema }}</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  {% endfor %}
+</urlset>


### PR DESCRIPTION
Only issue so far is that the generated sitemap.xml includes application.css and javascript.js.

I assume that's because those are parsed by Jekyll since they include other files. So I guess we'll have to exclude those from being included. Any ideas are welcome.

PS. I really wish Jekyll would stop outputting superfluous whitespaces after using its tags like `{% endfor %}`...
