### PR TITLE
don't use the same color for headings and links

### DIFF
--- a/assets/css/application.scss
+++ b/assets/css/application.scss
@@ -80,7 +80,7 @@ strong {
 }
 
 .home h2 {
-  color: #149ad4;
+  color: #687072;
   font-size: 27px;
   line-height: 70px;
   margin-bottom: 45px;


### PR DESCRIPTION
Changed to a slightly-blue grey, which IMO fits well with the current style.

Screenshot:
![screenshot](https://cloud.githubusercontent.com/assets/478237/14894087/dd8d7fa2-0d69-11e6-8612-b56fe2c77a68.png)
