### PR TITLE
Use jsonify to build license json

### DIFF
--- a/licenses.json
+++ b/licenses.json
@@ -5,24 +5,4 @@ comment: \
   increment an index to see if we're on the true last iteration.
 ---
 {% assign count = 0 %}{% for page in site.pages %}{% if page.layout == "license" %}{% assign count = count | plus: 1 %}{% endif %}{% endfor %}{% assign i = 0 %}
-[
-{% for page in site.pages %}{% if page.layout == "license" %}
-  {
-    "title": "{{ page.title }}",
-    "permalink": "{{ page.permalink }}",
-    "featured": {% if page.featured %}true{% else %}false{% endif %},
-    "description": "{{ page.description | replace: '"', '\"' }}",
-    "how": "{{ page.how | replace: '"', '\"' }}",
-    "rules": {
-    {% for category in site.rules %}
-        {% assign cat = category[0] %}
-        "{{ cat }}": [
-        {% for rule in page[cat] %}
-            "{{ rule }}"{% if forloop.rindex0 > 0 %},{% endif %}
-        {% endfor %}
-        ]{% if forloop.rindex0 > 0 %},{% endif %}
-    {% endfor %}
-    }{% assign i = i | plus: 1 %}
-  }{% if i < count %},{% endif %}
- {% endif %}{% endfor %}
-]
+[{% for page in site.pages %}{% if page.layout == "license" %}{{ page | jsonify }}{% assign i = i | plus: 1 %}{% if i < count %},{% endif %}{% endif %}{% endfor %}]


### PR DESCRIPTION
Rather than manually building the JSON string for `/licenses.json`, rely on Jekyll's `jsonify` filter.

This also expands the information made available via the API to the full license text and all metadata and ensures the JSON if properly escaped, valid JSON in all cases.

Note: until Jekyll 2.0 drops, we still have to build the for loop ourself and manually place the trailing comma, as the `where` filter is not yet implemented to let us filter by layout. :soon:
