### PR TITLE
Allow auto filling like for MIT license {yyyy}{name of copyright owne…

### DIFF
--- a/_licenses/apache-2.0.txt
+++ b/_licenses/apache-2.0.txt
@@ -219,7 +219,7 @@ limitations:
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright {yyyy} {name of copyright owner}
+   Copyright [year] [fullname]
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
Allow auto filling like for MIT license
 `{yyyy}{name of copyright owne…r}`->`[year] [fullname]`

TL;DR- Bug this Commit is fixing: When Autogenerating MIT , year and name are automatically filled. When autogenerating Apache 2.0 they are not. I would expect behaviour to be consistent - either autofill everwhere, either nowhere.

Actually two fields: `{yyyy} {name of copyright owner}` in Apache
License are not automatically substituted.

I see them automatically substituted in case of X11 AKA MIT License,
here it is, initial commit for same workflow but by selecting MIT
instead of Apache 2.0:
https://github.com/gwpl/test_autogen_MIT_LICENSE/commit/6efc5748d77c528c976e0457dbdb3ea7f6298115
as you see in MIT license both: year and author got substituted.

Here is how it is defined for MIT `[year] [fullname]`: https://github.com/github/choosealicense.com/blob/gh-pages/_licenses/mit.txt#L30

I would expect behaviour to be consistent across all licenses.
