### PR TITLE
Remove 'library-usage'

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,6 @@ The license properties (rules) are stored as a bulleted list within the licenses
 * `document-changes` - Indicate significant changes made to the code.
 * `disclose-source` - Source code must be made available when distributing the software. In the case of LGPL and OSL 3.0, the source for the library (and not the entire program) must be made available.
 * `network-use-disclose` - Users who interact with the software via network are given the right to receive a copy of the corresponding source code.
-* `library-usage` - The library may be used within a non-open-source application.
 * `rename` - You must change the name of the software if you modify it.
 
 #### Permitted

--- a/_data/rules.yml
+++ b/_data/rules.yml
@@ -11,9 +11,6 @@ required:
 - description: Users who interact with the software via network are given the right to receive a copy of the corresponding source code.
   label: Network Use is Distribution
   tag: network-use-disclose
-- description: The library may be used within a non-open-source application.
-  label: Library usage
-  tag: library-usage
 - description: You must change the name of the software if you modify it.
   label: Rename
   tag: rename

--- a/_licenses/lgpl-2.1.html
+++ b/_licenses/lgpl-2.1.html
@@ -15,7 +15,6 @@ note: The Free Software Foundation recommends taking the additional step of addi
 
 required:
   - include-copyright
-  - library-usage
   - disclose-source
 
 permitted:

--- a/_licenses/lgpl-3.0.html
+++ b/_licenses/lgpl-3.0.html
@@ -14,7 +14,6 @@ note: The Free Software Foundation recommends taking the additional step of addi
 
 required:
   - include-copyright
-  - library-usage
   - disclose-source
 
 permitted:


### PR DESCRIPTION
The last meaningful change to this tag was c4c48d49 (Change nonstatic
to library usage, 2013-07-10), but I'm not sure where that discussion
happened.  In any case, that commit changed some "must" wording to
"may" wording, which seems like it should move the label from required
to permitted.

The 'usage' -> 'use' change is just for consistency with the other
labels about using a package.
