### PR TITLE
Missing "patent grant" feature in AGPL

### DIFF
--- a/licenses/agpl.txt
+++ b/licenses/agpl.txt
@@ -20,6 +20,7 @@ permitted:
   - commercial-use
   - modifications
   - distribution
+  - patent-grant
   - private-use
 
 forbidden:


### PR DESCRIPTION
The AGPL license is missing the "patent grant" feature in the "permitted" category.

Unless I'm mistaken [section 11](http://www.gnu.org/licenses/agpl-3.0.html#section11) of the license is about granting patents licenses (it's the same text found in [GPLv3's section 11](http://www.gnu.org/licenses/gpl-3.0.html#section11)).
