### PR TITLE
Add Rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,16 @@
+AllCops:
+  TargetRubyVersion: 2.1
+  Exclude:
+    - _site/**/*
+
+Metrics/LineLength:
+  Enabled: false
+
+Metrics/MethodLength:
+  Enabled: false
+
+Metrics/AbcSize:
+  Enabled: false
+
+Style/Documentation:
+  Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,6 +2,7 @@ AllCops:
   TargetRubyVersion: 2.1
   Exclude:
     - _site/**/*
+    - vendor/**/*
 
 Metrics/LineLength:
   Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
-source "https://rubygems.org"
+source 'https://rubygems.org'
 
-gem "github-pages"
-gem "jekyll-seo-tag"
+gem 'github-pages'
+gem 'jekyll-seo-tag'
 
 group :development do
   gem 'colored'
@@ -11,7 +11,8 @@ end
 
 group :test do
   gem 'html-proofer', '2.5.2'
-  gem "rake"
-  gem "rspec"
-  gem "nokogiri"
+  gem 'rake'
+  gem 'rspec'
+  gem 'nokogiri'
+  gem 'rubocop'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,6 +9,7 @@ GEM
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
     addressable (2.3.8)
+    ast (2.2.0)
     coffee-script (2.4.1)
       coffee-script-source
       execjs
@@ -112,7 +113,11 @@ GEM
     octokit (4.2.0)
       sawyer (~> 0.6.0, >= 0.5.3)
     parallel (1.6.1)
+    parser (2.3.0.3)
+      ast (~> 2.2)
+    powerpack (0.1.1)
     public_suffix (1.5.3)
+    rainbow (2.1.0)
     rake (10.5.0)
     rb-fsevent (0.9.7)
     rb-inotify (0.9.5)
@@ -133,6 +138,13 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.4.0)
     rspec-support (3.4.1)
+    rubocop (0.37.0)
+      parser (>= 2.3.0.2, < 3.0)
+      powerpack (~> 0.1)
+      rainbow (>= 1.99.1, < 3.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (~> 0.3)
+    ruby-progressbar (1.7.5)
     safe_yaml (1.0.4)
     sass (3.4.21)
     sawyer (0.6.0)
@@ -144,6 +156,7 @@ GEM
       ethon (>= 0.8.0)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
+    unicode-display_width (0.3.1)
     yell (2.0.5)
 
 PLATFORMS
@@ -158,6 +171,7 @@ DEPENDENCIES
   nokogiri
   rake
   rspec
+  rubocop
   terminal-table
 
 BUNDLED WITH

--- a/Rakefile
+++ b/Rakefile
@@ -1,18 +1,18 @@
-require "html/proofer"
+require 'html/proofer'
 require 'rspec/core/rake_task'
 
-desc "Run specs"
+desc 'Run specs'
 RSpec::Core::RakeTask.new do |t|
   t.pattern = 'spec/**/*_spec.rb'
-  t.rspec_opts = ["--order", "rand", "--color"]
+  t.rspec_opts = ['--order', 'rand', '--color']
 end
 
 task :test do
-  sh "bundle exec jekyll build --trace"
-  Rake::Task["spec"].invoke
-  HTML::Proofer.new("./_site", :check_html => true,
-                    :validation => { :ignore_script_embeds => true },
-                    :href_swap => { %r{http://choosealicense.com} => "" }).run
+  sh 'bundle exec jekyll build'
+  Rake::Task['spec'].invoke
+  HTML::Proofer.new('./_site', check_html: true,
+                               validation: { ignore_script_embeds: true },
+                               href_swap: { %r{http://choosealicense.com} => '' }).run
 end
 
 task :approved_licenses do
@@ -20,10 +20,10 @@ task :approved_licenses do
   approved = approved_licenses
   approved.select! { |l| spdx_ids.include?(l) }
   puts "#{approved.count} approved licenses:"
-  puts approved.join(", ")
+  puts approved.join(', ')
   puts "\n"
 
-  potential = approved - licenses.map { |l| l["id"] }
+  potential = approved - licenses.map { |l| l['id'] }
   puts "#{potential.count} potential additions:"
-  puts potential.join(", ")
+  puts potential.join(', ')
 end

--- a/script/check-approval
+++ b/script/check-approval
@@ -10,52 +10,52 @@ require 'fuzzy_match'
 
 # Display usage instructions
 if ARGV.count != 1
-  puts File.open(__FILE__).read.scan(/^# .*/)[0...3].join("\n").gsub(/^# /,"")
+  puts File.open(__FILE__).read.scan(/^# .*/)[0...3].join("\n").gsub(/^# /, '')
 end
 
 class TrueClass
   def to_s
-    "Yes".green
+    'Yes'.green
   end
 end
 
 class FalseClass
   def to_s
-    "No".red
+    'No'.red
   end
 end
 
 license = ARGV[0].downcase.strip
 approvals = {
-  "OSI": osi_approved_licenses,
-  "FSF": fsf_approved_licenses,
-  "OD":  od_approved_licenses
+  'OSI' => osi_approved_licenses,
+  'FSF' => fsf_approved_licenses,
+  'OD' => od_approved_licenses
 }
 
 id, spdx = find_spdx(license)
 rows = []
 
 if spdx.nil?
-  id = "Invalid".red
-  name = "None".red
+  id = 'Invalid'.red
+  name = 'None'.red
 else
   id = id.green
-  name = spdx["name"].green
+  name = spdx['name'].green
 end
 
-rows << ["SPDX ID", id]
-rows << ["SPDX Name", name]
+rows << ['SPDX ID', id]
+rows << ['SPDX Name', name]
 
-approvals.each do |name, licenses|
-  rows << ["#{name} approved", licenses.include?(license)]
+approvals.each do |approver, licenses|
+  rows << ["#{approver} approved", licenses.include?(license)]
 end
 
 current = license_ids.include?(license)
-rows << ["Current license", current]
+rows << ['Current license', current]
 
 rows << :separator
-eligible = !!(!current && spdx && approved_licenses.include?(license))
-rows << ["Eligible", eligible]
+eligible = (!current && spdx && approved_licenses.include?(license))
+rows << ['Eligible', eligible]
 
 puts Terminal::Table.new title: "License: #{license}", rows: rows
 puts
@@ -63,7 +63,7 @@ puts "Code search: https://github.com/search?q=#{license}+filename%3ALICENSE&typ
 
 if spdx.nil?
   puts
-  puts "SPDX ID not found. Some possible matches:"
+  puts 'SPDX ID not found. Some possible matches:'
   puts
 
   fm = FuzzyMatch.new(spdx_ids)

--- a/script/cibuild
+++ b/script/cibuild
@@ -4,3 +4,4 @@ set -e
 
 echo "building the site..."
 bundle exec rake test
+bundle exec rubocop -D -S

--- a/script/downcase
+++ b/script/downcase
@@ -1,7 +1,7 @@
 #! /usr/bin/env ruby
 # downcases all licenses in a git-friendly way
 
-Dir["_licenses/*"].each do |file|
+Dir['_licenses/*'].each do |file|
   system "git mv #{file} #{file.downcase}2"
   system "git mv #{file.downcase}2 #{file.downcase}"
 end

--- a/script/generate-docs
+++ b/script/generate-docs
@@ -5,32 +5,32 @@
 
 require 'yaml'
 
-fields = YAML.load_file("_data/fields.yml")
-meta   = YAML.load_file("_data/meta.yml")
-rules  = YAML.load_file("_data/rules.yml")
+fields = YAML.load_file('_data/fields.yml')
+meta   = YAML.load_file('_data/meta.yml')
+rules  = YAML.load_file('_data/rules.yml')
 
 puts "\n### Fields\n\n"
 fields.each do |field|
-  puts "* `#{field["name"]}` - #{field["description"]}"
+  puts "* `#{field['name']}` - #{field['description']}"
 end
 
 puts "\n### YAML front matter\n"
-meta = meta.group_by { |m| m["required"] }
+meta = meta.group_by { |m| m['required'] }
 
 puts "\n#### Required fields\n\n"
-meta[true].each do |meta|
-  puts "* `#{meta["name"]}` - #{meta["description"]}"
+meta[true].each do |field|
+  puts "* `#{field['name']}` - #{field['description']}"
 end
 
 puts "\n#### Optional fields\n\n"
-meta[false].each do |meta|
-  puts "* `#{meta["name"]}` - #{meta["description"]}"
+meta[false].each do |field|
+  puts "* `#{field['name']}` - #{field['description']}"
 end
 
 puts "\n### Rules\n"
-rules.each do |group, rules|
+rules.each do |group, group_rules|
   puts "\n#### #{group.capitalize}\n\n"
-  rules.each do |rule|
-    puts "* `#{rule["tag"]}` - #{rule["description"]}"
+  group_rules.each do |rule|
+    puts "* `#{rule['tag']}` - #{rule['description']}"
   end
 end

--- a/spec/license_bom_spec.rb
+++ b/spec/license_bom_spec.rb
@@ -1,11 +1,11 @@
 require 'spec_helper'
 
-describe "byte order marks" do
+describe 'byte order marks' do
   Dir["#{licenses_path}/*.html"].each do |file|
-    context "the #{File.basename(file, ".html")} license" do
-      it "does not begin with a byte order mark" do
-        bom = !!(File.open(file).read =~ /\A\xEF\xBB\xBF/)
-        msg = "License file begins with a Byte Order Mark. See http://stackoverflow.com/a/1068700."
+    context "the #{File.basename(file, '.html')} license" do
+      it 'does not begin with a byte order mark' do
+        bom = File.open(file).read.start_with?("\u0000EF\u0000BB\u0000BF")
+        msg = 'License file begins with a Byte Order Mark. See http://stackoverflow.com/a/1068700.'
         expect(bom).to eql(false), msg
       end
     end

--- a/spec/license_category_spec.rb
+++ b/spec/license_category_spec.rb
@@ -1,30 +1,30 @@
 require 'spec_helper'
 
-describe "license categories" do
+describe 'license categories' do
   families.each do |family|
     context "the #{family} family" do
-      family_licenses = licenses.select { |l| l["family"] == family }
-      primary = family_licenses.select  { |l| l["variant"] == false }
-      variants = family_licenses.select { |l| l["variant"] == true }
+      family_licenses = licenses.select { |l| l['family'] == family }
+      primary = family_licenses.select  { |l| l['variant'] == false }
+      variants = family_licenses.select { |l| l['variant'] == true }
 
-      it "should only have one primary license" do
+      it 'should only have one primary license' do
         expect(primary.count).to eql(1)
       end
 
-      it "all other licenses should be variants" do
+      it 'all other licenses should be variants' do
         expected = family_licenses.count - 1
         expect(variants.count).to eql(expected)
       end
 
       family_licenses.each do |license|
-        context "the #{license["title"]} license" do
-          it "should have a unique slug" do
-            dupes = family_licenses.select { |l| l["tab-slug"] == license["tab-slug"] }.count
+        context "the #{license['title']} license" do
+          it 'should have a unique slug' do
+            dupes = family_licenses.count { |l| l['tab-slug'] == license['tab-slug'] }
             expect(dupes).to eql(1)
           end
 
-          it "should have a valid tab-slug" do
-            expect(license["tab-slug"]).to match(/[a-z0-9_]/)
+          it 'should have a valid tab-slug' do
+            expect(license['tab-slug']).to match(/[a-z0-9_]/)
           end
         end
       end

--- a/spec/license_fields_spec.rb
+++ b/spec/license_fields_spec.rb
@@ -1,11 +1,11 @@
 require 'spec_helper'
 
-describe "license fillable fields" do
+describe 'license fillable fields' do
   licenses.each do |license|
-    context "The #{license["title"]} license" do
-      it "should only contain supported fillable fields" do
-        matches = license["content"].scan(/\[([a-z]+)\]/)
-        extra_fields = matches.flatten - fields.map { |f| f["name"] }
+    context "The #{license['title']} license" do
+      it 'should only contain supported fillable fields' do
+        matches = license['content'].scan(/\[([a-z]+)\]/)
+        extra_fields = matches.flatten - fields.map { |f| f['name'] }
         expect(extra_fields).to be_empty
       end
     end

--- a/spec/license_meta_spec.rb
+++ b/spec/license_meta_spec.rb
@@ -1,31 +1,30 @@
 require 'spec_helper'
 
-describe "license meta" do
+describe 'license meta' do
   licenses.each do |license|
-
     # Manually load the raw license so we don't get thed defaults
-    raw_fields = SafeYAML.load_file("_licenses/#{license["id"]}.html")
+    raw_fields = SafeYAML.load_file("_licenses/#{license['id']}.html")
 
-    context "The #{license["title"]} license" do
-      it "should only contain supported meta fields" do
-        extra_fields = raw_fields.keys - meta.map { |m| m["name"] }
+    context "The #{license['title']} license" do
+      it 'should only contain supported meta fields' do
+        extra_fields = raw_fields.keys - meta.map { |m| m['name'] }
         expect(extra_fields).to be_empty
       end
 
-      it "should contain all required meta fields" do
-        required = meta.select { |m| m["required"] }.map { |m| m["name"] }
+      it 'should contain all required meta fields' do
+        required = meta.select { |m| m['required'] }.map { |m| m['name'] }
         missing = required - raw_fields.keys
         expect(missing).to be_empty
       end
 
-      if license["family"]
-        it "should contain the required license variant fields" do
-          missing = ["family", "tab-slug"] - license.keys
+      if license['family']
+        it 'should contain the required license variant fields' do
+          missing = ['family', 'tab-slug'] - license.keys
           expect(missing).to be_empty
         end
       else
-        it "should not contain license family specific fields" do
-          extra = ["variant", "family", "tab-slug"].select{ |f| raw_fields.keys.include?(f) }
+        it 'should not contain license family specific fields' do
+          extra = ['variant', 'family', 'tab-slug'].select { |f| raw_fields.keys.include?(f) }
           expect(extra).to be_empty
         end
       end

--- a/spec/license_rules_spec.rb
+++ b/spec/license_rules_spec.rb
@@ -1,21 +1,19 @@
 require 'spec_helper'
 
-describe "license rules" do
+describe 'license rules' do
   licenses.each do |license|
-
     groups = rules.keys
 
-    context "The #{license["title"]} license" do
+    context "The #{license['title']} license" do
       groups.each do |group|
-
-        valid_tags = rules[group].map { |r| r["tag"] }
+        valid_tags = rules[group].map { |r| r['tag'] }
 
         context "the #{group} group" do
-          it "should exist" do
+          it 'should exist' do
             expect(license[group]).to_not be_nil
           end
 
-          it "should only contain valid tags" do
+          it 'should only contain valid tags' do
             extra = license[group] - valid_tags
             expect(extra).to be_empty
           end

--- a/spec/license_shown_spec.rb
+++ b/spec/license_shown_spec.rb
@@ -1,10 +1,9 @@
 require 'spec_helper'
 
-describe "shown licenses" do
-
+describe 'shown licenses' do
   # Whitelist of popular licenses that are shown (non-hidden)
   # Note: most new licenses that are added should be hidden by default
-  SHOWN_LICENSES = %w[
+  SHOWN_LICENSES = %w(
     agpl-3.0
     apache-2.0
     artistic-2.0
@@ -20,16 +19,16 @@ describe "shown licenses" do
     mit
     mpl-2.0
     unlicense
-  ]
+  ).freeze
 
-  it "has the expected number of shown licenses" do
+  it 'has the expected number of shown licenses' do
     expect(shown_licenses.count).to eql(15)
   end
 
   shown_licenses.each do |license|
-    context "the #{license["title"]} license" do
-      it "is whitelisted to be shown" do
-        expect(SHOWN_LICENSES).to include(license["id"])
+    context "the #{license['title']} license" do
+      it 'is whitelisted to be shown' do
+        expect(SHOWN_LICENSES).to include(license['id'])
       end
     end
   end

--- a/spec/license_spec.rb
+++ b/spec/license_spec.rb
@@ -1,30 +1,27 @@
 require 'spec_helper'
 
-describe "licenses" do
-
-  it "matches the number of files in the _licenses folder" do
+describe 'licenses' do
+  it 'matches the number of files in the _licenses folder' do
     expect(licenses.count).to eql(Dir["#{licenses_path}/*.html"].count)
   end
 
   licenses.each do |license|
+    context "The #{license['title']} license" do
+      let(:id) { license['id'] }
 
-    context "The #{license["title"]} license" do
-
-      let(:id) { license["id"]  }
-
-      it "has an SPDX ID" do
+      it 'has an SPDX ID' do
         expect(spdx_ids).to include(id)
       end
 
-      it "uses its SPDX name" do
+      it 'uses its SPDX name' do
         spdx = find_spdx(id)
         expect(spdx).to_not be_nil
-        expect(spdx[1]["name"].gsub(/ only$/,"")).to eql(license["title"])
+        expect(spdx[1]['name'].gsub(/ only$/, '')).to eql(license['title'])
       end
 
-      context "industry approval" do
-        it "should be approved by OSI or FSF or OD" do
-          expect(approved_licenses).to include(id), "See https://git.io/vzCTV."
+      context 'industry approval' do
+        it 'should be approved by OSI or FSF or OD' do
+          expect(approved_licenses).to include(id), 'See https://git.io/vzCTV.'
         end
       end
     end


### PR DESCRIPTION
As they say at GitHub:

> Pedantic Robots > Pedantic Humans

Inspired by trying to be helpful over in https://github.com/github/choosealicense.com/pull/345, this pull requests adds Rubocop, to enforce Ruby style.

It's relatively straightforward because it's mostly just tests and ad-hoc scripts, but I find those are the most likely to be overlooked, and with multiple maintainers, it'd be best to clean things up.

As an added benefit, this fixes some not-really-global global variables that were used for caching, meaning tests are now _significantly_ faster.

I went with the default tests, and disabled a few that'd be too onerous to enforce. There should be no change to the resulting site or test logic. It should all be stylistic.
