### PR TITLE
AGPL: Highlight the Affero Feature

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -17,8 +17,8 @@ rules:
     label: Disclose Source
     tag: disclose-source
   - description: Users who interact with the software via network are given the right to receive a copy of the corresponding source code.
-    label: SaaS is Distribution
-    tag: saas-disclose
+    label: Network Use is Distribution
+    tag: network-use-disclose
   - description: The library may be used within a non-open-source application.
     label: Library usage
     tag: library-usage

--- a/_config.yml
+++ b/_config.yml
@@ -16,6 +16,9 @@ rules:
   - description: Source code must be made available when distributing the software. In the case of LGPL, the source for the library (and not the entire program) must be made available.
     label: Disclose Source
     tag: disclose-source
+  - description: Users who interact with the software via network are given the right to receive a copy of the corresponding source code.
+    label: SaaS is Distribution
+    tag: saas-disclose
   - description: The library may be used within a non-open-source application.
     label: Library usage
     tag: library-usage

--- a/licenses/agpl-v3.txt
+++ b/licenses/agpl-v3.txt
@@ -16,6 +16,7 @@ required:
   - include-copyright
   - document-changes
   - disclose-source
+  - saas-disclose
 
 permitted:
   - commercial-use

--- a/licenses/agpl-v3.txt
+++ b/licenses/agpl-v3.txt
@@ -16,7 +16,7 @@ required:
   - include-copyright
   - document-changes
   - disclose-source
-  - saas-disclose
+  - network-use-disclose
 
 permitted:
   - commercial-use


### PR DESCRIPTION
This is a follow up to #197

A new point in the "required" section of the AGPL highlights the difference to the plain GPL.
It states that running a network service of the software triggers the disclose-source requirement, e.g. in SaaS use cases.

This is my personal interpretation of the paragraph 13 AGPL, IANAL.

Comments are welcome!
