### PR TITLE
Add license nicknames for license list

### DIFF
--- a/_includes/license-overview.html
+++ b/_includes/license-overview.html
@@ -16,7 +16,13 @@
       <ul class="nav-pills js-nav-pills">
         {% for variation in site.licenses %}
           {% if variation.category and variation.category == license.category %}
-        <li{% if license.tab-slug == variation.tab-slug %} class="active"{% endif %}><a href="#{{ variation.tab-slug }}" data-selected-tab="variation-{{ variation.tab-slug }}">{{ variation.title }}</a></li>
+        <li{% if license.tab-slug == variation.tab-slug %} class="active"{% endif %}><a href="#{{ variation.tab-slug }}" data-selected-tab="variation-{{ variation.tab-slug }}">
+          {% if variation.nickname != nil %}
+            {{ variation.nickname }}
+          {% else %}
+            {{ variation.title }}
+          {% endif %}
+        </a></li>
           {% endif %}
         {% endfor %}
       </ul>

--- a/_licenses/agpl-3.0.txt
+++ b/_licenses/agpl-3.0.txt
@@ -1,5 +1,6 @@
 ---
 title: GNU Affero General Public License v3.0
+nickname: GNU Affero GPL v3.0
 category: GPL
 tab-slug: agpl-v3
 hide-from-license-list: true

--- a/_licenses/bsd-2-clause.txt
+++ b/_licenses/bsd-2-clause.txt
@@ -1,6 +1,7 @@
 ---
 layout: license
 title: BSD 2-clause "Simplified" License
+nickname: Simplified BSD
 category: BSD
 tab-slug: bsd
 hide-from-license-list: true

--- a/_licenses/bsd-3-clause.txt
+++ b/_licenses/bsd-3-clause.txt
@@ -1,6 +1,7 @@
 ---
 layout: license
 title: BSD 3-clause "New" or "Revised" License
+nickname: New BSD
 category: BSD
 tab-slug: bsd-3
 hide-from-license-list: true

--- a/_licenses/cc0-1.0.txt
+++ b/_licenses/cc0-1.0.txt
@@ -1,6 +1,7 @@
 ---
 layout: license
 title: Creative Commons Zero v1.0 Universal
+nickname: CC0 1.0 Universal
 category: Public Domain Dedication
 tab-slug: cc0
 permalink: /licenses/cc0/

--- a/_licenses/gpl-2.0.txt
+++ b/_licenses/gpl-2.0.txt
@@ -1,5 +1,6 @@
 ---
 title: GNU General Public License v2.0
+nickname: GNU GPL v2.0
 category: GPL
 tab-slug: gpl-v2
 hide-from-license-list: false

--- a/_licenses/gpl-3.0.txt
+++ b/_licenses/gpl-3.0.txt
@@ -1,5 +1,6 @@
 ---
 title: GNU General Public License v3.0
+nickname: GNU GPL v2.0
 category: GPL
 tab-slug: gpl-v3
 hide-from-license-list: true

--- a/_licenses/lgpl-2.1.txt
+++ b/_licenses/lgpl-2.1.txt
@@ -1,6 +1,7 @@
 ---
 layout: license
 title: GNU Lesser General Public License v2.1
+nickname: GNU LGPL v2.1
 category: LGPL
 tab-slug: lgpl-v2_1
 redirect_from: /licenses/lgpl-v2.1/

--- a/_licenses/lgpl-3.0.txt
+++ b/_licenses/lgpl-3.0.txt
@@ -1,6 +1,7 @@
 ---
 layout: license
 title: GNU Lesser General Public License v3.0
+nickname: GNU LGPL v3.0
 category: LGPL
 tab-slug: lgpl-v3
 hide-from-license-list: true


### PR DESCRIPTION
This fixes a problem introduced in https://github.com/github/choosealicense.com/pull/252 whereby the official license names on the license list become a bit too much for the design.

This introduces the concept of the license "nickname" (the common name, what was listed before for many licenses) that we can use on the license list to keep things simple for those browsing, but can still use the official SPDX compliant name where appropriate.
### Before

![screen shot 2015-03-07 at 2 16 02 pm](https://cloud.githubusercontent.com/assets/282759/6542847/85ed9cde-c4d4-11e4-86bb-081815f92b6c.png)
### After

![screen shot 2015-03-07 at 2 16 07 pm](https://cloud.githubusercontent.com/assets/282759/6542848/8ce9c13e-c4d4-11e4-84ab-e9d368f26347.png)
