### PR TITLE
Revert "Update descriptions of fields to reflect hidden default change"

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,13 +50,13 @@ Licenses sit in the `/_licenses` folder. Each license has YAML front matter desc
 
 * `note` - Additional information about the licenses
 * `using` - A list of notable projects using the license in the form of `project_name: "url"`
-* `hidden` - Whether the license is hidden from the license list (defaults to true)
-* `redirect_from` - Relative path(s) to redirect to the license from, to prevent breaking old URLs
+* `hidden` - Whether the license is hidden from the license list (defaults to false)
+* `redirect_from` - Relative path(s) to redirect to the license from
 * `featured` - Whether the license should be featured on the main page (defaults to false)
-* `nickname` - A shorter, human-readable license name where the SPDX license name (`title` above) is long
-* `variant` - Whether the license is a variant of a family of licenses (defaults to false)
+* `nickname` - A shorter, human-readable license name where the SPDX license name is long
+* `variant` - Whether the license is a variant of a family of licenses (e.g., GPL)
 * `family` - If part of a license family, the name of the license family (e.g., `GPL`)
-* `tab-slug` - If part of a license family, a license slug containing only `a-z`, `0-9`, and `_` characters, used for internal links on the licenses page
+* `tab-slug` - If part of a license family, a license slug containing only `a-z`, `0-9`, and `_` characters
 
 ### Auto-populated fields
 

--- a/_data/meta.yml
+++ b/_data/meta.yml
@@ -40,11 +40,11 @@
   required: false
 
 - name: hidden
-  description: Whether the license is hidden from the license list (defaults to true)
+  description: Whether the license is hidden from the license list (defaults to false)
   required: false
 
 - name: redirect_from
-  description: Relative path(s) to redirect to the license from, to prevent breaking old URLs
+  description: Relative path(s) to redirect to the license from
   required: false
 
 - name: featured
@@ -52,11 +52,11 @@
   required: false
 
 - name: nickname
-  description: A shorter, human-readable license name where the SPDX license name (`title` above) is long
+  description: A shorter, human-readable license name where the SPDX license name is long
   required: false
 
 - name: variant
-  description: Whether the license is a variant of a family of licenses (defaults to false)
+  description: Whether the license is a variant of a family of licenses (e.g., GPL)
   required: false
 
 - name: family
@@ -64,5 +64,5 @@
   required: false
 
 - name: tab-slug
-  description: If part of a license family, a license slug containing only `a-z`, `0-9`, and `_` characters, used for internal links on the licenses page
+  description: If part of a license family, a license slug containing only `a-z`, `0-9`, and `_` characters
   required: false


### PR DESCRIPTION
Reverts github/choosealicense.com#337

Individual licenses URLs 404 on choosealicense.com eg http://choosealicense.com/licenses/mit/

Can't reproduce locally be either something in this change or a pages failure. Reverting to see.
