### PR TITLE
rm gplv2 from homepage

### DIFF
--- a/_includes/license-overview.html
+++ b/_includes/license-overview.html
@@ -35,7 +35,7 @@
       </ul>
       {% endif %}
     </div>
-    
+
     {% if license.family %}
       {% assign variations = site.licenses | where:"hidden",false | where:"family",license.family %}
     {% else %}

--- a/_includes/using-sentence.html
+++ b/_includes/using-sentence.html
@@ -1,0 +1,17 @@
+{% assign id = "/licenses/" | append: include.license-id %}
+{% assign licenses = site.licenses | where:"id", id %}
+{% for license in licenses %}
+  {% assign using = license.using %}
+  {% if using.size > 0 %}
+    {% for used in using limit: 3 %}
+      {% assign last = forloop.last %}
+      {% if last %}
+        and
+      {% endif %}
+      {% for hash in used %}
+        <a href="{{ hash[1] }}">{{ hash[0] }}</a>{% if last == false %},{% endif %}
+      {% endfor %}
+    {% endfor %}
+    use the {% if license.nickname %}{{ license.nickname }}{% else %}{{ license.title }}{% endif %}.
+  {% endif %}
+{% endfor %}

--- a/_licenses/apache-2.0.txt
+++ b/_licenses/apache-2.0.txt
@@ -10,6 +10,11 @@ how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of 
 
 note: The Apache Foundation recommends taking the additional step of adding a boilerplate notice to the header of each source file. You can find the notice at the very end of the license in the appendix.
 
+using:
+  - Android: https://github.com/android/platform_system_core/blob/master/NOTICE
+  - Apache: https://svn.apache.org/viewvc/httpd/httpd/trunk/LICENSE?view=markup
+  - Swift: https://github.com/apple/swift/blob/master/LICENSE.txt
+
 required:
   - include-copyright
   - document-changes

--- a/_licenses/gpl-2.0.txt
+++ b/_licenses/gpl-2.0.txt
@@ -12,6 +12,10 @@ how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of 
 
 note: The Free Software Foundation recommends taking the additional step of adding a boilerplate notice to the top of each file. The boilerplate can be found at the end of the license.
 
+using:
+  - Linux: https://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/tree/COPYING
+  - WordPress: https://github.com/WordPress/WordPress/blob/master/license.txt
+
 required:
   - include-copyright
   - document-changes

--- a/_licenses/gpl-3.0.txt
+++ b/_licenses/gpl-3.0.txt
@@ -12,6 +12,11 @@ how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of 
 
 note: The Free Software Foundation recommends taking the additional step of adding a boilerplate notice to the top of each file. The boilerplate can be found at the end of the license.
 
+using:
+  - Bash: http://git.savannah.gnu.org/cgit/bash.git/tree/COPYING
+  - GIMP: https://git.gnome.org/browse/gimp/tree/COPYING
+  - Privacy Badger: https://github.com/EFForg/privacybadgerfirefox/blob/master/LICENSE
+  
 required:
   - include-copyright
   - document-changes

--- a/_licenses/mit.txt
+++ b/_licenses/mit.txt
@@ -1,7 +1,7 @@
 ---
 title: MIT License
 featured: true
-source: http://opensource.org/licenses/MIT
+source: https://opensource.org/licenses/MIT
 
 description: A permissive license that is short and to the point. It lets people do anything with your code with proper attribution and without warranty.
 

--- a/_licenses/mit.txt
+++ b/_licenses/mit.txt
@@ -7,6 +7,12 @@ description: A permissive license that is short and to the point. It lets people
 
 how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file. Replace [year] with the current year and [fullname] with the name (or names) of the copyright holders.
 
+using:
+  - jQuery: https://github.com/jquery/jquery/blob/master/LICENSE.txt
+  - .NET Core: https://github.com/dotnet/corefx/blob/master/LICENSE
+  - Rails: https://github.com/rails/rails/blob/master/activerecord/MIT-LICENSE
+
+
 required:
   - include-copyright
 

--- a/index.html
+++ b/index.html
@@ -42,10 +42,10 @@ permalink: /
       <h3>I care about sharing improvements.</h3>
     </a>
     <p>
-      The GNU GPL (<a href="licenses/gpl-2.0/">V2</a> or <a href="licenses/gpl-3.0/">V3</a>) is a copyleft license that requires anyone who distributes your code or a derivative work to make the source available under the same terms. V3 is similar to V2, but further restricts use in hardware that forbids software alterations.
+      The <a href="licenses/gpl-3.0/">GNU GPLv3</a> is a copyleft license that requires anyone who distributes your code or a derivative work to make the source available under the same terms, and also provides an express grant of patent rights from contributors to users.
     </p>
     <p>
-      <a href="https://github.com/WordPress/WordPress/blob/master/license.txt">WordPress</a>, <a href="https://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/tree/COPYING">Linux</a>, and <a href="http://git.savannah.gnu.org/cgit/bash.git/tree/COPYING">Bash</a> use the GNU GPL.
+      <a href="http://git.savannah.gnu.org/cgit/bash.git/tree/COPYING">Bash</a>, <a href="https://git.gnome.org/browse/gimp/tree/COPYING">GIMP</a>, and <a href="https://github.com/EFForg/privacybadgerfirefox/blob/master/LICENSE">Privacy Badger</a> use the GNU GPLv3.
     </p>
   </li>
 </ul>

--- a/index.html
+++ b/index.html
@@ -21,7 +21,7 @@ permalink: /
       The <a href="licenses/mit">MIT License</a> is a permissive license that is short and to the point. It lets people do anything they want with your code as long as they provide attribution back to you and don’t hold you liable.
     </p>
     <p>
-      <a href="https://github.com/jquery/jquery/blob/master/LICENSE.txt">jQuery</a>, <a href="https://github.com/rails/rails/blob/master/activerecord/MIT-LICENSE">Rails</a> and <a href="https://github.com/dotnet/corefx/blob/master/LICENSE">.NET Core</a> use the MIT&nbsp;License.
+      {% include using-sentence.html license-id="mit" %}
     </p>
   </li>
   <li class="patents">
@@ -33,7 +33,7 @@ permalink: /
       The <a href="licenses/apache-2.0/">Apache License 2.0</a> is a permissive license similar to the MIT License, but also provides an express grant of patent rights from contributors to users.
     </p>
     <p>
-      <a href="https://svn.apache.org/viewvc/httpd/httpd/trunk/LICENSE?view=markup">Apache</a>, <a href="https://github.com/apple/swift/blob/master/LICENSE.txt">Swift</a>, and <a href="https://github.com/android/platform_system_core/blob/master/NOTICE">Android</a> use the Apache&nbsp;License&nbsp;2.0.
+      {% include using-sentence.html license-id="apache-2.0" %}
     </p>
   </li>
   <li class="copyleft">
@@ -45,7 +45,7 @@ permalink: /
       The <a href="licenses/gpl-3.0/">GNU GPLv3</a> is a copyleft license that requires anyone who distributes your code or a derivative work to make the source available under the same terms, and also provides an express grant of patent rights from contributors to users.
     </p>
     <p>
-      <a href="http://git.savannah.gnu.org/cgit/bash.git/tree/COPYING">Bash</a>, <a href="https://git.gnome.org/browse/gimp/tree/COPYING">GIMP</a>, and <a href="https://github.com/EFForg/privacybadgerfirefox/blob/master/LICENSE">Privacy Badger</a> use the GNU GPLv3.
+      {% include using-sentence.html license-id="gpl-3.0" %}
     </p>
   </li>
 </ul>


### PR DESCRIPTION
- remove descrption of v2 v3 difference
- add to description v3 express patent grant
- update example projects to only include v3 ones
- move v2 projects to gplv2 license using property

partially addresses feedback in #335
