### PR TITLE
when contributing existing projects and commmunities

### DIFF
--- a/existing.md
+++ b/existing.md
@@ -1,0 +1,19 @@
+---
+layout: default
+permalink: existing/
+title: Existing projects and communities
+---
+
+If you're contributing to or extending an existing project, it's almost always easiest to continue using that project's license. Look for a file called `LICENSE` or `COPYING`, or a notice in the project's `README` to find out what that license is. If you can'd finda license, [ask](/no-license/#for-users).
+
+Depending on how you're building on an existing project and what its license is, using the existing project's license for your own might not just be the easiest thing to do, but a condition on which your permission to build on the existing project rests: see the "same license" condition of [some licenses](/licenses/).
+
+Some communities have strong preferences for particular licenses. If you want to participate in one of these, it will be easier to use the preferred license even if you're starting a brand new project with no exisiting dependencies. A few examples:
+
+{: .bullets}
+
+* [Apache](https://www.apache.org/licenses/) requires [Apache License 2.0](/licenses/apache-2.0/)
+* [GNU](https://www.gnu.org/licenses/license-recommendations.html) recommends [GNU GPLv3](/licenses/gpl-3.0/) for most programs
+* [OpenBSD](http://www.openbsd.org/policy.html) prefers [ISC](/licenses/isc/)
+
+Communities come in all shapes and sizes. The examples above are *very* well established. If the community you see your project as a part of doesn't have set-in-stone licensing traditions, or you don't see your project as part of any particular community, that's just fine: [make your own choice of an open source license](/).

--- a/existing.md
+++ b/existing.md
@@ -4,7 +4,7 @@ permalink: existing/
 title: Existing projects and communities
 ---
 
-If you're contributing to or extending an existing project, it's almost always easiest to continue using that project's license. Look for a file called `LICENSE` or `COPYING`, or a notice in the project's `README` to find out what that license is. If you can'd finda license, [ask](/no-license/#for-users).
+If you're contributing to or extending an existing project, it's almost always easiest to continue using that project's license. Look for a file called `LICENSE` or `COPYING`, or a notice in the project's `README` to find out what that license is. If you can't find a license, [ask](/no-license/#for-users).
 
 Depending on how you're building on an existing project and what its license is, using the existing project's license for your own might not just be the easiest thing to do, but a condition on which your permission to build on the existing project rests: see the "same license" condition of [some licenses](/licenses/).
 

--- a/existing.md
+++ b/existing.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-permalink: existing/
+permalink: /existing/
 title: Existing projects and communities
 ---
 


### PR DESCRIPTION
page covering licensing for this situation
- not linked anywhere yet
- partially addresses #239
- tangentially addresses #242, could be extended to address including
  code from other projects more explicitly
- with some additional work (feedback wanted) could be useful to link
  as another "situation" from the home page
