### PR TITLE
Add SPDX license list reference

### DIFF
--- a/about.md
+++ b/about.md
@@ -20,7 +20,7 @@ See our [appendix](/appendix) for a table of all of the licenses cataloged in th
 
 * Open Source Initiative's [list of licenses](https://opensource.org/licenses/) approved as conforming to the [Open Source Definition](https://opensource.org/osd)
 * Free Software Foundation's [comments on various licenses](http://www.gnu.org/licenses/license-list.html)
-* Linux Foundation's SPDX [licenses list] (http://spdx.org/licenses)/
+* Linux Foundation's SPDX [licenses list](https://spdx.org/licenses/)
 * [Comparison of free and open-source software licenses](https://en.wikipedia.org/wiki/Comparison_of_free_and_open-source_software_licenses) on English Wikipedia
 * [License differentiator](http://www.oss-watch.ac.uk/apps/licdiff/) ([source](https://github.com/ox-it/licdiff)) from [OSS Watch](http://www.oss-watch.ac.uk/)
 * [Free/Libre/Open Source license selection wizard](http://home.ccil.org/~cowan/floss/) by John Cowan

--- a/about.md
+++ b/about.md
@@ -20,6 +20,7 @@ See our [appendix](/appendix) for a table of all of the licenses cataloged in th
 
 * Open Source Initiative's [list of licenses](https://opensource.org/licenses/) approved as conforming to the [Open Source Definition](https://opensource.org/osd)
 * Free Software Foundation's [comments on various licenses](http://www.gnu.org/licenses/license-list.html)
+* Linux Foundation's SPDX [licenses list] (http://spdx.org/licenses)/
 * [Comparison of free and open-source software licenses](https://en.wikipedia.org/wiki/Comparison_of_free_and_open-source_software_licenses) on English Wikipedia
 * [License differentiator](http://www.oss-watch.ac.uk/apps/licdiff/) ([source](https://github.com/ox-it/licdiff)) from [OSS Watch](http://www.oss-watch.ac.uk/)
 * [Free/Libre/Open Source license selection wizard](http://home.ccil.org/~cowan/floss/) by John Cowan


### PR DESCRIPTION
It may be relevant to add a link to SPDX as even though  SPDX is referenced is many other places in the repo, it does not show up in the about.md.
That would a nice addition! (disclaimer: I am one of the SPDX co-founders)

Feel free to reject this: I would understand that you want to keep this to a bare minimum of highly authoritative links. MO is that SPDX qualifies, but this is your call.
