### PR TITLE
Normalize sorting of license properties

### DIFF
--- a/_licenses/agpl-3.0.txt
+++ b/_licenses/agpl-3.0.txt
@@ -1,17 +1,17 @@
 ---
 title: GNU Affero General Public License v3.0
 nickname: GNU Affero GPL v3.0
-category: GPL
 tab-slug: agpl-v3
+redirect_from: /licenses/agpl/
+category: GPL
 variant: true
 source: http://www.gnu.org/licenses/agpl-3.0.txt
-redirect_from: /licenses/agpl/
 
 description: "The GPL family of licenses is the most widely used free software license and has a strong copyleft requirement. When distributing derived works, the source code of the work must be made available under the same license. The AGPL family of licenses is distinguished from GPLv2 and GPLv3 in that hosted services using the code are considered distribution and trigger the copyleft requirements."
 
-note: The Free Software Foundation recommends taking the additional step of adding a boilerplate notice to the top of each file. The boilerplate can be found at the end of the license.
-
 how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file.
+
+note: The Free Software Foundation recommends taking the additional step of adding a boilerplate notice to the top of each file. The boilerplate can be found at the end of the license.
 
 required:
   - include-copyright

--- a/_licenses/apache-2.0.txt
+++ b/_licenses/apache-2.0.txt
@@ -1,16 +1,15 @@
 ---
 title: Apache License 2.0
+nickname: Apache
 redirect_from: /licenses/apache/
 featured: true
-nickname: Apache
+source: http://www.apache.org/licenses/LICENSE-2.0.html
 
 description: A permissive license that also provides an express grant of patent rights from contributors to users.
 
-note: The Apache Foundation recommends taking the additional step of adding a boilerplate notice to the header of each source file. You can find the notice at the very end of the license in the appendix.
-
 how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file.
 
-source: http://www.apache.org/licenses/LICENSE-2.0.html
+note: The Apache Foundation recommends taking the additional step of adding a boilerplate notice to the header of each source file. You can find the notice at the very end of the license in the appendix.
 
 required:
   - include-copyright
@@ -22,7 +21,6 @@ permitted:
   - distribution
   - sublicense
   - patent-grant
-
   - private-use
 
 forbidden:

--- a/_licenses/artistic-2.0.txt
+++ b/_licenses/artistic-2.0.txt
@@ -21,7 +21,9 @@ permitted:
 forbidden:
   - no-liability
   - trademark-use
+
 ---
+
                The Artistic License 2.0
 
            Copyright (c) [year] [fullname]

--- a/_licenses/bsd-2-clause.txt
+++ b/_licenses/bsd-2-clause.txt
@@ -1,16 +1,15 @@
 ---
 title: BSD 2-clause "Simplified" License
 nickname: Simplified BSD
-category: BSD
 tab-slug: bsd
-variant: true
 redirect_from: /licenses/bsd/
+category: BSD
+variant: true
+source: http://opensource.org/licenses/BSD-2-Clause
 
 description: A permissive license that comes in two variants, the <a href="/licenses/bsd">BSD 2-Clause</a> and <a href="/licenses/bsd-3-clause">BSD 3-Clause</a>. Both have very minute differences to the MIT license.
 
 how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file. Replace [year] with the current year and [fullname] with the name (or names) of the copyright holders.
-
-source: http://opensource.org/licenses/BSD-2-Clause
 
 required:
   - include-copyright

--- a/_licenses/bsd-3-clause.txt
+++ b/_licenses/bsd-3-clause.txt
@@ -1,15 +1,14 @@
 ---
 title: BSD 3-clause "New" or "Revised" License
 nickname: New BSD
-category: BSD
 tab-slug: bsd-3
+category: BSD
 variant: true
+source: http://opensource.org/licenses/BSD-3-Clause
 
 description: A permissive license that comes in two variants, the <a href="/licenses/bsd">BSD 2-Clause</a> and <a href="/licenses/bsd-3-clause">BSD 3-Clause</a>. Both have very minute differences to the MIT license. The three clause variant prohibits others from using the name of the project or its contributors to promote derivative works without written consent.
 
 how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file. Replace [year] with the current year and [fullname] with the name (or names) of the copyright holders. Replace [project] with the project organization, if any, that sponsors this work.
-
-source: http://opensource.org/licenses/BSD-3-Clause
 
 required:
   - include-copyright

--- a/_licenses/cc0-1.0.txt
+++ b/_licenses/cc0-1.0.txt
@@ -1,12 +1,10 @@
 ---
 title: Creative Commons Zero v1.0 Universal
 nickname: CC0 1.0 Universal
-redirect_from: /licenses/cc0/
-
 tab-slug: cc0
+redirect_from: /licenses/cc0/
 category: Public Domain Dedication
 variant: true
-
 source: http://creativecommons.org/publicdomain/zero/1.0/
 
 description: The <a href="http://creativecommons.org/publicdomain/zero/1.0/">Creative Commons CC0 Public Domain Dedication</a> waives copyright interest in any a work you've created and dedicates it to the world-wide public domain. Use CC0 to opt out of copyright entirely and ensure your work has the widest reach. As with the Unlicense and typical software licenses, CC0 disclaims warranties. CC0 is very similar to the Unlicense.
@@ -20,13 +18,14 @@ permitted:
   - modifications
   - distribution
   - private-use
-  
+
 forbidden:
   - no-liability
 
 required: []
 
 ---
+
 CC0 1.0 Universal
 
 Statement of Purpose

--- a/_licenses/epl-1.0.txt
+++ b/_licenses/epl-1.0.txt
@@ -1,8 +1,11 @@
 ---
 title: Eclipse Public License 1.0
 redirect_from: /licenses/eclipse/
+source: http://www.eclipse.org/legal/epl-v10.html
 
 description: This commercially-friendly copyleft license provides the ability to commercially license binaries; a modern royalty-free patent license grant; and the ability for linked works to use other licenses, including commercial ones.
+
+how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file.
 
 using:
   The Eclipse Foundation: "http://www.eclipse.org"
@@ -11,10 +14,6 @@ using:
   JUnit: "http://junit.org/"
   Ruby: "https://github.com/jruby/jruby"
   Mondrian: "http://en.wikipedia.org/wiki/Mondrian_OLAP_server"
-
-how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file.
-
-source: http://www.eclipse.org/legal/epl-v10.html
 
 required:
   - disclose-source
@@ -32,6 +31,7 @@ forbidden:
   - no-liability
 
 ---
+
 Eclipse Public License - v 1.0
 
 THE ACCOMPANYING PROGRAM IS PROVIDED UNDER THE TERMS OF THIS ECLIPSE PUBLIC

--- a/_licenses/gpl-2.0.txt
+++ b/_licenses/gpl-2.0.txt
@@ -1,15 +1,13 @@
 ---
 title: GNU General Public License v2.0
 nickname: GNU GPL v2.0
+tab-slug: gpl-v2
 redirect_from: /licenses/gpl-v2/
+category: GPL
+featured: true
 source: http://www.gnu.org/licenses/gpl-2.0.txt
 
-category: GPL
-tab-slug: gpl-v2
-
 description: GPL is the most widely used free software license and has a strong copyleft requirement. When distributing derived works, the source code of the work must be made available under the same license. There are multiple variants of the GPL, each with different requirements.
-
-featured: true
 
 how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file.
 

--- a/_licenses/gpl-3.0.txt
+++ b/_licenses/gpl-3.0.txt
@@ -1,10 +1,10 @@
 ---
 title: GNU General Public License v3.0
 nickname: GNU GPL v3.0
-category: GPL
 tab-slug: gpl-v3
-variant: true
 redirect_from: /licenses/gpl-v3/
+category: GPL
+variant: true
 source: http://www.gnu.org/licenses/gpl-3.0.txt
 
 description: GPL is the most widely used free software license and has a strong copyleft requirement. When distributing derived works, the source code of the work must be made available under the same license.
@@ -30,6 +30,7 @@ forbidden:
   - no-sublicense
 
 ---
+
                     GNU GENERAL PUBLIC LICENSE
                        Version 3, 29 June 2007
 

--- a/_licenses/isc.txt
+++ b/_licenses/isc.txt
@@ -1,9 +1,8 @@
 ---
 title: ISC License
-source: http://opensource.org/licenses/isc-license
-
-category: BSD
 tab-slug: isc
+category: BSD
+source: http://opensource.org/licenses/isc-license
 
 description: A permissive license lets people do anything with your code with proper attribution and without warranty. The ISC license is functionally equivalent to the <a href="/licenses/bsd">BSD 2-Clause</a> and <a href="/licenses/mit">MIT</a> licenses, removing some language that is no longer necessary.
 

--- a/_licenses/lgpl-2.1.txt
+++ b/_licenses/lgpl-2.1.txt
@@ -1,11 +1,10 @@
 ---
 title: GNU Lesser General Public License v2.1
 nickname: GNU LGPL v2.1
-redirect_from: /licenses/lgpl-v2.1/
-source: http://www.gnu.org/licenses/lgpl-2.1.txt
-
-category: LGPL
 tab-slug: lgpl-v2_1
+redirect_from: /licenses/lgpl-v2.1/
+category: LGPL
+source: http://www.gnu.org/licenses/lgpl-2.1.txt
 
 description: Primarily used for software libraries, LGPL requires that derived works be licensed under the same license, but works that only link to it do not fall under this restriction. There are two commonly used versions of the LGPL.
 

--- a/_licenses/lgpl-3.0.txt
+++ b/_licenses/lgpl-3.0.txt
@@ -1,10 +1,10 @@
 ---
 title: GNU Lesser General Public License v3.0
 nickname: GNU LGPL v3.0
-category: LGPL
 tab-slug: lgpl-v3
-variant: true
 redirect_from: /licenses/lgpl-v3/
+category: LGPL
+variant: true
 source: http://www.gnu.org/licenses/lgpl-3.0.txt
 
 description: Version 3 of the LGPL is an additional set of permissions to the <a href="/licenses/GPL-3.0">GPL v3 license</a> that requires that derived works be licensed under the same license, but works that only link to it do not fall under this restriction.
@@ -30,6 +30,7 @@ forbidden:
   - no-liability
 
 ---
+
                    GNU LESSER GENERAL PUBLIC LICENSE
                        Version 3, 29 June 2007
 

--- a/_licenses/mit.txt
+++ b/_licenses/mit.txt
@@ -1,7 +1,7 @@
 ---
 title: MIT License
-source: http://opensource.org/licenses/MIT
 featured: true
+source: http://opensource.org/licenses/MIT
 
 description: A permissive license that is short and to the point. It lets people do anything with your code with proper attribution and without warranty.
 

--- a/_licenses/mpl-2.0.txt
+++ b/_licenses/mpl-2.0.txt
@@ -24,6 +24,7 @@ forbidden:
   - trademark-use
 
 ---
+
 Mozilla Public License, version 2.0
 
 1. Definitions

--- a/_licenses/no-license.txt
+++ b/_licenses/no-license.txt
@@ -4,9 +4,9 @@ source: "http://choosealicense.com/no-license/"
 
 description: You retain all rights and do not permit distribution, reproduction, or derivative works. You may grant some rights in cases where you publish your source code to a site that requires accepting terms of service. For example, publishing code in a public repository on GitHub requires that you allow others to view and fork your code.
 
-note: This option may be subject to the Terms Of Use of the site where you publish your source code.
-
 how: Simply do nothing, though including a copyright notice is recommended.
+
+note: This option may be subject to the Terms Of Use of the site where you publish your source code.
 
 required:
   - include-copyright

--- a/_licenses/ofl-1.1.txt
+++ b/_licenses/ofl-1.1.txt
@@ -1,15 +1,14 @@
 ---
 title: SIL Open Font License 1.1
-hidden: true
 redirect_from: /licenses/ofl/
-
+hidden: true
 source: http://scripts.sil.org/OFL_web
 
 description: The Open Font License (OFL) is maintained by SIL International. It attempts to be a compromise between the values of the free software and typeface design communities. It is used for almost all open source font projects, including those by Adobe, Google and Mozilla.
 
-note: This license doesn't require source provision, but recommends it. All files derived from OFL files must remain licensed under the OFL.
-
 how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your font source and copy the text of the license into the file. Replace [year] with the current year and [fullname] ([email]) with the name and contact email address of each copyright holder. You may take the additional step of appending a Reserved Font Name notice. This option requires anyone making modifications to change the font's name, and is not ideal for web fonts (which all users will modify by changing formats and subsetting for their own needs.)
+
+note: This license doesn't require source provision, but recommends it. All files derived from OFL files must remain licensed under the OFL.
 
 required:
   - include-copyright

--- a/_licenses/osl-3.0.txt
+++ b/_licenses/osl-3.0.txt
@@ -1,8 +1,11 @@
 ---
 title: Open Software License 3.0
 hidden: true
+source: http://opensource.org/licenses/OSL-3.0
 
 description: OSL 3.0 is a copyleft license that does not require reciprocal licensing on linked works. It also provides an express grant of patent rights from contributors to users, with a termination clause triggered if a user files a patent infringement lawsuit.
+
+how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file. Files licensed under OSL 3.0 must also include the notice "Licensed under the Open Software License version 3.0" adjacent to the copyright notice.
 
 note: OSL 3.0's author has <a href="http://rosenlaw.com/OSL3.0-explained.htm">provided an explanation</a> behind the creation of the license.
 
@@ -12,10 +15,6 @@ using:
   PrestaShop: "https://www.prestashop.com"
   Mulgara: "http://mulgara.org"
   AbanteCart: "http://www.abantecart.com/"
-
-how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file. Files licensed under OSL 3.0 must also include the notice "Licensed under the Open Software License version 3.0" adjacent to the copyright notice.
-
-source: http://opensource.org/licenses/OSL-3.0
 
 required:
   - include-copyright

--- a/_licenses/unlicense.txt
+++ b/_licenses/unlicense.txt
@@ -1,9 +1,8 @@
 ---
 title: The Unlicense
-source: http://unlicense.org/UNLICENSE
-
-category: Public Domain Dedication
 tab-slug: unlicense
+category: Public Domain Dedication
+source: http://unlicense.org/UNLICENSE
 
 description: Because copyright is automatic in most countries, <a href="http://unlicense.org">the Unlicense</a> is a template to waive copyright interest in software you've written and dedicate it to the public domain. Use the Unlicense to opt out of copyright entirely. It also includes the no-warranty statement from the MIT/X11 license.
 
@@ -24,6 +23,7 @@ forbidden:
 required: []
 
 ---
+
 This is free and unencumbered software released into the public domain.
 
 Anyone is free to copy, modify, publish, use, compile, sell, or


### PR DESCRIPTION
Properties are now consistently sorted across all license files,
appearing in the following order:

**title**
nickname
tab-slug
redirect_from
category
variant
featured
hidden
**source**

**description**
**how**
note

using

**required**
**permitted**
**forbidden**
