### PR TITLE
Revert 13c9eb92fb1b01d441e68570979a2da349914d9c.

### DIFF
--- a/_layouts/license.html
+++ b/_layouts/license.html
@@ -2,7 +2,7 @@
 
       <div class="clearfix">
         <div class="license-body">
-          <pre id="license-text">{{ content | markdownify | strip_html }}</pre>
+          <pre id="license-text">{{ content | replace:"<", "&lt;" | replace:">", "&gt;" }}</pre>
         </div> <!-- /license-body -->
 
 {% include sidebar.html %}


### PR DESCRIPTION
Due to Jekyll outputting useless whitespace, we need to work around this ourselves.
