### PR TITLE
Add BSD-3 and AGPL descriptions

### DIFF
--- a/_licenses/agpl-3.0.txt
+++ b/_licenses/agpl-3.0.txt
@@ -8,7 +8,7 @@ permalink: /licenses/agpl-3.0/
 source: http://www.gnu.org/licenses/agpl-3.0.txt
 redirect_from: /licenses/agpl/
 
-description: "GPL is the most widely used free software license and has a strong copyleft requirement. When distributing derived works, the source code of the work must be made available under the same license. The AGPL is distinguished from GPLv2 and GPLv3 in that hosted services using the code are considered distribution and trigger the copyleft requirements."
+description: "The GPL family of licenses is the most widely used free software license and has a strong copyleft requirement. When distributing derived works, the source code of the work must be made available under the same license. The AGPL family of licenses is distinguished from GPLv2 and GPLv3 in that hosted services using the code are considered distribution and trigger the copyleft requirements."
 
 note: The Free Software Foundation recommends taking the additional step of adding a boilerplate notice to the top of each file. The boilerplate can be found at the end of the license.
 

--- a/_licenses/agpl-3.0.txt
+++ b/_licenses/agpl-3.0.txt
@@ -8,6 +8,8 @@ permalink: /licenses/agpl-3.0/
 source: http://www.gnu.org/licenses/agpl-3.0.txt
 redirect_from: /licenses/agpl/
 
+description: "GPL is the most widely used free software license and has a strong copyleft requirement. When distributing derived works, the source code of the work must be made available under the same license. The AGPL is distinguished from GPLv2 and GPLv3 in that hosted services using the code are considered distribution and trigger the copyleft requirements."
+
 note: The Free Software Foundation recommends taking the additional step of adding a boilerplate notice to the top of each file. The boilerplate can be found at the end of the license.
 
 how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file.

--- a/_licenses/bsd-3-clause.txt
+++ b/_licenses/bsd-3-clause.txt
@@ -6,6 +6,8 @@ tab-slug: bsd-3
 hide-from-license-list: true
 permalink: /licenses/bsd-3-clause/
 
+description: A permissive license that comes in two variants, the <a href="/licenses/bsd">BSD 2-Clause</a> and <a href="/licenses/bsd-3-clause">BSD 3-Clause</a>. Both have very minute differences to the MIT license. The three clause variant prohibits others from using the name of the project or its contributors to promote derivative works without written consent.
+
 how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file. Replace [year] with the current year and [fullname] with the name (or names) of the copyright holders. Replace {organization} with the organization, if any, that sponsors this work.
 
 source: http://opensource.org/licenses/BSD-3-Clause


### PR DESCRIPTION
For some reason the BSD-3 and AGPL were missing descriptions. This adds simple descriptions for each, based on the primary license from that category + a short description of what distinguishes them.
