### PR TITLE
Increase accuracy re trademark clauses

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ The license properties (rules) are stored as a bulleted list within the licenses
 
 #### Forbidden
 
-* `trademark-use` - While this may be implicitly true of all licenses, this license explicitly states that it does NOT grant you any rights in the trademarks of contributors.
+* `trademark-use` - While this may be implicitly true of all licenses, this license explicitly states that it does NOT grant you any rights in the trademarks or other marks of contributors.
 * `no-liability` - Software is provided without warranty and the software author/license owner cannot be held liable for damages.
 * `no-sublicense` - You may not grant a sublicense to modify and distribute this software to third parties not included in the license.
 * `modifications` - This software may not be modified.

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ The license properties (rules) are stored as a bulleted list within the licenses
 
 #### Forbidden
 
-* `trademark-use` - While this may be implicitly true of all licenses, this license explicitly states that you may NOT use the names, logos, or trademarks of contributors.
+* `trademark-use` - While this may be implicitly true of all licenses, this license explicitly states that it does NOT grant you any rights in the trademarks of contributors.
 * `no-liability` - Software is provided without warranty and the software author/license owner cannot be held liable for damages.
 * `no-sublicense` - You may not grant a sublicense to modify and distribute this software to third parties not included in the license.
 * `modifications` - This software may not be modified.

--- a/_data/rules.yml
+++ b/_data/rules.yml
@@ -39,7 +39,7 @@ permitted:
   tag: patent-use
 
 forbidden:
-- description: While this may be implicitly true of all licenses, this license explicitly states that it does NOT grant you any rights in the trademarks of contributors.
+- description: While this may be implicitly true of all licenses, this license explicitly states that it does NOT grant you any rights in the trademarks or other marks of contributors.
   label: Use Trademark
   tag: trademark-use
 - description: Software is provided without warranty and the software author/license owner cannot be held liable for damages.

--- a/_data/rules.yml
+++ b/_data/rules.yml
@@ -39,7 +39,7 @@ permitted:
   tag: patent-use
 
 forbidden:
-- description: While this may be implicitly true of all licenses, this license explicitly states that you may NOT use the names, logos, or trademarks of contributors.
+- description: While this may be implicitly true of all licenses, this license explicitly states that it does NOT grant you any rights in the trademarks of contributors.
   label: Use Trademark
   tag: trademark-use
 - description: Software is provided without warranty and the software author/license owner cannot be held liable for damages.

--- a/_licenses/bsd-3-clause-clear.txt
+++ b/_licenses/bsd-3-clause-clear.txt
@@ -25,7 +25,6 @@ permitted:
 
 forbidden:
   - no-liability
-  - trademark-use
 
 ---
 

--- a/_licenses/bsd-3-clause.txt
+++ b/_licenses/bsd-3-clause.txt
@@ -22,7 +22,6 @@ permitted:
 
 forbidden:
   - no-liability
-  - trademark-use
 
 ---
 

--- a/_licenses/cc0-1.0.txt
+++ b/_licenses/cc0-1.0.txt
@@ -21,6 +21,7 @@ permitted:
 
 forbidden:
   - no-liability
+  - trademark-use
 
 required: []
 

--- a/_licenses/ofl-1.1.txt
+++ b/_licenses/ofl-1.1.txt
@@ -21,7 +21,6 @@ permitted:
 
 forbidden:
   - no-liability
-  - trademark-use
 
 ---
 


### PR DESCRIPTION
Slightly increase accuracy of trademark info:
- use not directly forbideen by certain licenses, rather rights not granted
- trademark is universal for such licenses, documentation was too specific re related non-grants
- CC0-1.0 is one of those licenses with explicit non-grant
- BSD and OFL license have no-endorsement clauses, which are a different thing
