### PR TITLE
Use W3C compliant `textContent` instead of `innerText

### DIFF
--- a/assets/js/app.coffee
+++ b/assets/js/app.coffee
@@ -90,11 +90,11 @@ class Choosealicense
 
   # Callback to restore the clipboard button's original text
   clipboardMouseout: (client, args) ->
-    @innerText = $(this).data("clipboard-prompt")
+    @textContent = $(this).data("clipboard-prompt")
 
   # Post-copy user feedback callback
   clipboardComplete: (client, args) ->
-    @innerText = "Copied!"
+    @textContent = "Copied!"
 
   # Initializes pill navigation for license variations
   initLicenseVariationNav: ->


### PR DESCRIPTION
Closes https://github.com/github/choosealicense.com/issues/119, closes https://github.com/github/choosealicense.com/issues/46.

Firefox doesn't have `innerText`, but it does have `textContent`. This change allows the button to say "Copied!" when click on, and, on mouseleave, it goes back to the default text. This was also tested and working in Chrome.

![ff](https://cloud.githubusercontent.com/assets/64050/5494793/aaaf8926-86ac-11e4-993b-ccab4aa1458c.gif)

It's a minimal change, but still: /cc @github/choosealicense-com 
