### PR TITLE
Make licenses hidden by default

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -18,7 +18,7 @@ defaults:
     values:
       layout: license
       featured: false
-      hidden: false
+      hidden: true
       variant: false
 
 exclude:
@@ -41,7 +41,7 @@ gems:
   - jekyll-sitemap
   - jekyll-redirect-from
   - jekyll-seo-tag
-  
+
 sass:
     sass_dir: _sass
     style: :compressed

--- a/_licenses/afl-3.0.txt
+++ b/_licenses/afl-3.0.txt
@@ -4,8 +4,6 @@ source: http://opensource.org/licenses/afl-3.0
 
 description: The Academic Free License is a variant of the Open Source License that does not require that the source code of derivative works be disclosed. It contains explicit copyright and patent grants and reserves trademark rights in the author.
 
-hidden: true
-
 how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file. Files licensed under OSL 3.0 must also include the notice "Licensed under the Academic Free License version 3.0" adjacent to the copyright notice.
 
 required:

--- a/_licenses/agpl-3.0.txt
+++ b/_licenses/agpl-3.0.txt
@@ -30,6 +30,7 @@ forbidden:
   - no-liability
   - no-sublicense
 
+hidden: false
 ---
 
                     GNU AFFERO GENERAL PUBLIC LICENSE

--- a/_licenses/apache-2.0.txt
+++ b/_licenses/apache-2.0.txt
@@ -27,6 +27,7 @@ forbidden:
   - trademark-use
   - no-liability
 
+hidden: false
 ---
 
                                  Apache License

--- a/_licenses/artistic-2.0.txt
+++ b/_licenses/artistic-2.0.txt
@@ -22,6 +22,7 @@ forbidden:
   - no-liability
   - trademark-use
 
+hidden: false
 ---
 
                The Artistic License 2.0

--- a/_licenses/bsd-2-clause.txt
+++ b/_licenses/bsd-2-clause.txt
@@ -24,6 +24,7 @@ permitted:
 forbidden:
   - no-liability
 
+hidden: false
 ---
 
 Copyright (c) [year], [fullname]

--- a/_licenses/bsd-3-clause-clear.txt
+++ b/_licenses/bsd-3-clause-clear.txt
@@ -1,7 +1,6 @@
 ---
 title: BSD 3-clause Clear License
 nickname: Clear BSD
-hidden: true
 
 family: BSD
 tab-slug: bsd-3-clear

--- a/_licenses/bsd-3-clause.txt
+++ b/_licenses/bsd-3-clause.txt
@@ -23,6 +23,7 @@ permitted:
 forbidden:
   - no-liability
 
+hidden: false
 ---
 
 Copyright (c) [year], [fullname]

--- a/_licenses/cc0-1.0.txt
+++ b/_licenses/cc0-1.0.txt
@@ -25,6 +25,7 @@ forbidden:
 
 required: []
 
+hidden: false
 ---
 
 CC0 1.0 Universal

--- a/_licenses/epl-1.0.txt
+++ b/_licenses/epl-1.0.txt
@@ -30,6 +30,7 @@ permitted:
 forbidden:
   - no-liability
 
+hidden: false
 ---
 
 Eclipse Public License - v 1.0

--- a/_licenses/gpl-2.0.txt
+++ b/_licenses/gpl-2.0.txt
@@ -29,6 +29,7 @@ forbidden:
   - no-liability
   - no-sublicense
 
+hidden: false
 ---
 
                     GNU GENERAL PUBLIC LICENSE

--- a/_licenses/gpl-3.0.txt
+++ b/_licenses/gpl-3.0.txt
@@ -28,6 +28,7 @@ permitted:
 forbidden:
   - no-liability
 
+hidden: false
 ---
 
                     GNU GENERAL PUBLIC LICENSE

--- a/_licenses/isc.txt
+++ b/_licenses/isc.txt
@@ -21,6 +21,7 @@ permitted:
 forbidden:
   - no-liability
 
+hidden: false
 ---
 
 Copyright (c) [year], [fullname]

--- a/_licenses/lgpl-2.1.txt
+++ b/_licenses/lgpl-2.1.txt
@@ -29,6 +29,7 @@ permitted:
 forbidden:
   - no-liability
 
+hidden: false
 ---
 
                   GNU LESSER GENERAL PUBLIC LICENSE

--- a/_licenses/lgpl-3.0.txt
+++ b/_licenses/lgpl-3.0.txt
@@ -28,6 +28,7 @@ permitted:
 forbidden:
   - no-liability
 
+hidden: false
 ---
 
                    GNU LESSER GENERAL PUBLIC LICENSE

--- a/_licenses/mit.txt
+++ b/_licenses/mit.txt
@@ -20,6 +20,7 @@ permitted:
 forbidden:
   - no-liability
 
+hidden: false
 ---
 
 The MIT License (MIT)

--- a/_licenses/mpl-2.0.txt
+++ b/_licenses/mpl-2.0.txt
@@ -23,6 +23,7 @@ forbidden:
   - no-liability
   - trademark-use
 
+hidden: false
 ---
 
 Mozilla Public License Version 2.0

--- a/_licenses/ms-pl.txt
+++ b/_licenses/ms-pl.txt
@@ -1,6 +1,5 @@
 ---
 title: Microsoft Public License
-hidden: true  
 
 source: http://opensource.org/licenses/ms-pl
 

--- a/_licenses/ms-rl.txt
+++ b/_licenses/ms-rl.txt
@@ -1,6 +1,5 @@
 ---
 title: Microsoft Reciprocal License
-hidden: true  
 
 source: http://opensource.org/licenses/ms-pl
 

--- a/_licenses/no-license.txt
+++ b/_licenses/no-license.txt
@@ -20,6 +20,7 @@ forbidden:
   - distribution
   - sublicense
 
+hidden: false
 ---
 
 Copyright [year] [fullname]

--- a/_licenses/ofl-1.1.txt
+++ b/_licenses/ofl-1.1.txt
@@ -1,7 +1,6 @@
 ---
 title: SIL Open Font License 1.1
 redirect_from: /licenses/ofl/
-hidden: true
 source: http://scripts.sil.org/OFL_web
 
 description: The Open Font License (OFL) is maintained by SIL International. It attempts to be a compromise between the values of the free software and typeface design communities. It is used for almost all open source font projects, including those by Adobe, Google and Mozilla.

--- a/_licenses/osl-3.0.txt
+++ b/_licenses/osl-3.0.txt
@@ -1,6 +1,5 @@
 ---
 title: Open Software License 3.0
-hidden: true
 source: http://opensource.org/licenses/OSL-3.0
 
 description: OSL 3.0 is a copyleft license that does not require reciprocal licensing on linked works. It also provides an express grant of patent rights from contributors to users, with a termination clause triggered if a user files a patent infringement lawsuit.

--- a/_licenses/unlicense.txt
+++ b/_licenses/unlicense.txt
@@ -22,6 +22,7 @@ forbidden:
 
 required: []
 
+hidden: false
 ---
 
 This is free and unencumbered software released into the public domain.

--- a/_licenses/wtfpl.txt
+++ b/_licenses/wtfpl.txt
@@ -1,6 +1,5 @@
 ---
 title: "Do What The F*ck You Want To Public License"
-hidden: true
 source: http://www.wtfpl.net/
 
 description: The easiest licence out there. It gives the user permissions to do whatever they want with your code.

--- a/spec/license_shown_spec.rb
+++ b/spec/license_shown_spec.rb
@@ -1,0 +1,37 @@
+require 'spec_helper'
+
+describe "shown licenses" do
+
+  # Whitelist of popular licenses that are shown (non-hidden)
+  # Note: most new licenses that are added should be hidden by default
+  SHOWN_LICENSES = %w[
+    agpl-3.0
+    apache-2.0
+    artistic-2.0
+    bsd-2-clause
+    bsd-3-clause
+    cc0-1.0
+    epl-1.0
+    gpl-2.0
+    gpl-3.0
+    isc
+    lgpl-2.1
+    lgpl-3.0
+    mit
+    mpl-2.0
+    no-license
+    unlicense
+  ]
+
+  it "has the expected number of shown licenses" do
+    expect(shown_licenses.count).to eql(16)
+  end
+
+  shown_licenses.each do |license|
+    context "the #{license["title"]} license" do
+      it "is whitelisted to be shown" do
+        expect(SHOWN_LICENSES).to include(license["id"])
+      end
+    end
+  end
+end

--- a/spec/license_spec.rb
+++ b/spec/license_spec.rb
@@ -1,6 +1,7 @@
 require 'spec_helper'
 
 describe "licenses" do
+
   licenses.each do |license|
 
     # "No license" isn't really a license, so no need to test

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -19,10 +19,20 @@ def config
 end
 
 def licenses
-  site.collections["licenses"].docs.map do |license|
-    id = File.basename(license.basename, ".txt")
-    license.to_liquid.merge("id" => id)
+  $licenses ||= begin
+    site.collections["licenses"].docs.map do |license|
+      id = File.basename(license.basename, ".txt")
+      license.to_liquid.merge("id" => id)
+    end
   end
+end
+
+def hidden_licenses
+  licenses.select { |l| l["hidden"] }
+end
+
+def shown_licenses
+  licenses.select { |l| !l["hidden"] }
 end
 
 def license_ids


### PR DESCRIPTION
The intent here is to make it easier for contributors to propose new licenses be added, without multiple rounds of back-and-forth to correct metadata, or extensive review by maintainers. In other words, let robots do the work, rather than humans.

There should be no change to the site output or metadata. Instead, this PR does three things:
1. Makes `hidden: true` the default for licenses in `_config.yml`
2. Adds `hidden: false` to previously shown licenses, and removes `hidden: true` from hidden licenses 
3. Adds a test to ensure the number of shown licenses does not expand unless we explicitly update the test.

Fixes https://github.com/github/choosealicense.com/issues/323.
