### PR TITLE
Test each license file does not begin with byte order mark

### DIFF
--- a/spec/license_bom_spec.rb
+++ b/spec/license_bom_spec.rb
@@ -1,0 +1,16 @@
+require 'spec_helper'
+
+describe "license file" do
+
+  bom = "\xEF\xBB\xBF".each_byte.to_a
+
+  files = Dir["_licenses/*.txt"]
+
+  files.each do |fn|
+    first3 = File.open(fn) {|f| f.read(3)}
+
+    it "#{fn} should not have a byte order mark" do
+      expect(first3.each_byte.to_a).not_to eq(bom)
+    end
+  end
+end

--- a/spec/license_bom_spec.rb
+++ b/spec/license_bom_spec.rb
@@ -1,16 +1,13 @@
 require 'spec_helper'
 
-describe "license file" do
-
-  bom = "\xEF\xBB\xBF".each_byte.to_a
-
-  files = Dir["_licenses/*.txt"]
-
-  files.each do |fn|
-    first3 = File.open(fn) {|f| f.read(3)}
-
-    it "#{fn} should not have a byte order mark" do
-      expect(first3.each_byte.to_a).not_to eq(bom)
+describe "byte order marks" do
+  Dir["#{licenses_path}/*.txt"].each do |file|
+    context "the #{File.basename(file, ".txt")} license" do
+      it "does not begin with a byte order mark" do
+        bom = !!(File.open(file).read =~ /\A\xEF\xBB\xBF/)
+        msg = "License file begins with a Byte Order Mark. See http://stackoverflow.com/a/1068700."
+        expect(bom).to eql(false), msg
+      end
     end
   end
 end

--- a/spec/license_spec.rb
+++ b/spec/license_spec.rb
@@ -2,6 +2,10 @@ require 'spec_helper'
 
 describe "licenses" do
 
+  it "matches the number of files in the _licenses folder" do
+    expect(licenses.count).to eql(Dir["#{licenses_path}/*.txt"].count)
+  end
+
   licenses.each do |license|
 
     context "The #{license["title"]} license" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,6 +12,10 @@ def source
   File.expand_path("../", File.dirname(__FILE__))
 end
 
+def licenses_path
+  File.expand_path "_licenses", source
+end
+
 def config
   config = Jekyll::Configuration.new.read_config_file config_file
   config = Jekyll::Utils.deep_merge_hashes(config, {:source => source})


### PR DESCRIPTION
My Ruby is probably extremely bad. For one thing I couldn't get the first 3 bytes read to equal "\xEF\xBB\xBF" (with any operator) and I couldn't discern what the difference was in irb. So I resorted to comparing them as byte arrays, which works fine.

Not sure this test is even worth including, but critique of any sort welcome in any case.
