### PR TITLE
Hidden licenses

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -17,7 +17,8 @@ defaults:
     values:
       layout: license
       featured: false
-      "hide-from-license-list": false
+      hidden: false
+      variant: false
 
 exclude:
   - app.coffee

--- a/_licenses/agpl-3.0.txt
+++ b/_licenses/agpl-3.0.txt
@@ -3,7 +3,7 @@ title: GNU Affero General Public License v3.0
 nickname: GNU Affero GPL v3.0
 category: GPL
 tab-slug: agpl-v3
-hide-from-license-list: true
+variant: true
 layout: license
 permalink: /licenses/agpl-3.0/
 source: http://www.gnu.org/licenses/agpl-3.0.txt

--- a/_licenses/bsd-2-clause.txt
+++ b/_licenses/bsd-2-clause.txt
@@ -4,7 +4,7 @@ title: BSD 2-clause "Simplified" License
 nickname: Simplified BSD
 category: BSD
 tab-slug: bsd
-hide-from-license-list: true
+variant: true
 redirect_from: /licenses/bsd/
 permalink: /licenses/bsd-2-clause/
 

--- a/_licenses/bsd-3-clause.txt
+++ b/_licenses/bsd-3-clause.txt
@@ -4,7 +4,7 @@ title: BSD 3-clause "New" or "Revised" License
 nickname: New BSD
 category: BSD
 tab-slug: bsd-3
-hide-from-license-list: true
+variant: true
 permalink: /licenses/bsd-3-clause/
 
 description: A permissive license that comes in two variants, the <a href="/licenses/bsd">BSD 2-Clause</a> and <a href="/licenses/bsd-3-clause">BSD 3-Clause</a>. Both have very minute differences to the MIT license. The three clause variant prohibits others from using the name of the project or its contributors to promote derivative works without written consent.

--- a/_licenses/cc0-1.0.txt
+++ b/_licenses/cc0-1.0.txt
@@ -6,7 +6,7 @@ category: Public Domain Dedication
 tab-slug: cc0
 permalink: /licenses/cc0/
 class: license-types
-hide-from-license-list: true
+variant: true
 filename: LICENSE
 
 source: http://creativecommons.org/publicdomain/zero/1.0/

--- a/_licenses/gpl-2.0.txt
+++ b/_licenses/gpl-2.0.txt
@@ -3,7 +3,7 @@ title: GNU General Public License v2.0
 nickname: GNU GPL v2.0
 category: GPL
 tab-slug: gpl-v2
-hide-from-license-list: false
+variant: false
 layout: license
 permalink: /licenses/gpl-2.0/
 redirect_from: /licenses/gpl-v2/

--- a/_licenses/gpl-3.0.txt
+++ b/_licenses/gpl-3.0.txt
@@ -3,7 +3,7 @@ title: GNU General Public License v3.0
 nickname: GNU GPL v3.0
 category: GPL
 tab-slug: gpl-v3
-hide-from-license-list: true
+variant: true
 layout: license
 permalink: /licenses/gpl-3.0/
 redirect_from: /licenses/gpl-v3/

--- a/_licenses/lgpl-3.0.txt
+++ b/_licenses/lgpl-3.0.txt
@@ -4,7 +4,7 @@ title: GNU Lesser General Public License v3.0
 nickname: GNU LGPL v3.0
 category: LGPL
 tab-slug: lgpl-v3
-hide-from-license-list: true
+variant: true
 redirect_from: /licenses/lgpl-v3/
 source: http://www.gnu.org/licenses/lgpl-3.0.txt
 permalink: /licenses/lgpl-3.0/

--- a/licenses.html
+++ b/licenses.html
@@ -17,7 +17,7 @@ title: Licenses
   Some communities tend to have specific licenses preferred by the
   community. For example, Perl developers often choose the Artistic License.
 </p>
-{% assign licenses = site.licenses | where:"featured",false | where:"hide-from-license-list",false %}
+{% assign licenses = site.licenses | where:"featured",false | where:"hidden",false | where:"variant",false %}
 {% for license in licenses %}
   {% include license-overview.html %}
 {% endfor %}


### PR DESCRIPTION
This pull request implements the "hidden license" functionality as described in https://github.com/github/choosealicense.com/issues/273. Licenses with `hidden: true` in their YAML front matter will not appear on the `/licenses` list.

In order to keep the front matter keys sane, `hide-from-license-list`, which really was used to described license variants, is now `variant`, with e.g., `GPLv3` being a "variant" of the GPL family of licenses.

Licenses default to `hidden: false` via `_config.yml` unless otherwise specified.

Fixes https://github.com/github/choosealicense.com/issues/273.
