### PR TITLE
Remove google verification header

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -3,7 +3,6 @@
   <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta name="google-site-verification" content="dtrPO0r_cFAQt3heidSusLdU0g3AtzvH4DFBSkJfeos">
     <title>{% if page.title %}{{ page.title | markdownify | strip_html | strip_newlines }} - {% endif %}{{ site.title}}</title>
     {% if page.description %}<meta name="description" content="{{ page.description | strip_html | strip_newlines }}">{% endif %}
     <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Chivo:900">


### PR DESCRIPTION
I don't think we need this now that we've verified the site.
