### PR TITLE
Minor SEO optimizations

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,6 +1,6 @@
 ---
 title: Choose a License
-description: A site to provide non-judgmental guidance on choosing a license for your open source project
+description: Non-judgmental guidance on choosing a license for your open source project
 relative_permalinks: false
 markdown: kramdown
 url: "http://choosealicense.com"

--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,5 @@
 ---
-title: ChooseALicense.com
+title: Choose a License
 relative_permalinks: false
 markdown: kramdown
 url: "http://choosealicense.com"
@@ -43,3 +43,7 @@ gems:
 sass:
     sass_dir: _sass
     style: :compressed
+
+twitter:
+  username: "@github"
+  account_id: "13334762"

--- a/_config.yml
+++ b/_config.yml
@@ -47,4 +47,3 @@ sass:
 
 twitter:
   username: "@github"
-  account_id: "13334762"

--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,6 @@
 ---
 title: Choose a License
+description: A site to provide non-judgmental guidance on choosing a license for your open source project
 relative_permalinks: false
 markdown: kramdown
 url: "http://choosealicense.com"

--- a/_includes/breadcrumbs.html
+++ b/_includes/breadcrumbs.html
@@ -8,4 +8,32 @@
       {% endif %}
     </li>
   </ol>
+  <script type="application/ld+json">
+  {
+    "@context": "http://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [{
+      "@type": "ListItem",
+      "position": 1,
+      "item": {
+        "@id": "{{ site.github.url }}/",
+        "name": "Home"
+      }
+    },{% if page.layout == "license" %}{
+      "@type": "ListItem",
+      "position": 2,
+      "item": {
+        "@id": "{{ site.github.url }}/licenses",
+        "name": "Licenses"
+      }
+    },{% endif %}{
+      "@type": "ListItem",
+      "position": {% if page.layout == "license" %}3{% else %}2{% endif %},
+      "item": {
+        "@id": "{{ site.github.url }}{{ page.url }}",
+        "name": "{{ page.title }}"
+      }
+    }]
+  }
+  </script>
 {% endunless %}

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -3,8 +3,7 @@
   <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <title>{% if page.title %}{{ page.title | markdownify | strip_html | strip_newlines }} - {% endif %}{{ site.title}}</title>
-    {% if page.description %}<meta name="description" content="{{ page.description | strip_html | strip_newlines }}">{% endif %}
+
     <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Chivo:900">
     <link rel="stylesheet" href="/assets/css/application.css?v={{ site.github.build_revision }}">
     <link rel="shortcut icon" href="/favicon.ico" type="image/x-icon">
@@ -13,6 +12,8 @@
     <script src="/assets/vendor/selectivizr/selectivizr.js"></script>
     <![endif]-->
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
+
+    {% include seo.html %}
   </head>
   <body class="{{ page.layout }}{% if page.class %} {{ page.class }}{% endif %}">
     <div class="container">

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
+  <head itemscope itemtype="http://schema.org/WebSite">
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
 

--- a/_includes/seo.html
+++ b/_includes/seo.html
@@ -14,11 +14,12 @@
     <title>{{ seo_title }}</title>
     <meta property="og:title" content="{{ seo_title }}"/>
     <meta property="og:site_name" content="{{ site.title }}"/>
+    <title itemprop='name'>{{ site.title }}</title>
 
     <meta name="description" content="{{ seo_description }}">
     <meta property='og:description' content="{{ seo_description }}"/>
 
-    <link rel="canonical" href="{{ site.github.url }}{{ page.url }}"/>
+    <link rel="canonical" href="{{ site.github.url }}{{ page.url }}" itemprop="url"/>
     <meta property='og:url' content='{{ site.github.url }}{{ page.url }}'/>
     <meta property='og:locale' content='en_us'/>
 

--- a/_includes/seo.html
+++ b/_includes/seo.html
@@ -7,7 +7,7 @@
     {% if page.description %}
       {% assign seo_description = page.description | strip_html | strip_newlines %}
     {% else %}
-      {% assign seo_description = site.tagline | strip_html | strip_newlines %}
+      {% assign seo_description = site.description | strip_html | strip_newlines %}
     {% endif %}
 
     <!-- le seo -->

--- a/_includes/seo.html
+++ b/_includes/seo.html
@@ -23,10 +23,8 @@
     <meta property='og:url' content='{{ site.github.url }}{{ page.url }}'/>
     <meta property='og:locale' content='en_us'/>
 
-    <meta property="twitter:account_id" content="{{ site.twitter.account_id }}" />
-    <meta property="twitter:card" content="summary" />
-    <meta property="twitter:title" content="{{ seo_title }}" />
-    <meta property="twitter:description" content="{{ seo_description }}" />
-    <meta property="twitter:site" content="{{ site.twitter.username }}" />
-    <meta property="twitter:creator" content="{{ site.twitter.username }}" />
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:title" content="{{ seo_title }}" />
+    <meta name="twitter:description" content="{{ seo_description }}" />
+    <meta name="twitter:site" content="{{ site.twitter.username }}" />
     <!-- /seo -->

--- a/_includes/seo.html
+++ b/_includes/seo.html
@@ -1,0 +1,31 @@
+    {% if page.title %}
+      {% capture seo_title %}{{ page.title | markdownify | strip_html | strip_newlines }} - {{ site.title }}{% endcapture %}
+    {% else %}
+      {% assign seo_title = site.title %}
+    {% endif %}
+
+    {% if page.description %}
+      {% assign seo_description = page.description | strip_html | strip_newlines %}
+    {% else %}
+      {% assign seo_description = site.tagline | strip_html | strip_newlines %}
+    {% endif %}
+
+    <!-- le seo -->
+    <title>{{ seo_title }}</title>
+    <meta property="og:title" content="{{ seo_title }}"/>
+    <meta property="og:site_name" content="{{ site.title }}"/>
+
+    <meta name="description" content="{{ seo_description }}">
+    <meta property='og:description' content="{{ seo_description }}"/>
+
+    <link rel="canonical" href="{{ site.github.url }}{{ page.url }}"/>
+    <meta property='og:url' content='{{ site.github.url }}{{ page.url }}'/>
+    <meta property='og:locale' content='en_us'/>
+
+    <meta property="twitter:account_id" content="{{ site.twitter.account_id }}" />
+    <meta property="twitter:card" content="summary" />
+    <meta property="twitter:title" content="{{ seo_title }}" />
+    <meta property="twitter:description" content="{{ seo_description }}" />
+    <meta property="twitter:site" content="{{ site.twitter.username }}" />
+    <meta property="twitter:creator" content="{{ site.twitter.username }}" />
+    <!-- /seo -->

--- a/assets/css/application.scss
+++ b/assets/css/application.scss
@@ -72,7 +72,7 @@ strong {
 }
 
 .home h1 {
-  font-size: 63px;
+  font-size: 60px;
 }
 
 .home h2 {

--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 layout: default
 class: home
 hide_breadcrumbs: true
-title: Choosing an OSS license doesn’t need to be scary
+title: Choosing an open source license doesn’t need to be scary
 description: A site to provide non-judgmental guidance on choosing a license for your open source project
 permalink: /
 ---

--- a/index.html
+++ b/index.html
@@ -3,7 +3,6 @@ layout: default
 class: home
 hide_breadcrumbs: true
 title: Choosing an open source license doesn’t need to be scary
-description: A site to provide non-judgmental guidance on choosing a license for your open source project
 permalink: /
 ---
 

--- a/no-license.md
+++ b/no-license.md
@@ -2,6 +2,7 @@
 layout: default
 permalink: no-license/
 title: No License
+description: "You're under no obligation to choose a license and it's your right not to include one with your code or project. But please note that opting out of open source licenses doesn't mean you're opting out of copyright law."
 ---
 
 You're under no obligation to choose a license and it's your right not to include one with your code or project. But please note that opting out of open source licenses doesn't mean you're opting out of copyright law.

--- a/terms-of-service.md
+++ b/terms-of-service.md
@@ -2,7 +2,7 @@
 title: Terms of Service
 layout: default
 permalink: /terms-of-service/
-
+description: Terms governing your use of choosealicense.com
 ---
 
 ### 1. Introduction


### PR DESCRIPTION
I feel gross doing it, but it's a necessary evil. Right now if you google for common keywords (license names, etc.) we're not even in the results. Let's fix that.

Specifically:
- Rename site in `title` tag from `ChooseALicense.com` to `Choose a License` 
- Add open graph (Facebook, Slack, etc.) and Twitter meta title and description tags
- Add canonical URL
- Change homepage tagline from  "Choosing an ~~OSS~~ license doesn’t need to be scary" to "Choosing an **open source** license doesn’t need to be scary"

Otherwise, human-readable output should be the same. Not sure if there's anything else we can/should be doing.

/cc @bkeepers, @github/seo 
