### PR TITLE
Fix #341 tests that broke post Jekyll 3 upgrade

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -11,6 +11,7 @@ task :test do
   sh "bundle exec jekyll build --trace"
   Rake::Task["spec"].invoke
   HTML::Proofer.new("./_site", :check_html => true,
+                    :validation => { :ignore_script_embeds => true },
                     :href_swap => { %r{http://choosealicense.com} => "" }).run
 end
 

--- a/_config.yml
+++ b/_config.yml
@@ -41,6 +41,7 @@ gems:
   - jekyll-sitemap
   - jekyll-redirect-from
   - jekyll-seo-tag
+  - jekyll-coffeescript
 
 sass:
     sass_dir: _sass


### PR DESCRIPTION
- explicitly include jekyll-coffeescript needed per
  http://jekyllrb.com/docs/upgrading/2-to-3/
- option to html-proofer to ignore script embeds; uncertain why
  warnings appeared post upgrade as it doesn't seem that either
  jekyll-seo-tag or html-proofer got new versions in
  https://github.com/github/choosealicense.com/pull/339/files but
  suppressed now in any case.
