### PR TITLE
Rework descriptions of 7 listed on /licenses

### DIFF
--- a/_licenses/agpl-3.0.txt
+++ b/_licenses/agpl-3.0.txt
@@ -4,7 +4,7 @@ nickname: GNU AGPLv3
 redirect_from: /licenses/agpl/
 source: http://www.gnu.org/licenses/agpl-3.0.txt
 
-description: The GNU GPL family of licenses is the most widely used free software license and has a strong copyleft requirement. When distributing derived works, the source code of the work must be made available under the same license. GNU AGPLv3 is distinguished from GNU GPLv3 in that hosted services using the code are considered distribution and trigger the copyleft requirements.
+description: The license with the strongest conditions for preserving openness. Complete source code of licensed works and modifications, which include larger works using a licensed work, must be made available under the same license when distributed. Copyright and license notices must be preserved. Contributors provide an express grant of patent rights to users. Additionally, when a modified version is used to provide a service over a network, the complete source code of the modified version must be made available to users of the service.
 
 how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file.
 

--- a/_licenses/agpl-3.0.txt
+++ b/_licenses/agpl-3.0.txt
@@ -4,7 +4,7 @@ nickname: GNU AGPLv3
 redirect_from: /licenses/agpl/
 source: http://www.gnu.org/licenses/agpl-3.0.txt
 
-description: The license with the strongest conditions for preserving openness. Complete source code of licensed works and modifications, which include larger works using a licensed work, must be made available under the same license when distributed. Copyright and license notices must be preserved. Contributors provide an express grant of patent rights to users. Additionally, when a modified version is used to provide a service over a network, the complete source code of the modified version must be made available to users of the service.
+description: Permissions of this strongest copyleft license are conditioned on making available complete source code of licensed works and modifications, which include larger works using a licensed work, under the same license when distributed. Copyright and license notices must be preserved. Contributors provide an express grant of patent rights to users. Additionally, when a modified version is used to provide a service over a network, the complete source code of the modified version must be made available to users of the service.
 
 how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file.
 

--- a/_licenses/agpl-3.0.txt
+++ b/_licenses/agpl-3.0.txt
@@ -5,7 +5,7 @@ nickname: GNU AGPLv3
 redirect_from: /licenses/agpl/
 source: http://www.gnu.org/licenses/agpl-3.0.txt
 
-description: Permissions of this strongest copyleft license are conditioned on making available complete source code of licensed works and modifications, which include larger works using a licensed work, under the same license when distributed. Copyright and license notices must be preserved. Contributors provide an express grant of patent rights to users. Additionally, when a modified version is used to provide a service over a network, the complete source code of the modified version must be made available to users of the service.
+description: Permissions of this strongest copyleft license are conditioned on making available complete source code of licensed works and modifications, which include larger works using a licensed work, under the same license. Copyright and license notices must be preserved. Contributors provide an express grant of patent rights. Additionally, when a modified version is used to provide a service over a network, the complete source code of the modified version must be made available.
 
 how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file.
 

--- a/_licenses/apache-2.0.txt
+++ b/_licenses/apache-2.0.txt
@@ -3,7 +3,7 @@ title: Apache License 2.0
 redirect_from: /licenses/apache/
 source: http://www.apache.org/licenses/LICENSE-2.0.html
 
-description: A permissive license that also provides an express grant of patent rights from contributors to users.
+description: A license whose main conditions require preservation of copyright and license notices. Contributors provide an express grant of patent rights to users. Licensed works, modifications, and larger works may be distributed under different terms and without source code.
 
 how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file.
 

--- a/_licenses/apache-2.0.txt
+++ b/_licenses/apache-2.0.txt
@@ -3,7 +3,7 @@ title: Apache License 2.0
 redirect_from: /licenses/apache/
 source: http://www.apache.org/licenses/LICENSE-2.0.html
 
-description: A license whose main conditions require preservation of copyright and license notices. Contributors provide an express grant of patent rights to users. Licensed works, modifications, and larger works may be distributed under different terms and without source code.
+description: A permissive license whose main conditions require preservation of copyright and license notices. Contributors provide an express grant of patent rights to users. Licensed works, modifications, and larger works may be distributed under different terms and without source code.
 
 how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file.
 

--- a/_licenses/apache-2.0.txt
+++ b/_licenses/apache-2.0.txt
@@ -5,7 +5,7 @@ redirect_from: /licenses/apache/
 source: http://www.apache.org/licenses/LICENSE-2.0.html
 featured: true
 
-description: A permissive license whose main conditions require preservation of copyright and license notices. Contributors provide an express grant of patent rights to users. Licensed works, modifications, and larger works may be distributed under different terms and without source code.
+description: A permissive license whose main conditions require preservation of copyright and license notices. Contributors provide an express grant of patent rights. Licensed works, modifications, and larger works may be distributed under different terms and without source code.
 
 how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file.
 

--- a/_licenses/gpl-3.0.txt
+++ b/_licenses/gpl-3.0.txt
@@ -4,7 +4,7 @@ nickname: GNU GPLv3
 redirect_from: /licenses/gpl-v3/
 source: http://www.gnu.org/licenses/gpl-3.0.txt
 
-description: A license with strong conditions for preserving openness. Complete source code of licensed works and modifications, which include larger works using a licensed work, must be made available under the same license when distributed. Copyright and license notices must be preserved. Contributors provide an express grant of patent rights to users.
+description: Permissions of this strong copyleft license are conditioned on making available complete source code of licensed works and modifications, which include larger works using a licensed work, under the same license when distributed. Copyright and license notices must be preserved. Contributors provide an express grant of patent rights to users.
 
 how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file.
 

--- a/_licenses/gpl-3.0.txt
+++ b/_licenses/gpl-3.0.txt
@@ -4,7 +4,7 @@ nickname: GNU GPLv3
 redirect_from: /licenses/gpl-v3/
 source: http://www.gnu.org/licenses/gpl-3.0.txt
 
-description: The GNU GPL is the most widely used free software license and has a strong copyleft requirement. When distributing derived works, the source code of the work must be made available under the same license.
+description: A license with strong conditions for preserving openness. Complete source code of licensed works and modifications, which include larger works using a licensed work, must be made available under the same license when distributed. Copyright and license notices must be preserved. Contributors provide an express grant of patent rights to users.
 
 how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file.
 

--- a/_licenses/gpl-3.0.txt
+++ b/_licenses/gpl-3.0.txt
@@ -6,7 +6,7 @@ redirect_from: /licenses/gpl-v3/
 source: http://www.gnu.org/licenses/gpl-3.0.txt
 featured: true
 
-description: Permissions of this strong copyleft license are conditioned on making available complete source code of licensed works and modifications, which include larger works using a licensed work, under the same license when distributed. Copyright and license notices must be preserved. Contributors provide an express grant of patent rights to users.
+description: Permissions of this strong copyleft license are conditioned on making available complete source code of licensed works and modifications, which include larger works using a licensed work, under the same license. Copyright and license notices must be preserved. Contributors provide an express grant of patent rights.
 
 how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file.
 

--- a/_licenses/lgpl-3.0.txt
+++ b/_licenses/lgpl-3.0.txt
@@ -4,7 +4,7 @@ nickname: GNU LGPLv3
 redirect_from: /licenses/lgpl-v3/
 source: http://www.gnu.org/licenses/lgpl-3.0.txt
 
-description: Version 3 of the GNU LGPL is an additional set of permissions to the <a href="/licenses/gpl-3.0/">GNU GPLv3 license</a> that requires that derived works be licensed under the same license, but works that only link to it do not fall under this restriction.
+description: A license with strong but narrowly applied conditions for preserving openness. Complete source code of licensed works and modifications must be made available under the same license or the GNU GPLv3 when distributed. Copyright and license notices must be preserved. Contributors provide an express grant of patent rights to users. However, a larger work using the licensed work through interfaces provided by the licensed work may be distributed under different terms and without source code for the larger work.
 
 how: This license is an additional set of permissions to the <a href="/licenses/gpl-3.0">GNU GPLv3</a> license. Follow the instructions to apply the GNU GPLv3. Then either paste this text to the bottom of the created file OR add a separate file (typically named COPYING.lesser or LICENSE.lesser) in the root of your source code and copy the text.
 

--- a/_licenses/lgpl-3.0.txt
+++ b/_licenses/lgpl-3.0.txt
@@ -4,7 +4,7 @@ nickname: GNU LGPLv3
 redirect_from: /licenses/lgpl-v3/
 source: http://www.gnu.org/licenses/lgpl-3.0.txt
 
-description: A license with strong but narrowly applied conditions for preserving openness. Complete source code of licensed works and modifications must be made available under the same license or the GNU GPLv3 when distributed. Copyright and license notices must be preserved. Contributors provide an express grant of patent rights to users. However, a larger work using the licensed work through interfaces provided by the licensed work may be distributed under different terms and without source code for the larger work.
+description: Permissions of this copyleft license are conditioned on making available complete source code of licensed works and modifications under the same license or the GNU GPLv3 when distributed. Copyright and license notices must be preserved. Contributors provide an express grant of patent rights to users. However, a larger work using the licensed work through interfaces provided by the licensed work may be distributed under different terms and without source code for the larger work.
 
 how: This license is an additional set of permissions to the <a href="/licenses/gpl-3.0">GNU GPLv3</a> license. Follow the instructions to apply the GNU GPLv3. Then either paste this text to the bottom of the created file OR add a separate file (typically named COPYING.lesser or LICENSE.lesser) in the root of your source code and copy the text.
 

--- a/_licenses/lgpl-3.0.txt
+++ b/_licenses/lgpl-3.0.txt
@@ -5,7 +5,7 @@ nickname: GNU LGPLv3
 redirect_from: /licenses/lgpl-v3/
 source: http://www.gnu.org/licenses/lgpl-3.0.txt
 
-description: Permissions of this copyleft license are conditioned on making available complete source code of licensed works and modifications under the same license or the GNU GPLv3 when distributed. Copyright and license notices must be preserved. Contributors provide an express grant of patent rights to users. However, a larger work using the licensed work through interfaces provided by the licensed work may be distributed under different terms and without source code for the larger work.
+description: Permissions of this copyleft license are conditioned on making available complete source code of licensed works and modifications under the same license or the GNU GPLv3. Copyright and license notices must be preserved. Contributors provide an express grant of patent rights. However, a larger work using the licensed work through interfaces provided by the licensed work may be distributed under different terms and without source code for the larger work.
 
 how: This license is an additional set of permissions to the <a href="/licenses/gpl-3.0">GNU GPLv3</a> license. Follow the instructions to apply the GNU GPLv3. Then either paste this text to the bottom of the created file OR add a separate file (typically named COPYING.lesser or LICENSE.lesser) in the root of your source code and copy the text.
 

--- a/_licenses/mit.txt
+++ b/_licenses/mit.txt
@@ -2,7 +2,7 @@
 title: MIT License
 source: https://opensource.org/licenses/MIT
 
-description: A permissive license that is short and to the point. It lets people do anything with your code with proper attribution and without warranty.
+description: A short and simple license with conditions only requiring preservation of copyright and license notices. Licensed works, modifications, and larger works may be distributed under different terms and without source code.
 
 how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file. Replace [year] with the current year and [fullname] with the name (or names) of the copyright holders.
 

--- a/_licenses/mit.txt
+++ b/_licenses/mit.txt
@@ -2,7 +2,7 @@
 title: MIT License
 source: https://opensource.org/licenses/MIT
 
-description: A short and simple license with conditions only requiring preservation of copyright and license notices. Licensed works, modifications, and larger works may be distributed under different terms and without source code.
+description: A short and simple permissive license with conditions only requiring preservation of copyright and license notices. Licensed works, modifications, and larger works may be distributed under different terms and without source code.
 
 how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file. Replace [year] with the current year and [fullname] with the name (or names) of the copyright holders.
 

--- a/_licenses/mpl-2.0.txt
+++ b/_licenses/mpl-2.0.txt
@@ -3,7 +3,7 @@ title: Mozilla Public License 2.0
 redirect_from: /licenses/mozilla/
 source: https://www.mozilla.org/media/MPL/2.0/index.txt
 
-description: A license with very narrowly applied conditions for preserving openness. Source code of licensed files and modifications of those files must be made available under the same license (or in certain cases, the GNU AGPLv3, GPLv2, LGPLv2.1, or later versions of those licenses) when distributed. Copyright and license notices must be preserved. Contributors provide an express grant of patent rights to users. However, a larger work using work may be distributed under different terms and without source code for other files the larger work.
+description: Permissions of this weak copyleft license are conditioned on making available source code of licensed files and modifications of those files under the same license (or in certain cases, the GNU AGPLv3, GPLv2, LGPLv2.1, or later versions of those licenses) when distributed. Copyright and license notices must be preserved. Contributors provide an express grant of patent rights to users. However, a larger work using work may be distributed under different terms and without source code for other files the larger work.
 
 how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file.
 

--- a/_licenses/mpl-2.0.txt
+++ b/_licenses/mpl-2.0.txt
@@ -3,7 +3,7 @@ title: Mozilla Public License 2.0
 redirect_from: /licenses/mozilla/
 source: https://www.mozilla.org/media/MPL/2.0/index.txt
 
-description: Permissions of this weak copyleft license are conditioned on making available source code of licensed files and modifications of those files under the same license (or in certain cases, the GNU AGPLv3, GPLv2, LGPLv2.1, or later versions of those licenses) when distributed. Copyright and license notices must be preserved. Contributors provide an express grant of patent rights to users. However, a larger work using work may be distributed under different terms and without source code for other files the larger work.
+description: Permissions of this weak copyleft license are conditioned on making available source code of licensed files and modifications of those files under the same license (or in certain cases, one of the GNU licenses) when distributed. Copyright and license notices must be preserved. Contributors provide an express grant of patent rights to users. However, a larger work using the licensed work may be distributed under different terms and without source code for files added in the larger work.
 
 how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file.
 

--- a/_licenses/mpl-2.0.txt
+++ b/_licenses/mpl-2.0.txt
@@ -4,7 +4,7 @@ spdx-id: MPL-2.0
 redirect_from: /licenses/mozilla/
 source: https://www.mozilla.org/media/MPL/2.0/index.txt
 
-description: Permissions of this weak copyleft license are conditioned on making available source code of licensed files and modifications of those files under the same license (or in certain cases, one of the GNU licenses) when distributed. Copyright and license notices must be preserved. Contributors provide an express grant of patent rights to users. However, a larger work using the licensed work may be distributed under different terms and without source code for files added in the larger work.
+description: Permissions of this weak copyleft license are conditioned on making available source code of licensed files and modifications of those files under the same license (or in certain cases, one of the GNU licenses). Copyright and license notices must be preserved. Contributors provide an express grant of patent rights. However, a larger work using the licensed work may be distributed under different terms and without source code for files added in the larger work.
 
 how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file.
 

--- a/_licenses/mpl-2.0.txt
+++ b/_licenses/mpl-2.0.txt
@@ -3,7 +3,7 @@ title: Mozilla Public License 2.0
 redirect_from: /licenses/mozilla/
 source: https://www.mozilla.org/media/MPL/2.0/index.txt
 
-description: The Mozilla Public License (MPL 2.0) is maintained by the Mozilla foundation. This license attempts to be a compromise between the permissive BSD license and the reciprocal GPL license.
+description: A license with very narrowly applied conditions for preserving openness. Source code of licensed files and modifications of those files must be made available under the same license (or in certain cases, the GNU AGPLv3, GPLv2, LGPLv2.1, or later versions of those licenses) when distributed. Copyright and license notices must be preserved. Contributors provide an express grant of patent rights to users. However, a larger work using work may be distributed under different terms and without source code for other files the larger work.
 
 how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file.
 

--- a/_licenses/unlicense.txt
+++ b/_licenses/unlicense.txt
@@ -2,7 +2,7 @@
 title: The Unlicense
 source: http://unlicense.org/UNLICENSE
 
-description: A license with no conditions whatsoever. Unlicensed works, modifications, and larger works may be distributed under different terms and without source code.
+description: A license with no conditions whatsoever which dedicates works to the public domain. Unlicensed works, modifications, and larger works may be distributed under different terms and without source code.
 
 
 how: Create a text file (typically named UNLICENSE or UNLICENSE.txt) in the root of your source code and copy the text of the license disclaimer into the file.

--- a/_licenses/unlicense.txt
+++ b/_licenses/unlicense.txt
@@ -2,7 +2,8 @@
 title: The Unlicense
 source: http://unlicense.org/UNLICENSE
 
-description: Because copyright is automatic in most countries, <a href="http://unlicense.org">the Unlicense</a> is a template to waive copyright interest in software you've written and dedicate it to the public domain. Use the Unlicense to opt out of copyright entirely. It also includes the no-warranty statement from the MIT/X11 license.
+description: A license with no conditions whatsoever. Unlicensed works, modifications, and larger works may be distributed under different terms and without source code.
+
 
 how: Create a text file (typically named UNLICENSE or UNLICENSE.txt) in the root of your source code and copy the text of the license disclaimer into the file.
 


### PR DESCRIPTION
- primarily functional
- drop self-naming
- minimize requiring significant understanding of other licenses or
  copyright
- should be excruciatingly bland for anyone who already knows the licenses
  well; newcomers shouldn't have to deal with baggage immediately

Probably a few more words should be added to the xGPLv3s about their
stronger patent terms.

Licenses not listed on /licenses could be described in similar style.

Suggestions and criticisms welcome!
