### PR TITLE
Express non patent grant

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ The license properties (rules) are stored as a bulleted list within the licenses
 * `no-liability` - Software is provided without warranty and the software author/license owner cannot be held liable for damages.
 * `modifications` - This software may not be modified.
 * `distribution` - You may not distribute this software.
+* `patent-use` -  This license explicitly states that it does NOT grant you any rights in the patents of contributors.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -98,8 +98,6 @@ The license properties (rules) are stored as a bulleted list within the licenses
 
 * `trademark-use` - While this may be implicitly true of all licenses, this license explicitly states that it does NOT grant you any rights in the trademarks or other marks of contributors.
 * `no-liability` - Software is provided without warranty and the software author/license owner cannot be held liable for damages.
-* `modifications` - This software may not be modified.
-* `distribution` - You may not distribute this software.
 * `patent-use` -  This license explicitly states that it does NOT grant you any rights in the patents of contributors.
 
 ## License

--- a/_data/rules.yml
+++ b/_data/rules.yml
@@ -42,3 +42,6 @@ forbidden:
 - description: Software is provided without warranty and the software author/license owner cannot be held liable for damages.
   label: Hold Liable
   tag: no-liability
+- description: This license explicitly states that it does NOT grant you any rights in the patents of contributors.
+  label: Patent Use
+  tag: patent-use

--- a/_data/rules.yml
+++ b/_data/rules.yml
@@ -37,7 +37,7 @@ permitted:
 
 forbidden:
 - description: While this may be implicitly true of all licenses, this license explicitly states that it does NOT grant you any rights in the trademarks or other marks of contributors.
-  label: Use Trademark
+  label: Trademark Use
   tag: trademark-use
 - description: Software is provided without warranty and the software author/license owner cannot be held liable for damages.
   label: Hold Liable

--- a/_licenses/bsd-3-clause-clear.txt
+++ b/_licenses/bsd-3-clause-clear.txt
@@ -20,6 +20,7 @@ permitted:
 
 forbidden:
   - no-liability
+  - patent-use
 
 ---
 

--- a/_licenses/cc-by-4.0.txt
+++ b/_licenses/cc-by-4.0.txt
@@ -20,6 +20,7 @@ permitted:
 forbidden:
   - no-liability
   - trademark-use
+  - patent-use
 ---
 
 Attribution 4.0 International

--- a/_licenses/cc-by-sa-4.0.txt
+++ b/_licenses/cc-by-sa-4.0.txt
@@ -21,6 +21,7 @@ permitted:
 forbidden:
   - no-liability
   - trademark-use
+  - patent-use
 ---
 
 Attribution-ShareAlike 4.0 International

--- a/_licenses/cc0-1.0.txt
+++ b/_licenses/cc0-1.0.txt
@@ -21,6 +21,7 @@ permitted:
 forbidden:
   - no-liability
   - trademark-use
+  - patent-use
 
 required: []
 


### PR DESCRIPTION
Add "forbidden" property for "patent-use", mirroring "trademark-use",
    for the sorry licenses that explicitly do not grant any patent
    permissions

sync README.md with _data/rules.yml, remove non-open forbiddens
    should have been removed as part of
    https://github.com/github/choosealicense.com/pull/345
    correct that oversight

Use Trademark -> Trademark Use to match otther Use Xs
