### PR TITLE
Add a note about more info available on hover

### DIFF
--- a/appendix.md
+++ b/appendix.md
@@ -5,7 +5,7 @@ title: Appendix
 class: license-types
 ---
 
-All licenses described in the choosealicense.com [repository](https://github.com/github/choosealicense.com), in a table.
+All licenses described in the choosealicense.com [repository](https://github.com/github/choosealicense.com), in a table. Hover on the circles for more info.
 
 <table border style="font-size: xx-small">
 {% assign types = "permissions|conditions|limitations" | split: "|" %}


### PR DESCRIPTION
It wasn't obvious to me, but expected something to happen on click/hover on circles because there is no legend anywhere. Let's remove the guesswork.
