### PR TITLE
Remove sublicense warning for GPL-3.0

### DIFF
--- a/_licenses/gpl-3.0.txt
+++ b/_licenses/gpl-3.0.txt
@@ -27,7 +27,6 @@ permitted:
 
 forbidden:
   - no-liability
-  - no-sublicense
 
 ---
 


### PR DESCRIPTION
From Section 10 of the GPL:

> Each time you convey a covered work, the recipient automatically
> receives a license from the original licensors, to run, modify and
> propagate that work, subject to this License.

Sublicensing is technically forbidden, but the copyleft makes the ability to sublicense irrelevant.

Fixes #10 
Closes #224

/cc @webmink @benbalter 
