### PR TITLE
Add rule tooltips to the appendix

### DIFF
--- a/appendix.md
+++ b/appendix.md
@@ -8,14 +8,15 @@ class: license-types
 All licenses described in the choosealicense.com [repository](https://github.com/github/choosealicense.com), in a table.
 
 <table border style="font-size: xx-small">
-<tr><th>License</th>
-{% assign types = "permissions|conditions|limitations" | split: "|" %}
-{% for type in types %}
-  {% assign rules = site.data.rules[type] | sort: "label" %}
-  {% for rule_obj in rules %}
-    <th style="text-align: center; width:7%">{{ rule_obj.label }}</th>
+<tr>
+  <th>License</th>
+  {% assign types = "permissions|conditions|limitations" | split: "|" %}
+  {% for type in types %}
+    {% assign rules = site.data.rules[type] | sort: "label" %}
+    {% for rule_obj in rules %}
+      <th style="text-align: center; width:7%">{{ rule_obj.label }}</th>
+    {% endfor %}
   {% endfor %}
-{% endfor %}
 </tr>
 {% for license in site.licenses | sort: 'path' %}
   <tr style="height: 3em"><td><a href="{{ license.id }}">{{ license.title }}</a></td>
@@ -24,7 +25,9 @@ All licenses described in the choosealicense.com [repository](https://github.com
     {% for rule_obj in rules %}
       <td class="license-{{ type }}" style="text-align:center">{% assign req = rule_obj.tag %}
       {% if license[type] contains req %}
-          <span class="license-sprite {{ req }}"></span>
+          <span class="{{ req }}">
+            <span class="license-sprite {{ req }}"></span>
+          </span>
       {% endif %}</td>
     {% endfor %}
   {% endfor %}

--- a/assets/js/app.coffee
+++ b/assets/js/app.coffee
@@ -38,11 +38,11 @@ class Choosealicense
     # Dynamically add annotations as title attribute to rule list items
     for ruletype, rules of window.annotations
       for rule in rules
-        $(".license-rules ul.license-#{ruletype} li.#{rule["tag"]}").attr "title", rule["description"]
+        $(".license-#{ruletype} .#{rule["tag"]}").attr "title", rule["description"]
 
     # Init tooltips on all rule list items
     for ruletype, label of @ruletypes
-      $(".license-#{ruletype} li").qtip
+      $(".license-#{ruletype} li, .license-#{ruletype} .license-sprite").qtip
         content:
           text: false
           title:


### PR DESCRIPTION
On hover example:

![screen shot 2016-05-10 at 1 42 58 pm](https://cloud.githubusercontent.com/assets/282759/15156493/4b014fb0-16b5-11e6-8c7b-f1dfbe93ebab.png)

Fixes #407 
