### PR TITLE
Add script to check approval of a license.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ gem "jekyll-seo-tag"
 group :development do
   gem 'colored'
   gem 'terminal-table'
+  gem 'fuzzy_match'
 end
 
 group :test do

--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,11 @@ source "https://rubygems.org"
 gem "github-pages"
 gem "jekyll-seo-tag"
 
+group :development do
+  gem 'colored'
+  gem 'terminal-table'
+end
+
 group :test do
   gem 'html-proofer', '2.5.2'
   gem "rake"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -166,12 +166,14 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  colored
   github-pages
   html-proofer (= 2.5.2)
   jekyll-seo-tag
   nokogiri
   rake
   rspec
+  terminal-table
 
 BUNDLED WITH
    1.11.2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -26,6 +26,7 @@ GEM
       multipart-post (>= 1.2, < 3)
     fast-stemmer (1.0.2)
     ffi (1.9.10)
+    fuzzy_match (2.1.0)
     gemoji (2.1.0)
     github-pages (43)
       RedCloth (= 4.2.9)
@@ -167,6 +168,7 @@ PLATFORMS
 
 DEPENDENCIES
   colored
+  fuzzy_match
   github-pages
   html-proofer (= 2.5.2)
   jekyll-seo-tag

--- a/script/check-approval
+++ b/script/check-approval
@@ -54,3 +54,5 @@ elligible = !!(spdx && approved_licenses.include?(license))
 rows << ["Elligible", elligible]
 
 puts Terminal::Table.new title: "License: #{license}", rows: rows
+puts
+puts "Code search: https://github.com/search?q=#{license}+filename%3ALICENSE&type=Code"

--- a/script/check-approval
+++ b/script/check-approval
@@ -50,8 +50,11 @@ approvals.each do |name, licenses|
   rows << ["#{name} approved", licenses.include?(license)]
 end
 
+current = license_ids.include?(license)
+rows << ["Current license", current]
+
 rows << :separator
-eligible = !!(spdx && approved_licenses.include?(license))
+eligible = !!(!current && spdx && approved_licenses.include?(license))
 rows << ["Eligible", eligible]
 
 puts Terminal::Table.new title: "License: #{license}", rows: rows
@@ -62,7 +65,7 @@ if spdx.nil?
   puts
   puts "SPDX ID not found. Some possible matches:"
   puts
-  
+
   fm = FuzzyMatch.new(spdx_ids)
   matches = fm.find_all_with_score(license)
   matches = matches[0...5].map { |record, _dice, _levin| record }

--- a/script/check-approval
+++ b/script/check-approval
@@ -1,0 +1,56 @@
+#!/usr/bin/env ruby
+# Checks if a given license meets the approval criteria to be added to choosealicense.com
+# See https://github.com/github/choosealicense.com/blob/gh-pages/CONTRIBUTING.md#adding-a-license
+# Usage: script/check-approval [SPDX LICENSE ID]
+
+require_relative '../spec/spec_helper'
+require 'terminal-table'
+require 'colored'
+
+# Display usage instructions
+if ARGV.count != 1
+  puts File.open(__FILE__).read.scan(/^# .*/)[0...3].join("\n").gsub(/^# /,"")
+end
+
+class TrueClass
+  def to_s
+    "Yes".green
+  end
+end
+
+class FalseClass
+  def to_s
+    "No".red
+  end
+end
+
+license = ARGV[0].downcase.strip
+approvals = {
+  "OSI": osi_approved_licenses,
+  "FSF": fsf_approved_licenses,
+  "OD":  od_approved_licenses
+}
+
+id, spdx = find_spdx(license)
+rows = []
+
+if spdx.nil?
+  id = "Invalid".red
+  name = "None".red
+else
+  id = id.green
+  name = spdx["name"].green
+end
+
+rows << ["SPDX ID", id]
+rows << ["SPDX Name", name]
+
+approvals.each do |name, licenses|
+  rows << ["#{name} approved", licenses.include?(license)]
+end
+
+rows << :separator
+elligible = !!(spdx && approved_licenses.include?(license))
+rows << ["Elligible", elligible]
+
+puts Terminal::Table.new title: "License: #{license}", rows: rows

--- a/script/check-approval
+++ b/script/check-approval
@@ -6,6 +6,7 @@
 require_relative '../spec/spec_helper'
 require 'terminal-table'
 require 'colored'
+require 'fuzzy_match'
 
 # Display usage instructions
 if ARGV.count != 1
@@ -56,3 +57,14 @@ rows << ["Eligible", eligible]
 puts Terminal::Table.new title: "License: #{license}", rows: rows
 puts
 puts "Code search: https://github.com/search?q=#{license}+filename%3ALICENSE&type=Code"
+
+if spdx.nil?
+  puts
+  puts "SPDX ID not found. Some possible matches:"
+  puts
+  
+  fm = FuzzyMatch.new(spdx_ids)
+  matches = fm.find_all_with_score(license)
+  matches = matches[0...5].map { |record, _dice, _levin| record }
+  matches.each { |l| puts "* #{l}" }
+end

--- a/script/check-approval
+++ b/script/check-approval
@@ -50,8 +50,8 @@ approvals.each do |name, licenses|
 end
 
 rows << :separator
-elligible = !!(spdx && approved_licenses.include?(license))
-rows << ["Elligible", elligible]
+eligible = !!(spdx && approved_licenses.include?(license))
+rows << ["Eligible", eligible]
 
 puts Terminal::Table.new title: "License: #{license}", rows: rows
 puts

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -19,7 +19,14 @@ def config
 end
 
 def licenses
-  site.collections["licenses"].docs.map { |l| l.to_liquid.merge("id" => l.basename(".txt")) }
+  site.collections["licenses"].docs.map do |license|
+    id = File.basename(license.basename, ".txt")
+    license.to_liquid.merge("id" => id)
+  end
+end
+
+def license_ids
+  licenses.map { |l| l["id"] }
 end
 
 def families


### PR DESCRIPTION
A follow up to https://github.com/github/choosealicense.com/pull/316, this adds a quick script to check the approval of a given license to help with responding to issues proposing new licenses be added.

Example output:

```
➜  choosealicense.com git:(approval-script) script/check-approval mit
+--------------+-------------+
|        License: mit        |
+--------------+-------------+
| SPDX ID      | MIT         |
| SPDX Name    | MIT License |
| OSI approved | Yes         |
| FSF approved | No          |
| OD approved  | No          |
+--------------+-------------+
| Eligible     | Yes         |
+--------------+-------------+

Code search: https://github.com/search?q=mit+filename%3ALICENSE&type=Code
```

```
➜  choosealicense.com git:(approval-script) script/check-approval foobar
+--------------+---------+
|    License: foobar     |
+--------------+---------+
| SPDX ID      | Invalid |
| SPDX Name    | None    |
| OSI approved | No      |
| FSF approved | No      |
| OD approved  | No      |
+--------------+---------+
| Eligible     | No      |
+--------------+---------+

Code search: https://github.com/search?q=foobar+filename%3ALICENSE&type=Code
```
