### PR TITLE
rm patent-use permission field from GPLv2 and LGPLv2.1 metadata

### DIFF
--- a/_licenses/gpl-2.0.txt
+++ b/_licenses/gpl-2.0.txt
@@ -24,7 +24,6 @@ permissions:
   - commercial-use
   - modifications
   - distribution
-  - patent-use
   - private-use
 
 limitations:

--- a/_licenses/lgpl-2.1.txt
+++ b/_licenses/lgpl-2.1.txt
@@ -19,7 +19,6 @@ permissions:
   - commercial-use
   - modifications
   - distribution
-  - patent-use
   - private-use
 
 limitations:


### PR DESCRIPTION
There's a strong argument they have implied patent licenses, but
this site doesn't annotate any other implied patent licenses, as
one would expect given the description of the patent-use field "This
license provides an express grant of patent rights from the contributor
to the recipient."
