### PR TITLE
Change variable names of Google Analytics tracking code

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -26,10 +26,10 @@
     {% endif %}
 
     <script>
-      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-      })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+      !function(L,I,C,e,N,S,E){L.GoogleAnalyticsObject=N,L[N]=L[N]||function(){
+      (L[N].q=L[N].q||[]).push(arguments)},L[N].l=+new Date,S=I.createElement(C),
+      E=I.getElementsByTagName(C)[0],S.src=e,E.parentNode.insertBefore(S,E)
+      }(window,document,"script","//www.google-analytics.com/analytics.js","ga");
 
       ga('create', 'UA-3769691-24', 'choosealicense.com');
       ga('send', 'pageview');


### PR DESCRIPTION
`i` `s` `o` `g` `r` `a` `m` -> `L` `I` `C` `e` `N` `S` `E`

It is generated by [isogram](https://github.com/shinnn/isogram), a [well tested](https://travis-ci.org/shinnn/isogram/jobs/36501332) google analytics code generator used by [gulp website](https://github.com/gulpjs/gulpjs.github.io/blob/fc2a237ef4b476dd9428fce0da77c6bd3f8b925d/index.html#L134).

I can update this PR if you prefer other variable names, such as:
- `g` `i` `t` `h` `u` `b`
- `c` `h` `o` `O` `s` `e`
