### PR TITLE
Add name of license to ISC license text

### DIFF
--- a/_licenses/isc.txt
+++ b/_licenses/isc.txt
@@ -22,6 +22,8 @@ limitations:
 hidden: false
 ---
 
+ISC License
+
 Copyright (c) [year], [fullname]
 
 Permission to use, copy, modify, and/or distribute this software for any


### PR DESCRIPTION
This makes it immediately clear which license this is without reading and comparing the whole text.
