### PR TITLE
Update README.md with new location of rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,11 +65,10 @@ notices. The available variables are:
 # Rules
 
 Rules (the license's properties) are stored as a bulleted list within the
-licenses YAML front matter. A full list of rules can be found in the
-repository's `_config.yml` file. Each rule has a name e.g.,
-`include-copyright`, a human-readable label, e.g., `Copyright inclusion`,
-and a description `Include the original copyright with the code`.
-To add a new rule, simply add it to `config.yml` and reference it in the
+licenses YAML front matter. A full list of rules can be found in `_data/rules.yml`.
+Each rule has a name e.g., `include-copyright`, a human-readable label, e.g.,
+`Copyright inclusion`, and a description `Include the original copyright with the code`.
+To add a new rule, simply add it to `_data/rules.yml` and reference it in the
 appropriate license.
 
 # License


### PR DESCRIPTION
Rules are in `_data/rules.yml` now, not `_config.yml`.
