### PR TITLE
License identifiers and package descriptions hint

### DIFF
--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -14,7 +14,7 @@
     {% endif %}
     {% assign xgpl = false %}
     {% if page.spdx-id contains 'GPL' %}{% assign xgpl = true %}{% endif %}
-    <p>You can also add <strong><code>{{ page.spdx-id }}</code>{% if xgpl %}+{% endif %}</strong>{% if xgpl %} (or <strong><code>{{ page.spdx-id }}</code></strong> to disallow future versions){% endif %}, the standard identifier for this license, to your project's package description, if applicable. Examples: <a href="https://docs.npmjs.com/files/package.json#license">Node.js</a>, <a href="http://guides.rubygems.org/specification-reference/#license=">Ruby</a>, and <a href="http://doc.crates.io/manifest.html#package-metadata">Rust</a>.</p>
+    <p class="note">The standard identifier for this license is <strong><code>{{ page.spdx-id }}</code>{% if xgpl %}+{% endif %}</strong>{% if xgpl %} (or <strong><code>{{ page.spdx-id }}</code></strong> to disallow future versions){% endif %}. Optionally, you can add this to your project's package description, if applicable (e.g., <a href="https://docs.npmjs.com/files/package.json#license">Node.js</a>, <a href="http://guides.rubygems.org/specification-reference/#license=">Ruby</a>, and <a href="http://doc.crates.io/manifest.html#package-metadata">Rust</a>). This will ensure the license is displayed in package directories.</p>
   </div>
 
   {% if page.source %}

--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -12,7 +12,9 @@
       <strong>Note: </strong> {{ page.note | markdownify | remove: '<p>' | remove: '</p>' }}
     </p>
     {% endif %}
+    <p>You can also add <strong><code>{{ page.spdx-id }}</code></strong>, the standard identifier for this license, to your project's package description, if applicable. Examples: <a href="https://docs.npmjs.com/files/package.json#license">Node.js</a>, <a href="http://guides.rubygems.org/specification-reference/#license=">Ruby</a>, and <a href="http://doc.crates.io/manifest.html#package-metadata">Rust</a>.</p>
   </div>
+
   {% if page.source %}
   <div class="source">
     <a href="{{ page.source }}">

--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -12,7 +12,9 @@
       <strong>Note: </strong> {{ page.note | markdownify | remove: '<p>' | remove: '</p>' }}
     </p>
     {% endif %}
-    <p>You can also add <strong><code>{{ page.spdx-id }}</code></strong>, the standard identifier for this license, to your project's package description, if applicable. Examples: <a href="https://docs.npmjs.com/files/package.json#license">Node.js</a>, <a href="http://guides.rubygems.org/specification-reference/#license=">Ruby</a>, and <a href="http://doc.crates.io/manifest.html#package-metadata">Rust</a>.</p>
+    {% assign xgpl = false %}
+    {% if page.spdx-id contains 'GPL' %}{% assign xgpl = true %}{% endif %}
+    <p>You can also add <strong><code>{{ page.spdx-id }}</code>{% if xgpl %}+{% endif %}</strong>{% if xgpl %} (or <strong><code>{{ page.spdx-id }}</code></strong> to disallow future versions){% endif %}, the standard identifier for this license, to your project's package description, if applicable. Examples: <a href="https://docs.npmjs.com/files/package.json#license">Node.js</a>, <a href="http://guides.rubygems.org/specification-reference/#license=">Ruby</a>, and <a href="http://doc.crates.io/manifest.html#package-metadata">Rust</a>.</p>
   </div>
 
   {% if page.source %}

--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -14,7 +14,7 @@
     {% endif %}
     {% assign xgpl = false %}
     {% if page.spdx-id contains 'GPL' %}{% assign xgpl = true %}{% endif %}
-    <p class="note">The standard identifier for this license is <strong><code>{{ page.spdx-id }}</code>{% if xgpl %}+{% endif %}</strong>{% if xgpl %} (or <strong><code>{{ page.spdx-id }}</code></strong> to disallow future versions){% endif %}. Optionally, you can add this to your project's package description, if applicable (e.g., <a href="https://docs.npmjs.com/files/package.json#license">Node.js</a>, <a href="http://guides.rubygems.org/specification-reference/#license=">Ruby</a>, and <a href="http://doc.crates.io/manifest.html#package-metadata">Rust</a>). This will ensure the license is displayed in package directories.</p>
+    <p class="note"><strong>Optional: </strong> Add <strong><code>{{ page.spdx-id }}</code>{% if xgpl %}+{% endif %}</strong>{% if xgpl %} (or <strong><code>{{ page.spdx-id }}</code></strong> to disallow future versions){% endif %} to your project's package description, if applicable (e.g., <a href="https://docs.npmjs.com/files/package.json#license">Node.js</a>, <a href="http://guides.rubygems.org/specification-reference/#license=">Ruby</a>, and <a href="http://doc.crates.io/manifest.html#package-metadata">Rust</a>). This will ensure the license is displayed in package directories.</p>
   </div>
 
   {% if page.source %}

--- a/assets/css/application.scss
+++ b/assets/css/application.scss
@@ -286,6 +286,10 @@ strong {
   width: 100%;
 }
 
+.note {
+  color: #687072;
+}
+
 .button {
   -webkit-border-radius: 3px;
   -moz-border-radius: 3px;


### PR DESCRIPTION
Now that licenses' case-sensitive SPDX ID are [available](https://github.com/github/choosealicense.com/pull/418#issuecomment-221404630) I thought it might be useful to expose on individual license pages, along with a hint about how this can be used. Screenshot:

<img width="211" alt="package-metadata-license" src="https://cloud.githubusercontent.com/assets/40415/15660789/9215dd18-2695-11e6-8b85-fbb7c82cb327.png">

I also used this to sneak in an instruction about noting "or later" for _GPLs:

<img width="224" alt="package-metadata-gpl" src="https://cloud.githubusercontent.com/assets/40415/15660802/cc8e05c4-2695-11e6-8276-82eb90a6b474.png">
