### PR TITLE
rm symlinks, maybe fix #383 (Windows build)

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -41,7 +41,6 @@ gems:
   - jekyll-coffeescript
 
 sass:
-    sass_dir: assets/vendor
     style: :compressed
 
 twitter:

--- a/_config.yml
+++ b/_config.yml
@@ -41,7 +41,7 @@ gems:
   - jekyll-coffeescript
 
 sass:
-    sass_dir: _sass
+    sass_dir: assets/vendor
     style: :compressed
 
 twitter:

--- a/_sass/jquery.qtip.scss
+++ b/_sass/jquery.qtip.scss
@@ -1,1 +1,0 @@
-../assets/vendor/qtip2/jquery.qtip.css

--- a/_sass/normalize.scss
+++ b/_sass/normalize.scss
@@ -1,1 +1,0 @@
-../assets/vendor/normalize-css/normalize.css

--- a/assets/css/application.scss
+++ b/assets/css/application.scss
@@ -2,7 +2,7 @@
 ---
 
 @import "/assets/vendor/normalize-css/normalize.css";
-@import "/assets/vendor/qtip2/jquery.qtip.css";
+@import "/assets/vendor/qtip2/jquery.qtip.min.css";
 
 body {
   background: #fafafa;

--- a/assets/css/application.scss
+++ b/assets/css/application.scss
@@ -1,8 +1,8 @@
 ---
 ---
 
-@import "normalize-css/normalize.css";
-@import "qtip2/jquery.qtip.css";
+@import "/assets/vendor/normalize-css/normalize.css";
+@import "/assets/vendor/qtip2/jquery.qtip.css";
 
 body {
   background: #fafafa;

--- a/assets/css/application.scss
+++ b/assets/css/application.scss
@@ -1,8 +1,8 @@
 ---
 ---
 
-@import "normalize";
-@import "jquery.qtip";
+@import "normalize-css/normalize.css";
+@import "qtip2/jquery.qtip.css";
 
 body {
   background: #fafafa;


### PR DESCRIPTION
Not certain this is right thing to do, but
https://jekyllrb.com/docs/assets/ says "Note that the sass_dir
becomes the load path for Sass imports, nothing more" so setting
it to `assets/vendor` and changing imports accordingly ought and
seems to work without disturbing other files under `assets/vendor`,
even though the docs continue "This folder should only contain
imports."

Motivated by #383
