### PR TITLE
rename/order license properties better reflect how licenses work

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,9 @@ Licenses sit in the `/_licenses` folder. Each license has YAML front matter desc
 * `source` - The URL to the license source text
 * `description` - A human-readable description of the license
 * `how` - Instructions on how to implement the license
-* `required` - Bulleted list of required rules
-* `permitted` - Bulleted list of permitted rules
-* `forbidden` - Bulleted list of forbidden rules
+* `permissions` - Bulleted list of permission rules
+* `conditions` - Bulleted list of condition rules
+* `limitations` - Bulleted list of limitation rules
 
 #### Optional fields
 
@@ -77,7 +77,15 @@ The license properties (rules) are stored as a bulleted list within the licenses
 
 ### Rules
 
-#### Required
+#### Permissions
+
+* `commercial-use` - This software and derivatives may be used for commercial purposes.
+* `modifications` - This software may be modified.
+* `distribution` - You may distribute this software.
+* `private-use` - You may use and modify the software without distributing it.
+* `patent-use` - This license provides an express grant of patent rights from the contributor to the recipient.
+
+#### Conditions
 
 * `include-copyright` - Include a copy of the license and copyright notice with the code.
 * `document-changes` - Indicate significant changes made to the code.
@@ -86,15 +94,7 @@ The license properties (rules) are stored as a bulleted list within the licenses
 * `rename` - You must change the name of the software if you modify it.
 * `same-license` - Modifications must be released under the same license when distributing the software. In some cases a similar or related license may be used.
 
-#### Permitted
-
-* `commercial-use` - This software and derivatives may be used for commercial purposes.
-* `modifications` - This software may be modified.
-* `distribution` - You may distribute this software.
-* `private-use` - You may use and modify the software without distributing it.
-* `patent-use` - This license provides an express grant of patent rights from the contributor to the recipient.
-
-#### Forbidden
+#### Limitations
 
 * `trademark-use` - While this may be implicitly true of all licenses, this license explicitly states that it does NOT grant you any rights in the trademarks or other marks of contributors.
 * `no-liability` - Software is provided without warranty and the software author/license owner cannot be held liable for damages.

--- a/_data/meta.yml
+++ b/_data/meta.yml
@@ -17,16 +17,16 @@
   description: Instructions on how to implement the license
   required: true
 
-- name: required
+- name: conditions
   description: Bulleted list of required rules
   required: true
 
-- name: permitted
+- name: permissions
   description: Bulleted list of permitted rules
   required: true
 
-- name: forbidden
-  description: Bulleted list of forbidden rules
+- name: limitations
+  description: Bulleted list of limited rules
   required: true
 
 # Optional fields

--- a/_data/rules.yml
+++ b/_data/rules.yml
@@ -1,4 +1,4 @@
-required:
+conditions:
 - description: Include a copy of the license and copyright notice with the code.
   label: License and copyright notice
   tag: include-copyright
@@ -18,7 +18,7 @@ required:
   label: Same License
   tag: same-license
 
-permitted:
+permissions:
 - description: This software and derivatives may be used for commercial purposes.
   label: Commercial Use
   tag: commercial-use
@@ -35,7 +35,7 @@ permitted:
   label: Patent Use
   tag: patent-use
 
-forbidden:
+limitations:
 - description: While this may be implicitly true of all licenses, this license explicitly states that it does NOT grant you any rights in the trademarks or other marks of contributors.
   label: Trademark Use
   tag: trademark-use

--- a/_includes/css/responsive.css
+++ b/_includes/css/responsive.css
@@ -160,13 +160,13 @@
     top: 1px;
     position: relative;
   }
-  .license-rules:not(.license-rules-sidebar) .license-required span {
+  .license-rules:not(.license-rules-sidebar) .license-conditions span {
     background-position: -34px 0;
   }
-  .license-rules:not(.license-rules-sidebar) .license-permitted span {
+  .license-rules:not(.license-rules-sidebar) .license-permissions span {
     background-position: -24px 0px;
   }
-  .license-rules:not(.license-rules-sidebar) .license-forbidden span {
+  .license-rules:not(.license-rules-sidebar) .license-limitations span {
     background-position: -14px 0;
   }
 }

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -5,11 +5,11 @@
         </nav>
         <p>
           If you have questions or issues, it is always best to consult a legal professional.<br>
-          The content of this site is licensed under the <a href="http://creativecommons.org/licenses/by/3.0/">
+          The content of this site is licensed under the <a href="https://creativecommons.org/licenses/by/3.0/">
           Creative Commons Attribution 3.0 Unported License</a>.
         </p>
         <div class="with-love">
-          Demystified with &lt;3 by <a href="http://github.com">GitHub, Inc.</a>
+          Demystified with &lt;3 by <a href="https://github.com">GitHub, Inc.</a>
         </div>
       </footer>
 

--- a/_includes/license-overview.html
+++ b/_includes/license-overview.html
@@ -35,7 +35,7 @@
       </ul>
       {% endif %}
     </div>
-    
+
     {% if license.family %}
       {% assign variations = site.licenses | where:"hidden",false | where:"family",license.family %}
     {% else %}
@@ -46,7 +46,7 @@
     <div {% if variation.id %}id="{{ variation.id | remove: '/licenses/' | slugify }}" {% endif %}class="variation-tab {% if variation.id %}variation-{{ variation.id | remove: '/licenses/' | slugify }}{% endif %} js-variation-tab{% if license.id == variation.id %} active{% endif %}">
       <table class="license-rules">
         <tr>
-        {% assign types = "required|permitted|forbidden" | split: "|" %}
+        {% assign types = "permissions|conditions|limitations" | split: "|" %}
         {% for type in types %}
           <th class="label">{{ type | capitalize }}</th>
         {% endfor %}

--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -23,7 +23,7 @@
 
   <div class="license-rules license-rules-sidebar">
 
-  {% assign types = "required|permitted|forbidden" | split: "|" %}
+  {% assign types = "permissions|conditions|limitations" | split: "|" %}
   {% for type in types %}
     <h3>{{ type | capitalize }}</h3>
     <ul class="license-{{ type }}">

--- a/_licenses/afl-3.0.txt
+++ b/_licenses/afl-3.0.txt
@@ -6,17 +6,17 @@ description: The Academic Free License is a variant of the Open Source License t
 
 how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file. Files licensed under OSL 3.0 must also include the notice "Licensed under the Academic Free License version 3.0" adjacent to the copyright notice.
 
-required:
+conditions:
   - include-copyright
 
-permitted:
+permissions:
   - commercial-use
   - modifications
   - distribution
   - private-use
   - patent-use
 
-forbidden:
+limitations:
   - trademark-use
   - no-liability
 

--- a/_licenses/agpl-3.0.txt
+++ b/_licenses/agpl-3.0.txt
@@ -12,21 +12,21 @@ how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of 
 
 note: The Free Software Foundation recommends taking the additional step of adding a boilerplate notice to the top of each file. The boilerplate can be found at the end of the license.
 
-required:
+conditions:
   - include-copyright
   - document-changes
   - disclose-source
   - network-use-disclose
   - same-license
 
-permitted:
+permissions:
   - commercial-use
   - modifications
   - distribution
   - patent-use
   - private-use
 
-forbidden:
+limitations:
   - no-liability
 
 hidden: false

--- a/_licenses/apache-2.0.txt
+++ b/_licenses/apache-2.0.txt
@@ -10,18 +10,18 @@ how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of 
 
 note: The Apache Foundation recommends taking the additional step of adding a boilerplate notice to the header of each source file. You can find the notice at the very end of the license in the appendix.
 
-required:
+conditions:
   - include-copyright
   - document-changes
 
-permitted:
+permissions:
   - commercial-use
   - modifications
   - distribution
   - patent-use
   - private-use
 
-forbidden:
+limitations:
   - trademark-use
   - no-liability
 

--- a/_licenses/artistic-2.0.txt
+++ b/_licenses/artistic-2.0.txt
@@ -7,18 +7,18 @@ description: Heavily favored by the Perl community, the Artistic license require
 
 how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file. Replace [year] with the current year and [fullname] with the name (or names) of the copyright holders.
 
-required:
+conditions:
   - include-copyright
   - document-changes
 
-permitted:
+permissions:
   - commercial-use
   - modifications
   - distribution
   - patent-use
   - private-use
 
-forbidden:
+limitations:
   - no-liability
   - trademark-use
 

--- a/_licenses/bsd-2-clause.txt
+++ b/_licenses/bsd-2-clause.txt
@@ -10,16 +10,16 @@ description: A permissive license that comes in two variants, the <a href="/lice
 
 how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file. Replace [year] with the current year and [fullname] with the name (or names) of the copyright holders.
 
-required:
+conditions:
   - include-copyright
 
-permitted:
+permissions:
   - commercial-use
   - modifications
   - distribution
   - private-use
 
-forbidden:
+limitations:
   - no-liability
 
 hidden: false

--- a/_licenses/bsd-3-clause-clear.txt
+++ b/_licenses/bsd-3-clause-clear.txt
@@ -9,16 +9,16 @@ how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of 
 
 source: https://spdx.org/licenses/BSD-3-Clause-Clear.html
 
-required:
+conditions:
   - include-copyright
 
-permitted:
+permissions:
   - commercial-use
   - modifications
   - distribution
   - private-use
 
-forbidden:
+limitations:
   - no-liability
   - patent-use
 

--- a/_licenses/bsd-3-clause.txt
+++ b/_licenses/bsd-3-clause.txt
@@ -9,16 +9,16 @@ description: A permissive license that comes in two variants, the <a href="/lice
 
 how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file. Replace [year] with the current year and [fullname] with the name (or names) of the copyright holders. Replace [project] with the project organization, if any, that sponsors this work.
 
-required:
+conditions:
   - include-copyright
 
-permitted:
+permissions:
   - commercial-use
   - modifications
   - distribution
   - private-use
 
-forbidden:
+limitations:
   - no-liability
 
 hidden: false

--- a/_licenses/cc-by-4.0.txt
+++ b/_licenses/cc-by-4.0.txt
@@ -7,17 +7,17 @@ description: Permits almost any use subject to providing credit and license noti
 
 how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file. It is also acceptable to soley supply a link to a copy of the license, usually to the <a href='https://creativecommons.org/licenses/by/4.0/'>canonical URL for the license</a>.
 
-required:
+conditions:
   - include-copyright
   - document-changes
 
-permitted:
+permissions:
   - commercial-use
   - modifications
   - distribution
   - private-use
 
-forbidden:
+limitations:
   - no-liability
   - trademark-use
   - patent-use

--- a/_licenses/cc-by-sa-4.0.txt
+++ b/_licenses/cc-by-sa-4.0.txt
@@ -7,18 +7,18 @@ description: Similar to <a href='/licenses/cc-by-4.0/'>CC-BY-4.0</a> but require
 
 how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file. It is also acceptable to soley supply a link to a copy of the license, usually to the <a href='https://creativecommons.org/licenses/by-sa/4.0/'>canonical URL for the license</a>.
 
-required:
+conditions:
   - include-copyright
   - document-changes
   - same-license
 
-permitted:
+permissions:
   - commercial-use
   - modifications
   - distribution
   - private-use
 
-forbidden:
+limitations:
   - no-liability
   - trademark-use
   - patent-use

--- a/_licenses/cc0-1.0.txt
+++ b/_licenses/cc0-1.0.txt
@@ -10,20 +10,20 @@ description: The <a href="http://creativecommons.org/publicdomain/zero/1.0/">Cre
 
 how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the CC0 into the file.
 
-required:
+conditions:
 
-permitted:
+permissions:
   - commercial-use
   - modifications
   - distribution
   - private-use
 
-forbidden:
+limitations:
   - no-liability
   - trademark-use
   - patent-use
 
-required: []
+conditions: []
 
 hidden: false
 ---

--- a/_licenses/epl-1.0.txt
+++ b/_licenses/epl-1.0.txt
@@ -13,7 +13,7 @@ using:
   - Clojure: "http://clojure.org/"
   - JUnit: "http://junit.org/"
   - Ruby: "https://github.com/jruby/jruby"
-  - Mondrian: "http://en.wikipedia.org/wiki/Mondrian_OLAP_server"
+  - Mondrian: "https://en.wikipedia.org/wiki/Mondrian_OLAP_server"
 
 conditions:
   - disclose-source

--- a/_licenses/epl-1.0.txt
+++ b/_licenses/epl-1.0.txt
@@ -15,19 +15,19 @@ using:
   - Ruby: "https://github.com/jruby/jruby"
   - Mondrian: "http://en.wikipedia.org/wiki/Mondrian_OLAP_server"
 
-required:
+conditions:
   - disclose-source
   - include-copyright
   - same-license
 
-permitted:
+permissions:
   - commercial-use
   - distribution
   - modifications
   - patent-use
   - private-use
 
-forbidden:
+limitations:
   - no-liability
 
 hidden: false

--- a/_licenses/eupl-1.1.txt
+++ b/_licenses/eupl-1.1.txt
@@ -12,21 +12,21 @@ how: Create a text file (typically named COPYING or LICENCE.txt) in the root of 
 
 note: The European Commission recommends taking the additional step of adding a boilerplate notice to the top of each file. The boilerplate can be found at https://joinup.ec.europa.eu/sites/default/files/ckeditor_files/files/EUPL%201_1%20Guidelines%20EN%20Joinup.pdf
 
-required:
+conditions:
   - include-copyright
   - disclose-source
   - document-changes
   - network-use-disclose
   - same-license
 
-permitted:
+permissions:
   - commercial-use
   - modifications
   - distribution
   - patent-use
   - private-use
 
-forbidden:
+limitations:
   - no-liability
   - trademark-use
 

--- a/_licenses/gpl-2.0.txt
+++ b/_licenses/gpl-2.0.txt
@@ -12,20 +12,20 @@ how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of 
 
 note: The Free Software Foundation recommends taking the additional step of adding a boilerplate notice to the top of each file. The boilerplate can be found at the end of the license.
 
-required:
+conditions:
   - include-copyright
   - document-changes
   - disclose-source
   - same-license
 
-permitted:
+permissions:
   - commercial-use
   - modifications
   - distribution
   - patent-use
   - private-use
 
-forbidden:
+limitations:
   - no-liability
 
 hidden: false

--- a/_licenses/gpl-3.0.txt
+++ b/_licenses/gpl-3.0.txt
@@ -12,20 +12,20 @@ how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of 
 
 note: The Free Software Foundation recommends taking the additional step of adding a boilerplate notice to the top of each file. The boilerplate can be found at the end of the license.
 
-required:
+conditions:
   - include-copyright
   - document-changes
   - disclose-source
   - same-license
 
-permitted:
+permissions:
   - commercial-use
   - modifications
   - distribution
   - patent-use
   - private-use
 
-forbidden:
+limitations:
   - no-liability
 
 hidden: false

--- a/_licenses/isc.txt
+++ b/_licenses/isc.txt
@@ -7,16 +7,16 @@ description: A permissive license lets people do anything with your code with pr
 
 how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file. Replace [year] with the current year and [fullname] with the name (or names) of the copyright holders.
 
-required:
+conditions:
   - include-copyright
 
-permitted:
+permissions:
   - commercial-use
   - distribution
   - modifications
   - private-use
 
-forbidden:
+limitations:
   - no-liability
 
 hidden: false

--- a/_licenses/lgpl-2.1.txt
+++ b/_licenses/lgpl-2.1.txt
@@ -12,19 +12,19 @@ how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of 
 
 note: The Free Software Foundation recommends taking the additional step of adding a boilerplate notice to the top of each file. The boilerplate can be found at the end of the license.
 
-required:
+conditions:
   - include-copyright
   - disclose-source
   - same-license
 
-permitted:
+permissions:
   - commercial-use
   - modifications
   - distribution
   - patent-use
   - private-use
 
-forbidden:
+limitations:
   - no-liability
 
 hidden: false

--- a/_licenses/lgpl-3.0.txt
+++ b/_licenses/lgpl-3.0.txt
@@ -11,20 +11,20 @@ how: This license is an additional set of permissions to the <a href="/licenses/
 
 note: The Free Software Foundation recommends taking the additional step of adding a boilerplate notice to the top of each file. The boilerplate can be found at the end of the <a href="/licenses/gpl-3.0">GNU GPLv3 license</a>. Insert the word “Lesser” before “General” in all three places in the boilerplate notice to make sure that you refer to the GNU LGPLv3 and not the GNU GPLv3.
 
-required:
+conditions:
   - include-copyright
   - disclose-source
   - same-license
 
 
-permitted:
+permissions:
   - commercial-use
   - modifications
   - distribution
   - patent-use
   - private-use
 
-forbidden:
+limitations:
   - no-liability
 
 hidden: false

--- a/_licenses/lppl-1.3c.txt
+++ b/_licenses/lppl-1.3c.txt
@@ -11,18 +11,18 @@ how: To use this license, place in each of the components of your work both an e
 
 note: An example boilerplate and more information about how to use the license can be found at the end of the license.
 
-required:
+conditions:
   - include-copyright
   - document-changes 
   - disclose-source
   
-permitted:
+permissions:
   - commercial-use
   - modifications
   - distribution
   - private-use
 
-forbidden:
+limitations:
   - no-liability
   
 ---

--- a/_licenses/mit.txt
+++ b/_licenses/mit.txt
@@ -7,16 +7,16 @@ description: A permissive license that is short and to the point. It lets people
 
 how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file. Replace [year] with the current year and [fullname] with the name (or names) of the copyright holders.
 
-required:
+conditions:
   - include-copyright
 
-permitted:
+permissions:
   - commercial-use
   - modifications
   - distribution
   - private-use
 
-forbidden:
+limitations:
   - no-liability
 
 hidden: false

--- a/_licenses/mpl-2.0.txt
+++ b/_licenses/mpl-2.0.txt
@@ -7,19 +7,19 @@ description: The Mozilla Public License (MPL 2.0) is maintained by the Mozilla f
 
 how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file.
 
-required:
+conditions:
   - disclose-source
   - include-copyright
   - same-license
 
-permitted:
+permissions:
   - commercial-use
   - modifications
   - distribution
   - patent-use
   - private-use
 
-forbidden:
+limitations:
   - no-liability
   - trademark-use
 

--- a/_licenses/ms-pl.txt
+++ b/_licenses/ms-pl.txt
@@ -7,17 +7,17 @@ description: "Microsoft Open Source"
 
 how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file.
 
-required:
+conditions:
   - include-copyright
 
-permitted:
+permissions:
   - commercial-use
   - modifications
   - distribution
   - patent-use
   - private-use
 
-forbidden:
+limitations:
   - no-liability
   - trademark-use
 ---

--- a/_licenses/ms-rl.txt
+++ b/_licenses/ms-rl.txt
@@ -7,18 +7,18 @@ description: "Microsoft Open Source"
 
 how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file.
 
-required:
+conditions:
   - include-copyright
   - same-license
 
-permitted:
+permissions:
   - commercial-use
   - modifications
   - distribution
   - patent-use
   - private-use
 
-forbidden:
+limitations:
   - no-liability
   - trademark-use
 ---

--- a/_licenses/ofl-1.1.txt
+++ b/_licenses/ofl-1.1.txt
@@ -9,17 +9,17 @@ how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of 
 
 note: This license doesn't require source provision, but recommends it. All files derived from OFL files must remain licensed under the OFL.
 
-required:
+conditions:
   - include-copyright
   - same-license
 
-permitted:
+permissions:
   - private-use
   - commercial-use
   - modifications
   - distribution
 
-forbidden:
+limitations:
   - no-liability
 
 ---

--- a/_licenses/osl-3.0.txt
+++ b/_licenses/osl-3.0.txt
@@ -15,19 +15,19 @@ using:
   - Mulgara: "http://mulgara.org"
   - AbanteCart: "http://www.abantecart.com/"
 
-required:
+conditions:
   - include-copyright
   - disclose-source
   - same-license
 
-permitted:
+permissions:
   - commercial-use
   - distribution
   - modifications
   - patent-use
   - private-use
 
-forbidden:
+limitations:
   - trademark-use
   - no-liability
 

--- a/_licenses/unlicense.txt
+++ b/_licenses/unlicense.txt
@@ -7,18 +7,18 @@ description: Because copyright is automatic in most countries, <a href="http://u
 
 how: Create a text file (typically named UNLICENSE or UNLICENSE.txt) in the root of your source code and copy the text of the license disclaimer into the file.
 
-required:
+conditions:
 
-permitted:
+permissions:
   - private-use
   - commercial-use
   - modifications
   - distribution
 
-forbidden:
+limitations:
   - no-liability
 
-required: []
+conditions: []
 
 hidden: false
 ---

--- a/_licenses/wtfpl.txt
+++ b/_licenses/wtfpl.txt
@@ -6,15 +6,15 @@ description: The easiest licence out there. It gives the user permissions to do 
 
 how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file.
 
-required: []
+conditions: []
 
-permitted:
+permissions:
   - commercial-use
   - modifications
   - distribution
   - private-use
 
-forbidden: []
+limitations: []
 
 ---
 

--- a/about.md
+++ b/about.md
@@ -16,8 +16,8 @@ This site is not a comprehensive directory of open source licenses. We think the
 
 {: .bullets}
 
-* [Open Source Initiative](http://opensource.org/licenses/) - comprehensive list of open source licenses
-* [Comparison of free and open-source software licenses](http://en.wikipedia.org/wiki/Comparison_of_free_and_open-source_software_licenses) on Wikipedia
+* [Open Source Initiative](https://opensource.org/licenses/) - comprehensive list of open source licenses
+* [Comparison of free and open-source software licenses](https://en.wikipedia.org/wiki/Comparison_of_free_and_open-source_software_licenses) on Wikipedia
 * [License differentiator](http://www.oss-watch.ac.uk/apps/licdiff/) from [OSS Watch](http://www.oss-watch.ac.uk/)
 * [TLDRLegal](https://tldrlegal.com/){: data-proofer-ignore="true" }
 

--- a/assets/css/application.scss
+++ b/assets/css/application.scss
@@ -245,9 +245,9 @@ strong {
 }
 
 .sidebar .source span   { background-position: 0 0;     width: 16px; height: 12px; }
-.license-forbidden span { background-position: -16px 0; width: 12px; height: 12px; }
-.license-permitted span { background-position: -28px 0; width: 12px; height: 12px; }
-.license-required span  { background-position: -40px 0; width: 12px; height: 12px; }
+.license-limitations span { background-position: -16px 0; width: 12px; height: 12px; }
+.license-permissions span { background-position: -28px 0; width: 12px; height: 12px; }
+.license-conditions span  { background-position: -40px 0; width: 12px; height: 12px; }
 
 .license-rules-sidebar li {
   float: none;
@@ -420,25 +420,25 @@ strong {
 
 /* Qtip styles */
 
-.qtip-required,
-.qtip-permitted,
-.qtip-forbidden {
+.qtip-conditions,
+.qtip-permissions,
+.qtip-limitations {
   font-size: 12px;
   line-height: 1.3;
 }
 
-.qtip-required {
+.qtip-conditions {
   background-color: #d0ebf6;
   border-color: #149ad4;
   color: #0d648a;
 }
 
-.qtip-required .qtip-titlebar {
+.qtip-conditions .qtip-titlebar {
   background-color: #149ad4;
   color: #fff;
 }
 
-.qtip-permitted {
+.qtip-permissions {
   background-color: #d8f4d7;
   border-color: #3dc637;
   color: #298625;
@@ -449,13 +449,13 @@ strong {
   color: #fff;
 }
 
-.qtip-forbidden {
+.qtip-limitations {
   background-color: #f4d9d8;
   border-color: #c6403d;
   color: #812a28;
 }
 
-.qtip-forbidden .qtip-titlebar {
+.qtip-limitations .qtip-titlebar {
   background-color: #c6403d;
   color: #fff;
 }

--- a/spec/license_spec.rb
+++ b/spec/license_spec.rb
@@ -26,7 +26,7 @@ describe 'licenses' do
       end
 
       context 'minimum permissions' do
-        let(:permissions) { license['permitted'] }
+        let(:permissions) { license['permissions'] }
         it 'should allow commercial use' do
           expect(permissions).to include('commercial-use')
         end


### PR DESCRIPTION
and are structured

grant (permissions)
conditioned on (conditions)
with limitations

Permissions coming first combats mistaken but apparently widespread
impression that licenses impose conditions, even such that without
a license, there would be no conditions/work would be in the public
domain.

Requirements->Conditions emphasizes that they are pertinent if one
wants to take advantage of permissions.

Forbiddens->Limitations is more accurate: in most cases licenses
don't give permission to hold licensors liable, in some cases to
use licensors' trademarks or patents, but a licensee does not lose
the permissions granted by the license if the licensee holds licensor
liable, etc. Also emphasizes that there are limitatations on the
license grant, not that the license imposes prohibitions.

The most concise place to see both the rename and reorder is in
_includes/license-overview.html

I did not reorder the appearance of the groups of properties in
license source files (.txt files in _licenses) as those orderings
are not used to render anything on the webiste. Might do so later.
