### PR TITLE
Fixed bug with include when using.size == 1

### DIFF
--- a/_includes/using-sentence.html
+++ b/_includes/using-sentence.html
@@ -5,7 +5,7 @@
   {% if using.size > 0 %}
     {% for used in using limit: 3 %}
       {% assign last = forloop.last %}
-      {% if last %}
+      {% if last and using.size > 1 %}
         and
       {% endif %}
       {% for hash in used %}

--- a/_includes/using-sentence.html
+++ b/_includes/using-sentence.html
@@ -12,6 +12,6 @@
         <a href="{{ hash[1] }}">{{ hash[0] }}</a>{% if last == false %},{% endif %}
       {% endfor %}
     {% endfor %}
-    use the {% if license.nickname %}{{ license.nickname }}{% else %}{{ license.title }}{% endif %}.
+    use{% if using.size == 1 %}s{% endif %} the {% if license.nickname %}{{ license.nickname }}{% else %}{{ license.title }}{% endif %}.
   {% endif %}
 {% endfor %}


### PR DESCRIPTION
If using.size is 1, then the resulting html would be "and PROJECT use the ..." without anything being listed before the "and".
