### PR TITLE
Make nickname a required meta field

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,8 @@ Licenses sit in the `/_licenses` folder. Each license has YAML front matter desc
 
 #### Required fields
 
-* `title` - The SPDX-compliant, human-readable license name
+* `title` - The license full name specified by http://spdx.org/licenses/
+* `nickname` - A shorter license name; customary if applicable (e.g., GPLv3) or the SPDX ID (e.g., MPL-2.0)
 * `source` - The URL to the license source text
 * `description` - A human-readable description of the license
 * `how` - Instructions on how to implement the license
@@ -53,7 +54,6 @@ Licenses sit in the `/_licenses` folder. Each license has YAML front matter desc
 * `note` - Additional information about the licenses
 * `using` - A list of notable projects using the license in the form of `project_name: "url"`
 * `redirect_from` - Relative path(s) to redirect to the license from, to prevent breaking old URLs
-* `nickname` - A shorter, human-readable license name where the SPDX license name (`title` above) is long
 
 ### Auto-populated fields
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Licenses sit in the `/_licenses` folder. Each license has YAML front matter desc
 #### Required fields
 
 * `title` - The license full name specified by http://spdx.org/licenses/
-* `nickname` - A shorter license name; customary if applicable (e.g., GPLv3) or the SPDX ID (e.g., MPL-2.0)
+* `spdx-id` - Short identifier specified by http://spdx.org/licenses/
 * `source` - The URL to the license source text
 * `description` - A human-readable description of the license
 * `how` - Instructions on how to implement the license
@@ -51,6 +51,7 @@ Licenses sit in the `/_licenses` folder. Each license has YAML front matter desc
 #### Optional fields
 
 * `featured` - Whether the license should be featured on the main page (defaults to false)
+* `nickname` - Customary short name if applicable (e.g, GPLv3)
 * `note` - Additional information about the licenses
 * `using` - A list of notable projects using the license in the form of `project_name: "url"`
 * `redirect_from` - Relative path(s) to redirect to the license from, to prevent breaking old URLs

--- a/_data/meta.yml
+++ b/_data/meta.yml
@@ -2,8 +2,12 @@
 # The available fields are:
 
 - name: title
-  description: The SPDX-compliant, human-readable license name
+  description: The license full name specified by http://spdx.org/licenses/
   required: true
+
+- name: nickname
+  description: A shorter license name; customary if applicable (e.g., GPLv3) or the SPDX ID (e.g., MPL-2.0)
+  required: required
 
 - name: source
   description: The URL to the license source text
@@ -45,8 +49,4 @@
 
 - name: redirect_from
   description: Relative path(s) to redirect to the license from, to prevent breaking old URLs
-  required: false
-
-- name: nickname
-  description: A shorter, human-readable license name where the SPDX license name (`title` above) is long
   required: false

--- a/_data/meta.yml
+++ b/_data/meta.yml
@@ -5,8 +5,8 @@
   description: The license full name specified by http://spdx.org/licenses/
   required: true
 
-- name: nickname
-  description: A shorter license name; customary if applicable (e.g., GPLv3) or the SPDX ID (e.g., MPL-2.0)
+- name: spdx-id
+  description: Short identifier specified by http://spdx.org/licenses/
   required: required
 
 - name: source
@@ -37,6 +37,10 @@
 
 - name: featured
   description: Whether the license should be featured on the main page (defaults to false)
+  required: false
+
+- name: nickname
+  description: Customary short name if applicable (e.g, GPLv3)
   required: false
 
 - name: note

--- a/_licenses/afl-3.0.txt
+++ b/_licenses/afl-3.0.txt
@@ -1,6 +1,6 @@
 ---
 title: Academic Free License v3.0
-nickname: AFL-3.0
+spdx-id: AFL-3.0
 source: http://opensource.org/licenses/afl-3.0
 
 description: The Academic Free License is a variant of the Open Software License that does not require that the source code of derivative works be disclosed. It contains explicit copyright and patent grants and reserves trademark rights in the author.

--- a/_licenses/afl-3.0.txt
+++ b/_licenses/afl-3.0.txt
@@ -1,5 +1,6 @@
 ---
 title: Academic Free License v3.0
+nickname: AFL-3.0
 source: http://opensource.org/licenses/afl-3.0
 
 description: The Academic Free License is a variant of the Open Software License that does not require that the source code of derivative works be disclosed. It contains explicit copyright and patent grants and reserves trademark rights in the author.

--- a/_licenses/agpl-3.0.txt
+++ b/_licenses/agpl-3.0.txt
@@ -1,5 +1,6 @@
 ---
 title: GNU Affero General Public License v3.0
+spdx-id: AGPL-3.0
 nickname: GNU AGPLv3
 redirect_from: /licenses/agpl/
 source: http://www.gnu.org/licenses/agpl-3.0.txt

--- a/_licenses/apache-2.0.txt
+++ b/_licenses/apache-2.0.txt
@@ -1,6 +1,6 @@
 ---
 title: Apache License 2.0
-nickname: Apache-2.0
+spdx-id: Apache-2.0
 redirect_from: /licenses/apache/
 source: http://www.apache.org/licenses/LICENSE-2.0.html
 featured: true

--- a/_licenses/apache-2.0.txt
+++ b/_licenses/apache-2.0.txt
@@ -1,5 +1,6 @@
 ---
 title: Apache License 2.0
+nickname: Apache-2.0
 redirect_from: /licenses/apache/
 source: http://www.apache.org/licenses/LICENSE-2.0.html
 featured: true

--- a/_licenses/artistic-2.0.txt
+++ b/_licenses/artistic-2.0.txt
@@ -1,6 +1,6 @@
 ---
 title: Artistic License 2.0
-nickname: Artistic-2.0
+spdx-id: Artistic-2.0
 redirect_from: /licenses/artistic/
 source: http://www.perlfoundation.org/attachment/legal/artistic-2_0.txt
 

--- a/_licenses/artistic-2.0.txt
+++ b/_licenses/artistic-2.0.txt
@@ -1,5 +1,6 @@
 ---
 title: Artistic License 2.0
+nickname: Artistic-2.0
 redirect_from: /licenses/artistic/
 source: http://www.perlfoundation.org/attachment/legal/artistic-2_0.txt
 

--- a/_licenses/bsd-2-clause.txt
+++ b/_licenses/bsd-2-clause.txt
@@ -1,6 +1,6 @@
 ---
 title: BSD 2-clause "Simplified" License
-nickname: BSD 2-Clause
+spdx-id: BSD-2-Clause
 redirect_from: /licenses/bsd/
 source: http://opensource.org/licenses/BSD-2-Clause
 

--- a/_licenses/bsd-3-clause-clear.txt
+++ b/_licenses/bsd-3-clause-clear.txt
@@ -1,6 +1,6 @@
 ---
 title: BSD 3-clause Clear License
-nickname: BSD-3-Clause-Clear
+spdx-id: BSD-3-Clause-Clear
 
 description: A variant of the <a href="/licenses/bsd-3-clause/">BSD 3-Clause License</a> that explicitly does not grant any patent rights.
 

--- a/_licenses/bsd-3-clause-clear.txt
+++ b/_licenses/bsd-3-clause-clear.txt
@@ -1,5 +1,6 @@
 ---
 title: BSD 3-clause Clear License
+nickname: BSD-3-Clause-Clear
 
 description: A variant of the <a href="/licenses/bsd-3-clause/">BSD 3-Clause License</a> that explicitly does not grant any patent rights.
 

--- a/_licenses/bsd-3-clause.txt
+++ b/_licenses/bsd-3-clause.txt
@@ -1,6 +1,6 @@
 ---
 title: BSD 3-clause "New" or "Revised" License
-nickname: BSD 3-Clause
+spdx-id: BSD-3-Clause
 source: http://opensource.org/licenses/BSD-3-Clause
 
 description: A permissive license similar to the <a href="/licenses/bsd-2-clause/">BSD 2-Clause License</a>, but with a 3rd clause that prohibits others from using the name of the project or its contributors to promote derived products without written consent.

--- a/_licenses/cc-by-4.0.txt
+++ b/_licenses/cc-by-4.0.txt
@@ -1,6 +1,6 @@
 ---
 title: Creative Commons Attribution 4.0
-nickname: CC-BY-4.0
+spdx-id: CC-BY-4.0
 source: https://creativecommons.org/licenses/by/4.0/legalcode.txt
 
 description: Permits almost any use subject to providing credit and license notice. Frequently used for media assets and educational materials. The most common license for Open Access scientific publications. Not recommended for software.

--- a/_licenses/cc-by-sa-4.0.txt
+++ b/_licenses/cc-by-sa-4.0.txt
@@ -1,6 +1,6 @@
 ---
 title: Creative Commons Attribution Share Alike 4.0
-nickname: CC-BY-SA-4.0
+spdx-id: CC-BY-SA-4.0
 source: https://creativecommons.org/licenses/by-sa/4.0/legalcode.txt
 
 description: Similar to <a href='/licenses/cc-by-4.0/'>CC-BY-4.0</a> but requires derivatives be distributed under the same or a similar, <a href="https://creativecommons.org/compatiblelicenses/">compatible</a> license. Frequently used for media assets and educational materials. A previous version is the default license for Wikipedia and other Wikimedia projects. Not recommended for software.

--- a/_licenses/cc0-1.0.txt
+++ b/_licenses/cc0-1.0.txt
@@ -1,6 +1,6 @@
 ---
 title: Creative Commons Zero v1.0 Universal
-nickname: CC0-1.0
+spdx-id: CC0-1.0
 redirect_from: /licenses/cc0/
 source: http://creativecommons.org/publicdomain/zero/1.0/
 

--- a/_licenses/cc0-1.0.txt
+++ b/_licenses/cc0-1.0.txt
@@ -1,6 +1,6 @@
 ---
 title: Creative Commons Zero v1.0 Universal
-nickname: CC0 1.0 Universal
+nickname: CC0-1.0
 redirect_from: /licenses/cc0/
 source: http://creativecommons.org/publicdomain/zero/1.0/
 

--- a/_licenses/epl-1.0.txt
+++ b/_licenses/epl-1.0.txt
@@ -1,5 +1,6 @@
 ---
 title: Eclipse Public License 1.0
+nickname: EPL-1.0
 redirect_from: /licenses/eclipse/
 source: https://www.eclipse.org/legal/epl-v10.html
 

--- a/_licenses/epl-1.0.txt
+++ b/_licenses/epl-1.0.txt
@@ -1,6 +1,6 @@
 ---
 title: Eclipse Public License 1.0
-nickname: EPL-1.0
+spdx-id: EPL-1.0
 redirect_from: /licenses/eclipse/
 source: https://www.eclipse.org/legal/epl-v10.html
 

--- a/_licenses/eupl-1.1.txt
+++ b/_licenses/eupl-1.1.txt
@@ -1,6 +1,6 @@
 ---
 title: European Union Public License 1.1
-nickname: EUPL-1.1
+spdx-id: EUPL-1.1
 redirect_from: /licenses/eupl-v1.1/
 source: https://joinup.ec.europa.eu/community/eupl/og_page/european-union-public-licence-eupl-v11
 

--- a/_licenses/gpl-2.0.txt
+++ b/_licenses/gpl-2.0.txt
@@ -1,5 +1,6 @@
 ---
 title: GNU General Public License v2.0
+spdx-id: GPL-2.0
 nickname: GNU GPLv2
 redirect_from: /licenses/gpl-v2/
 source: http://www.gnu.org/licenses/gpl-2.0.txt

--- a/_licenses/gpl-3.0.txt
+++ b/_licenses/gpl-3.0.txt
@@ -1,5 +1,6 @@
 ---
 title: GNU General Public License v3.0
+spdx-id: GPL-3.0
 nickname: GNU GPLv3
 redirect_from: /licenses/gpl-v3/
 source: http://www.gnu.org/licenses/gpl-3.0.txt

--- a/_licenses/isc.txt
+++ b/_licenses/isc.txt
@@ -1,6 +1,6 @@
 ---
 title: ISC License
-nickname: ISC
+spdx-id: ISC
 source: http://opensource.org/licenses/isc-license
 
 description: A permissive license lets people do anything with your code with proper attribution and without warranty. The ISC license is functionally equivalent to the <a href="/licenses/bsd-2-clause/">BSD 2-Clause</a> and <a href="/licenses/mit/">MIT</a> licenses, removing some language that is no longer necessary.

--- a/_licenses/isc.txt
+++ b/_licenses/isc.txt
@@ -1,5 +1,6 @@
 ---
 title: ISC License
+nickname: ISC
 source: http://opensource.org/licenses/isc-license
 
 description: A permissive license lets people do anything with your code with proper attribution and without warranty. The ISC license is functionally equivalent to the <a href="/licenses/bsd-2-clause/">BSD 2-Clause</a> and <a href="/licenses/mit/">MIT</a> licenses, removing some language that is no longer necessary.

--- a/_licenses/lgpl-2.1.txt
+++ b/_licenses/lgpl-2.1.txt
@@ -1,5 +1,6 @@
 ---
 title: GNU Lesser General Public License v2.1
+spdx-id: LGPL-2.1
 nickname: GNU LGPLv2.1
 redirect_from: /licenses/lgpl-v2.1/
 source: http://www.gnu.org/licenses/lgpl-2.1.txt

--- a/_licenses/lgpl-3.0.txt
+++ b/_licenses/lgpl-3.0.txt
@@ -1,5 +1,6 @@
 ---
 title: GNU Lesser General Public License v3.0
+spdx-id: LGPL-3.0
 nickname: GNU LGPLv3
 redirect_from: /licenses/lgpl-v3/
 source: http://www.gnu.org/licenses/lgpl-3.0.txt

--- a/_licenses/lppl-1.3c.txt
+++ b/_licenses/lppl-1.3c.txt
@@ -1,6 +1,6 @@
 ---
 title: LaTeX Project Public License v1.3c
-nickname: LPPL-1.3c
+spdx-id: LPPL-1.3c
 source: https://latex-project.org/lppl/lppl-1-3c.html
 
 description: The LaTeX Project Public License (LPPL) is the primary license under which the LaTeX kernel and the base LaTeX packages are distributed. 

--- a/_licenses/mit.txt
+++ b/_licenses/mit.txt
@@ -1,6 +1,6 @@
 ---
 title: MIT License
-nickname: MIT
+spdx-id: MIT
 source: https://opensource.org/licenses/MIT
 featured: true
 

--- a/_licenses/mit.txt
+++ b/_licenses/mit.txt
@@ -1,5 +1,6 @@
 ---
 title: MIT License
+nickname: MIT
 source: https://opensource.org/licenses/MIT
 featured: true
 

--- a/_licenses/mpl-2.0.txt
+++ b/_licenses/mpl-2.0.txt
@@ -1,5 +1,6 @@
 ---
 title: Mozilla Public License 2.0
+nickname: MPL-2.0
 redirect_from: /licenses/mozilla/
 source: https://www.mozilla.org/media/MPL/2.0/index.txt
 

--- a/_licenses/mpl-2.0.txt
+++ b/_licenses/mpl-2.0.txt
@@ -1,6 +1,6 @@
 ---
 title: Mozilla Public License 2.0
-nickname: MPL-2.0
+spdx-id: MPL-2.0
 redirect_from: /licenses/mozilla/
 source: https://www.mozilla.org/media/MPL/2.0/index.txt
 

--- a/_licenses/ms-pl.txt
+++ b/_licenses/ms-pl.txt
@@ -1,6 +1,6 @@
 ---
 title: Microsoft Public License
-nickname: MS-PL
+spdx-id: MS-PL
 
 source: http://opensource.org/licenses/ms-pl
 

--- a/_licenses/ms-pl.txt
+++ b/_licenses/ms-pl.txt
@@ -1,5 +1,6 @@
 ---
 title: Microsoft Public License
+nickname: MS-PL
 
 source: http://opensource.org/licenses/ms-pl
 

--- a/_licenses/ms-rl.txt
+++ b/_licenses/ms-rl.txt
@@ -1,6 +1,6 @@
 ---
 title: Microsoft Reciprocal License
-nickname: MS-RL
+spdx-id: MS-RL
 
 source: http://opensource.org/licenses/ms-pl
 

--- a/_licenses/ms-rl.txt
+++ b/_licenses/ms-rl.txt
@@ -1,5 +1,6 @@
 ---
 title: Microsoft Reciprocal License
+nickname: MS-RL
 
 source: http://opensource.org/licenses/ms-pl
 

--- a/_licenses/ofl-1.1.txt
+++ b/_licenses/ofl-1.1.txt
@@ -1,5 +1,6 @@
 ---
 title: SIL Open Font License 1.1
+nickname: OFL-1.1
 redirect_from: /licenses/ofl/
 source: http://scripts.sil.org/OFL_web
 

--- a/_licenses/ofl-1.1.txt
+++ b/_licenses/ofl-1.1.txt
@@ -1,6 +1,6 @@
 ---
 title: SIL Open Font License 1.1
-nickname: OFL-1.1
+spdx-id: OFL-1.1
 redirect_from: /licenses/ofl/
 source: http://scripts.sil.org/OFL_web
 

--- a/_licenses/osl-3.0.txt
+++ b/_licenses/osl-3.0.txt
@@ -1,6 +1,6 @@
 ---
 title: Open Software License 3.0
-nickname: OSL-3.0
+spdx-id: OSL-3.0
 source: http://opensource.org/licenses/OSL-3.0
 
 description: OSL 3.0 is a copyleft license that does not require reciprocal licensing on linked works. It also provides an express grant of patent rights from contributors to users, with a termination clause triggered if a user files a patent infringement lawsuit.

--- a/_licenses/osl-3.0.txt
+++ b/_licenses/osl-3.0.txt
@@ -1,5 +1,6 @@
 ---
 title: Open Software License 3.0
+nickname: OSL-3.0
 source: http://opensource.org/licenses/OSL-3.0
 
 description: OSL 3.0 is a copyleft license that does not require reciprocal licensing on linked works. It also provides an express grant of patent rights from contributors to users, with a termination clause triggered if a user files a patent infringement lawsuit.

--- a/_licenses/unlicense.txt
+++ b/_licenses/unlicense.txt
@@ -1,6 +1,6 @@
 ---
 title: The Unlicense
-nickname: Unlicense
+spdx-id: Unlicense
 source: http://unlicense.org/UNLICENSE
 
 description: Because copyright is automatic in most countries, <a href="http://unlicense.org">the Unlicense</a> is a template to waive copyright interest in software you've written and dedicate it to the public domain. Use the Unlicense to opt out of copyright entirely. It also includes the no-warranty statement from the MIT/X11 license.

--- a/_licenses/unlicense.txt
+++ b/_licenses/unlicense.txt
@@ -1,5 +1,6 @@
 ---
 title: The Unlicense
+nickname: Unlicense
 source: http://unlicense.org/UNLICENSE
 
 description: Because copyright is automatic in most countries, <a href="http://unlicense.org">the Unlicense</a> is a template to waive copyright interest in software you've written and dedicate it to the public domain. Use the Unlicense to opt out of copyright entirely. It also includes the no-warranty statement from the MIT/X11 license.

--- a/_licenses/wtfpl.txt
+++ b/_licenses/wtfpl.txt
@@ -1,6 +1,6 @@
 ---
 title: "Do What The F*ck You Want To Public License"
-nickname: WTFPL
+spdx-id: WTFPL
 source: http://www.wtfpl.net/
 
 description: The easiest licence out there. It gives the user permissions to do whatever they want with your code.

--- a/_licenses/wtfpl.txt
+++ b/_licenses/wtfpl.txt
@@ -1,5 +1,6 @@
 ---
 title: "Do What The F*ck You Want To Public License"
+nickname: WTFPL
 source: http://www.wtfpl.net/
 
 description: The easiest licence out there. It gives the user permissions to do whatever they want with your code.

--- a/spec/license_spec.rb
+++ b/spec/license_spec.rb
@@ -8,13 +8,18 @@ describe 'licenses' do
   licenses.each do |license|
     context "The #{license['title']} license" do
       let(:id) { license['id'] }
+      let(:spdx_id) { license['spdx-id'] }
 
       it 'has an SPDX ID' do
-        expect(spdx_ids).to include(id)
+        expect(spdx_ids).to include(spdx_id)
+      end
+
+      it 'has an ID that is downcased SPDX ID' do
+        expect(spdx_id.casecmp(id).zero?)
       end
 
       it 'uses its SPDX name' do
-        spdx = find_spdx(id)
+        spdx = find_spdx(spdx_id)
         expect(spdx).to_not be_nil
         expect(spdx[1]['name'].gsub(/ only$/, '')).to eql(license['title'])
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -75,11 +75,11 @@ def spdx_list
 end
 
 def spdx_ids
-  spdx_list.map { |name, _properties| name.downcase }
+  spdx_list.map { |name, _properties| name }
 end
 
 def find_spdx(license)
-  spdx_list.find { |name, _properties| name.casecmp(license).zero? }
+  spdx_list.find { |name, _properties| name == license }
 end
 
 def osi_approved_licenses


### PR DESCRIPTION
Add missing nicknames

Use SPDX ID if no customary nickname (eg GNU GPLv3) exists

This ensures that a relatively compact name is always available

I may be missing some obvious customary names, e.g., is "Eclipse
1.0" customary? For now I've used the SPDX ID, EPL-1.0.
