### PR TITLE
Rename "Patent Grant" to "Patent Use"

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ The license properties (rules) are stored as a bulleted list within the licenses
 * `distribution` - You may distribute this software.
 * `sublicense` - You may grant a sublicense to modify and distribute this software to third parties not included in the license.
 * `private-use` - You may use and modify the software without distributing it.
-* `patent-grant` - This license provides an express grant of patent rights from the contributor to the recipient.
+* `patent-use` - This license provides an express grant of patent rights from the contributor to the recipient.
 
 #### Forbidden
 

--- a/_data/rules.yml
+++ b/_data/rules.yml
@@ -35,8 +35,8 @@ permitted:
   label: Private Use
   tag: private-use
 - description: This license provides an express grant of patent rights from the contributor to the recipient.
-  label: Patent Grant
-  tag: patent-grant
+  label: Patent Use
+  tag: patent-use
 
 forbidden:
 - description: While this may be implicitly true of all licenses, this license explicitly states that you may NOT use the names, logos, or trademarks of contributors.

--- a/_licenses/afl-3.0.txt
+++ b/_licenses/afl-3.0.txt
@@ -17,7 +17,7 @@ permitted:
   - distribution
   - sublicense
   - private-use
-  - patent-grant
+  - patent-use
 
 forbidden:
   - trademark-use

--- a/_licenses/agpl-3.0.txt
+++ b/_licenses/agpl-3.0.txt
@@ -23,7 +23,7 @@ permitted:
   - commercial-use
   - modifications
   - distribution
-  - patent-grant
+  - patent-use
   - private-use
 
 forbidden:

--- a/_licenses/apache-2.0.txt
+++ b/_licenses/apache-2.0.txt
@@ -20,7 +20,7 @@ permitted:
   - modifications
   - distribution
   - sublicense
-  - patent-grant
+  - patent-use
   - private-use
 
 forbidden:

--- a/_licenses/epl-1.0.txt
+++ b/_licenses/epl-1.0.txt
@@ -24,7 +24,7 @@ permitted:
   - distribution
   - modifications
   - sublicense
-  - patent-grant
+  - patent-use
   - private-use
 
 forbidden:

--- a/_licenses/gpl-2.0.txt
+++ b/_licenses/gpl-2.0.txt
@@ -22,7 +22,7 @@ permitted:
   - commercial-use
   - modifications
   - distribution
-  - patent-grant
+  - patent-use
   - private-use
 
 forbidden:

--- a/_licenses/gpl-3.0.txt
+++ b/_licenses/gpl-3.0.txt
@@ -22,7 +22,7 @@ permitted:
   - commercial-use
   - modifications
   - distribution
-  - patent-grant
+  - patent-use
   - private-use
 
 forbidden:

--- a/_licenses/lgpl-2.1.txt
+++ b/_licenses/lgpl-2.1.txt
@@ -22,7 +22,7 @@ permitted:
   - modifications
   - distribution
   - sublicense
-  - patent-grant
+  - patent-use
   - private-use
 
 forbidden:

--- a/_licenses/lgpl-3.0.txt
+++ b/_licenses/lgpl-3.0.txt
@@ -23,7 +23,7 @@ permitted:
   - modifications
   - distribution
   - sublicense
-  - patent-grant
+  - patent-use
   - private-use
 
 forbidden:

--- a/_licenses/mpl-2.0.txt
+++ b/_licenses/mpl-2.0.txt
@@ -16,7 +16,7 @@ permitted:
   - modifications
   - distribution
   - sublicense
-  - patent-grant
+  - patent-use
   - private-use
 
 forbidden:

--- a/_licenses/ms-pl.txt
+++ b/_licenses/ms-pl.txt
@@ -15,7 +15,7 @@ permitted:
   - commercial-use
   - modifications
   - distribution
-  - patent-grant
+  - patent-use
   - private-use
 
 forbidden:

--- a/_licenses/ms-rl.txt
+++ b/_licenses/ms-rl.txt
@@ -15,7 +15,7 @@ permitted:
   - commercial-use
   - modifications
   - distribution
-  - patent-grant
+  - patent-use
   - private-use
 
 forbidden:

--- a/_licenses/osl-3.0.txt
+++ b/_licenses/osl-3.0.txt
@@ -24,7 +24,7 @@ permitted:
   - commercial-use
   - distribution
   - modifications
-  - patent-grant
+  - patent-use
   - private-use
   - sublicense
 


### PR DESCRIPTION
Per the discussion in #168, the consumers of the softare are granted the right to use patents. So "Patent Use" makes more sense from a consumer perspective than "Patent Grant".

Fixes #168
