### PR TITLE
Remove api

### DIFF
--- a/licenses.json
+++ b/licenses.json
@@ -1,4 +1,0 @@
----
----
-
-{{ site.licenses | jsonify }}


### PR DESCRIPTION
This removes the `licenses.json` API, which (A) is currently broken, and (B) is better served by [the licenses api](https://developer.github.com/v3/licenses/).
