### PR TITLE
Artistic License 2.0 (c) is for license text, not a template

### DIFF
--- a/_licenses/artistic-2.0.txt
+++ b/_licenses/artistic-2.0.txt
@@ -27,7 +27,7 @@ hidden: false
 
                The Artistic License 2.0
 
-           Copyright (c) [year] [fullname]
+           Copyright (c) 2000-2006, The Perl Foundation.
 
      Everyone is permitted to copy and distribute verbatim copies
       of this license document, but changing it is not allowed.


### PR DESCRIPTION
fix #310 introduced in 0161a3d75d5f72fe842886b79c07db6ceb773ae2
