### PR TITLE
Update example projects

### DIFF
--- a/index.html
+++ b/index.html
@@ -42,7 +42,7 @@ permalink: /
       <h3>I care about sharing improvements.</h3>
     </a>
     <p>
-      The <a href="licenses/gpl-3.0/">GNU GPL</a> is a copyleft license that lets people do anything they want with your code as long as they give the same freedoms to anyone   else to which give your code or something based on it.
+      The GPL (<a href="licenses/gpl-2.0/">V2</a> or <a href="licenses/gpl-3.0/">V3</a>) is a copyleft license that requires anyone who distributes your code or a derivative work to make the source available under the same terms. V3 is similar to V2, but further restricts use in hardware that forbids software alterations.
     </p>
     <p>
       <strong>WordPress</strong>, <strong>Linux</strong>, and <strong>Bash</strong> use the GPL.

--- a/index.html
+++ b/index.html
@@ -21,7 +21,7 @@ permalink: /
       The <a href="licenses/mit">MIT License</a> is a permissive license that is short and to the point. It lets people do anything they want with your code as long as they provide attribution back to you and don’t hold you liable.
     </p>
     <p>
-      <strong>jQuery</strong> and <strong>Rails</strong> use the MIT&nbsp;License.
+      <strong>jQuery</strong>, <strong>Rails</strong> and <strong>.NET Core</strong> use the MIT&nbsp;License.
     </p>
   </li>
   <li class="patents">
@@ -33,7 +33,7 @@ permalink: /
       The <a href="licenses/apache-2.0/">Apache License</a> is a permissive license similar to the MIT License, but also provides an express grant of patent rights from contributors to users.
     </p>
     <p>
-      <strong>Apache</strong>, <strong>SVN</strong>, and <strong>NuGet</strong> use the Apache&nbsp;License.
+      <strong>Apache</strong>, <strong>Swift</strong>, and <strong>Docker</strong> use the Apache&nbsp;License.
     </p>
   </li>
   <li class="copyleft">
@@ -42,10 +42,10 @@ permalink: /
       <h3>I care about sharing improvements.</h3>
     </a>
     <p>
-      The GPL (<a href="licenses/gpl-2.0/">V2</a> or <a href="licenses/gpl-3.0/">V3</a>) is a copyleft license that requires anyone who distributes your code or a derivative work to make the source available under the same terms. V3 is similar to V2, but further restricts use in hardware that forbids software alterations.
+      The <a href="licenses/gpl-3.0/">GNU GPL</a> is a copyleft license that lets people do anything they want with your code as long as they give the same freedoms to anyone   else to which give your code or something based on it.
     </p>
     <p>
-      <strong>Linux</strong>, <strong>Git</strong>, and <strong>WordPress</strong> use the GPL.
+      <strong>WordPress</strong>, <strong>Linux</strong>, and <strong>Bash</strong> use the GPL.
     </p>
   </li>
 </ul>

--- a/index.html
+++ b/index.html
@@ -33,7 +33,7 @@ permalink: /
       The <a href="licenses/apache-2.0/">Apache License</a> is a permissive license similar to the MIT License, but also provides an express grant of patent rights from contributors to users.
     </p>
     <p>
-      <strong>Apache</strong>, <strong>Swift</strong>, and <strong>Docker</strong> use the Apache&nbsp;License.
+      <strong>Apache</strong>, <strong>Swift</strong>, and <strong>Android</strong> use the Apache&nbsp;License.
     </p>
   </li>
   <li class="copyleft">


### PR DESCRIPTION
This updates the example projects listed on the homepage for each license.
- add a 3rd example (.NET Core) to MIT for consistency
- replace SVN & NuGet with more more modern and well-known examples
  (Swift, Docker) for Apache
- Add a GPLv3 project to examples

There are not currently guidelines for how we choose the projects. We (@amateurhuman and I) tried to choose projects that:
- are more likely to be known by people in most ecosystems (sorry NuGet)
- represent different types of projects, like programming languages, libraries, and utilities
