### PR TITLE
A null value is used to indicate the lack of a value

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -1,5 +1,5 @@
 ---
-layout: nil
+layout: null
 ---
 
 # www.robotstxt.org/


### PR DESCRIPTION
This fixes the build warning:

```
Build Warning: Layout 'nil' requested in robots.txt does not exist.
```
