### PR TITLE
Make BSD nicknames self-descriptive and conform to OSI site use

### DIFF
--- a/_licenses/bsd-2-clause.txt
+++ b/_licenses/bsd-2-clause.txt
@@ -1,6 +1,6 @@
 ---
 title: BSD 2-clause "Simplified" License
-nickname: Simplified BSD
+nickname: BSD 2-Clause
 redirect_from: /licenses/bsd/
 family: BSD
 variant: true

--- a/_licenses/bsd-3-clause-clear.txt
+++ b/_licenses/bsd-3-clause-clear.txt
@@ -1,7 +1,5 @@
 ---
 title: BSD 3-clause Clear License
-nickname: Clear BSD
-
 family: BSD
 variant: true
 

--- a/_licenses/bsd-3-clause.txt
+++ b/_licenses/bsd-3-clause.txt
@@ -1,6 +1,6 @@
 ---
 title: BSD 3-clause "New" or "Revised" License
-nickname: New BSD
+nickname: BSD 3-Clause 
 family: BSD
 variant: true
 source: http://opensource.org/licenses/BSD-3-Clause


### PR DESCRIPTION
- don't require knowledge of 'new' or 'simplified' relative to _what_
- rm nickname for BSD 3-clause Clear License which is hidden and
  deserves to remain little known
