### PR TITLE
Correct copyright year of LICENSE.md

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
-Copyright (c) 2014 GitHub, Inc.
+Copyright (c) 2013 GitHub, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Revert 435a5c4 ; has to be the first year of publication https://en.wikipedia.org/wiki/Copyright#Copyright_notices_in_the_United_States
