### PR TITLE
upgrade to html-proofer 3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ group :development do
 end
 
 group :test do
-  gem 'html-proofer', '~> 2.6'
+  gem 'html-proofer', '~> 3.0'
   gem 'rake'
   gem 'rspec'
   gem 'nokogiri'

--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,4 @@
-require 'html/proofer'
+require 'html-proofer'
 require 'rspec/core/rake_task'
 
 desc 'Run specs'
@@ -10,9 +10,10 @@ end
 task :test do
   sh 'bundle exec jekyll build'
   Rake::Task['spec'].invoke
-  HTML::Proofer.new('./_site', check_html: true,
-                               validation: { ignore_script_embeds: true },
-                               href_swap: { %r{http://choosealicense.com} => '' }).run
+  HTMLProofer.check_directory('./_site',
+                              check_html: true,
+                              validation: { ignore_script_embeds: true },
+                              url_swap: { %r{http://choosealicense.com} => '' }).run
 end
 
 task :approved_licenses do


### PR DESCRIPTION
Want to eventually end annoying CI failures on status code 0 'something wrong' for external link checks, eg https://travis-ci.org/github/choosealicense.com/builds/112981705 ... first upgrade to current version of html-proofer so as to debug with that.
