### PR TITLE
Prefer (L)GPL 3.0 to 2.x.

### DIFF
--- a/_licenses/gpl-2.0.txt
+++ b/_licenses/gpl-2.0.txt
@@ -4,7 +4,7 @@ nickname: GNU GPL v2.0
 tab-slug: gpl-v2
 redirect_from: /licenses/gpl-v2/
 family: GPL
-featured: true
+variant: true
 source: http://www.gnu.org/licenses/gpl-2.0.txt
 
 description: GPL is the most widely used free software license and has a strong copyleft requirement. When distributing derived works, the source code of the work must be made available under the same license. There are multiple variants of the GPL, each with different requirements.

--- a/_licenses/gpl-3.0.txt
+++ b/_licenses/gpl-3.0.txt
@@ -4,7 +4,7 @@ nickname: GNU GPL v3.0
 tab-slug: gpl-v3
 redirect_from: /licenses/gpl-v3/
 family: GPL
-variant: true
+featured: true
 source: http://www.gnu.org/licenses/gpl-3.0.txt
 
 description: GPL is the most widely used free software license and has a strong copyleft requirement. When distributing derived works, the source code of the work must be made available under the same license.

--- a/_licenses/lgpl-2.1.txt
+++ b/_licenses/lgpl-2.1.txt
@@ -4,6 +4,7 @@ nickname: GNU LGPL v2.1
 tab-slug: lgpl-v2_1
 redirect_from: /licenses/lgpl-v2.1/
 family: LGPL
+variant: true
 source: http://www.gnu.org/licenses/lgpl-2.1.txt
 
 description: Primarily used for software libraries, LGPL requires that derived works be licensed under the same license, but works that only link to it do not fall under this restriction. There are two commonly used versions of the LGPL.

--- a/_licenses/lgpl-3.0.txt
+++ b/_licenses/lgpl-3.0.txt
@@ -4,7 +4,6 @@ nickname: GNU LGPL v3.0
 tab-slug: lgpl-v3
 redirect_from: /licenses/lgpl-v3/
 family: LGPL
-variant: true
 source: http://www.gnu.org/licenses/lgpl-3.0.txt
 
 description: Version 3 of the LGPL is an additional set of permissions to the <a href="/licenses/GPL-3.0">GPL v3 license</a> that requires that derived works be licensed under the same license, but works that only link to it do not fall under this restriction.

--- a/index.html
+++ b/index.html
@@ -37,7 +37,7 @@ permalink: /
     </p>
   </li>
   <li class="copyleft">
-    <a href="licenses/gpl-2.0/">
+    <a href="licenses/gpl-3.0/">
       <span class="triptych-sprite circular"></span>
       <h3>I care about sharing improvements.</h3>
     </a>


### PR DESCRIPTION
The GPL v3 is an improvement over v2 fixing several issues and
increasing compatibility with other free software licenses.  As such
there is no reason to feature v2 prominently rather than v3.  See
http://www.gnu.org/licenses/rms-why-gplv3.en.html for more rationale.
