### PR TITLE
Better limitations:trademark-use

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ The license properties (rules) are stored as a bulleted list within the licenses
 
 #### Limitations
 
-* `trademark-use` - While this may be implicitly true of all licenses, this license explicitly states that it does NOT grant you any rights in the trademarks or other marks of contributors.
+* `trademark-use` - This license explicitly states that it does NOT grant you trademark rights, even though licenses without such a statement probably do not grant you any implicit trademark rights.
 * `no-liability` - Software is provided without warranty and the software author/license owner cannot be held liable for damages.
 * `patent-use` -  This license explicitly states that it does NOT grant you any rights in the patents of contributors.
 

--- a/_data/rules.yml
+++ b/_data/rules.yml
@@ -33,7 +33,7 @@ permissions:
   tag: patent-use
 
 limitations:
-- description: While this may be implicitly true of all licenses, this license explicitly states that it does NOT grant you any rights in the trademarks or other marks of contributors.
+- description: This license explicitly states that it does NOT grant you any trademark rights, even though trademark rights are not implicitly granted by any common licenses.
   label: Trademark Use
   tag: trademark-use
 - description: Software is provided without warranty and the software author/license owner cannot be held liable for damages.

--- a/_data/rules.yml
+++ b/_data/rules.yml
@@ -33,7 +33,7 @@ permissions:
   tag: patent-use
 
 limitations:
-- description: This license explicitly states that it does NOT grant you any trademark rights, even though trademark rights are not implicitly granted by any common licenses.
+- description: This license explicitly states that it does NOT grant you trademark rights, even though licenses without such a statement probably do not grant you any implicit trademark rights.
   label: Trademark Use
   tag: trademark-use
 - description: Software is provided without warranty and the software author/license owner cannot be held liable for damages.


### PR DESCRIPTION
Existing phrase is likely confusing to new readers; trying to better clarify the fact that copyright licenses don't grant you trademarks anyway, but that these licenses are explicit about letting you know trademarks aren't copyrights.
