### PR TITLE
re-add 'featured' field

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Licenses sit in the `/_licenses` folder. Each license has YAML front matter desc
 
 #### Optional fields
 
+* `featured` - Whether the license should be featured on the main page (defaults to false)
 * `note` - Additional information about the licenses
 * `using` - A list of notable projects using the license in the form of `project_name: "url"`
 * `redirect_from` - Relative path(s) to redirect to the license from, to prevent breaking old URLs

--- a/_data/meta.yml
+++ b/_data/meta.yml
@@ -31,6 +31,10 @@
 
 # Optional fields
 
+- name: featured
+  description: Whether the license should be featured on the main page (defaults to false)
+  required: false
+
 - name: note
   description: Additional information about the licenses
   required: false

--- a/_licenses/apache-2.0.txt
+++ b/_licenses/apache-2.0.txt
@@ -2,6 +2,7 @@
 title: Apache License 2.0
 redirect_from: /licenses/apache/
 source: http://www.apache.org/licenses/LICENSE-2.0.html
+featured: true
 
 description: A permissive license that also provides an express grant of patent rights from contributors to users.
 

--- a/_licenses/gpl-3.0.txt
+++ b/_licenses/gpl-3.0.txt
@@ -3,6 +3,7 @@ title: GNU General Public License v3.0
 nickname: GNU GPLv3
 redirect_from: /licenses/gpl-v3/
 source: http://www.gnu.org/licenses/gpl-3.0.txt
+featured: true
 
 description: The GNU GPL is the most widely used free software license and has a strong copyleft requirement. When distributing derived works, the source code of the work must be made available under the same license.
 

--- a/_licenses/mit.txt
+++ b/_licenses/mit.txt
@@ -1,6 +1,7 @@
 ---
 title: MIT License
 source: https://opensource.org/licenses/MIT
+featured: true
 
 description: A permissive license that is short and to the point. It lets people do anything with your code with proper attribution and without warranty.
 


### PR DESCRIPTION
Was unused for choosealicense.com display after
https://github.com/github/choosealicense.com/pull/386

But choosealicense.com is vendored into licensee which eventually
is used in GitHub; 'featured' determines what is highlighted in
license drop-down eg at https://github.com/new

It _could_ be useful to highlight with a star and tooltip or something licenses which are featured on /licenses and their individual /license pages. Anyone with design skills wishing to try that, further pull requests welcome, or anyone who loves that idea but doesn't want ti implement, open an issue.
