### PR TITLE
rm 'rename' field; never used to describe any license

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,6 @@ The license properties (rules) are stored as a bulleted list within the licenses
 * `document-changes` - Indicate significant changes made to the code.
 * `disclose-source` - Source code must be made available when distributing the software.
 * `network-use-disclose` - Users who interact with the software via network are given the right to receive a copy of the corresponding source code.
-* `rename` - You must change the name of the software if you modify it.
 * `same-license` - Modifications must be released under the same license when distributing the software. In some cases a similar or related license may be used.
 
 #### Limitations

--- a/_data/rules.yml
+++ b/_data/rules.yml
@@ -11,9 +11,6 @@ conditions:
 - description: Users who interact with the software via network are given the right to receive a copy of the corresponding source code.
   label: Network Use is Distribution
   tag: network-use-disclose
-- description: You must change the name of the software if you modify it.
-  label: Rename
-  tag: rename
 - description: Modifications must be released under the same license when distributing the software. In some cases a similar or related license may be used.
   label: Same License
   tag: same-license


### PR DESCRIPTION
Searched with `git log -Srename`

Arguably _could_ be used to describe ofl-1.1 or artistic-2.0, but
renaming is an option for licensors to include in ofl-1.1 and one
of a few ways to comply with artistic-2.0. Doesn't seem straightforward
or common enough to catalog here.
