### PR TITLE
Restructure individual license pages, added styles to improve alignment

### DIFF
--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -1,23 +1,7 @@
 <div class="sidebar">
 
   <a href="#" data-clipboard-target="#license-text" data-proofer-ignore="true" class="js-clipboard-button button">Copy license text to clipboard</a>
-  
-  <div class="license-description">
-    <h3>Description</h3>
-    <p>
-      {{ page.description }}
-    </p>
-  </div>
-  
-  {% if page.nickname %}
-  <div class="license-nickname">
-    <h3>Nickname</h3>
-    <p>
-      {{ page.nickname }}
-    </p>
-  </div>
-  {% endif %}
-  
+    
   <div class="how-to-apply">
     <h3>How to apply this license</h3>
     <p>
@@ -37,27 +21,6 @@
     </a>
   </div>
   {% endif %}
-
-  <div class="license-rules license-rules-sidebar">
-
-  {% assign types = "permissions|conditions|limitations" | split: "|" %}
-  {% for type in types %}
-    <h3>{{ type | capitalize }}</h3>
-    <ul class="license-{{ type }}">
-      {% assign rules = site.data.rules[type] | sort: "label" %}
-      {% for rule_obj in rules %}
-        {% assign req = rule_obj.tag %}
-        {% if page[type] contains req %}
-          <li class="{{ req }}">
-            <span class="license-sprite"></span>
-            {{ rule_obj.label }}
-          </li>
-        {% endif %}
-      {% endfor %}
-    </ul>
-  {% endfor %}
-
-  </div>
 
   {% if page.using %}
   <div class="projects-with-license">

--- a/_layouts/license.html
+++ b/_layouts/license.html
@@ -1,8 +1,54 @@
 {% include header.html %}
 
       <div class="clearfix">
+      
         <div class="license-body">
-          <pre id="license-text">{{ content | replace:"<", "&lt;" | replace:">", "&gt;" }}</pre>
+        
+            {% if page.nickname %}
+            <p class="license-nickname">
+                {{ page.nickname }}
+            </p>
+            {% endif %}
+
+            <p>
+                {{ page.description }}
+            </p>
+            
+            <div class="license-page-details">
+            
+              <table class="license-rules">
+                <tr>
+                {% assign types = "permissions|conditions|limitations" | split: "|" %}
+                {% for type in types %}
+                  <th class="label">{{ type | capitalize }}</th>
+                {% endfor %}
+                </tr>
+                <tr>
+                  {% for type in types %}
+                    <td>
+                      <ul class="license-{{ type }}">
+                        {% assign rules = site.data.rules[type] | sort: "label" %}
+                        {% for rule_obj in rules %}
+                          {% assign req = rule_obj.tag %}
+                          {% if page[type] contains req %}
+                            <li class="{{ req }}">
+                              <span class="license-sprite"></span>
+                              {{ rule_obj.label }}
+                            </li>
+                          {% endif %}
+                        {% endfor %}
+                      </ul>
+                    </td>
+                  {% endfor %}
+                </tr>
+              </table>
+              
+            </div>
+            
+            <h3>License Text</h3>
+
+            <pre id="license-text">{{ content | replace:"<", "&lt;" | replace:">", "&gt;" }}</pre>
+          
         </div> <!-- /license-body -->
 
 {% include sidebar.html %}

--- a/_layouts/license.html
+++ b/_layouts/license.html
@@ -44,8 +44,6 @@
               </table>
               
             </div>
-            
-            <h3>License Text</h3>
 
             <pre id="license-text">{{ content | replace:"<", "&lt;" | replace:">", "&gt;" }}</pre>
           

--- a/assets/css/application.scss
+++ b/assets/css/application.scss
@@ -163,6 +163,12 @@ strong {
   padding-left: 20px;
 }
 
+.license-page-details {
+  -webkit-box-sizing: border-box;
+  -moz-box-sizing: border-box;
+  box-sizing: border-box;
+}
+
 .license-overview-name {
   font-size: 28px;
   margin-top: 5px;
@@ -263,6 +269,10 @@ strong {
   -o-border-radius: 3px;
   border-radius: 3px;
   padding: 20px;
+}
+
+.license-nickname {
+  margin-top: 0;
 }
 
 .sidebar {


### PR DESCRIPTION
This is in reference to #355 and an update to #382 (which essentially makes it obsolete)

Always wonderful visual:
![solo-license-page-restructure](https://cloud.githubusercontent.com/assets/8132772/14837800/5f48ab84-0bd0-11e6-9464-af8be9ec4f60.png)
