### PR TITLE
make tests not overwrite non-mutable document 'id'

### DIFF
--- a/spec/license_meta_spec.rb
+++ b/spec/license_meta_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe 'license meta' do
   licenses.each do |license|
     # Manually load the raw license so we don't get the defaults
-    raw_fields = SafeYAML.load_file("_licenses/#{license['id']}.txt")
+    raw_fields = SafeYAML.load_file("_licenses/#{license['spdx-lcase']}.txt")
 
     context "The #{license['title']} license" do
       it 'should only contain supported meta fields' do

--- a/spec/license_spec.rb
+++ b/spec/license_spec.rb
@@ -7,7 +7,7 @@ describe 'licenses' do
 
   licenses.each do |license|
     context "The #{license['title']} license" do
-      let(:id) { license['spdx-lcase'] }
+      let(:spdx_lcase) { license['spdx-lcase'] }
       let(:spdx_id) { license['spdx-id'] }
 
       it 'has an SPDX ID' do
@@ -15,7 +15,7 @@ describe 'licenses' do
       end
 
       it 'has an ID that is downcased SPDX ID' do
-        expect(spdx_id.casecmp(id).zero?)
+        expect(spdx_id.casecmp(spdx_lcase).zero?)
       end
 
       it 'uses its SPDX name' do
@@ -26,7 +26,7 @@ describe 'licenses' do
 
       context 'industry approval' do
         it 'should be approved by OSI or FSF or OD' do
-          expect(approved_licenses).to include(id), 'See https://git.io/vzCTV.'
+          expect(approved_licenses).to include(spdx_lcase), 'See https://git.io/vzCTV.'
         end
       end
 

--- a/spec/license_spec.rb
+++ b/spec/license_spec.rb
@@ -7,7 +7,7 @@ describe 'licenses' do
 
   licenses.each do |license|
     context "The #{license['title']} license" do
-      let(:id) { license['id'] }
+      let(:id) { license['spdx-lcase'] }
       let(:spdx_id) { license['spdx-id'] }
 
       it 'has an SPDX ID' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -35,7 +35,7 @@ def licenses
   SpecHelper.licenses ||= begin
     site.collections['licenses'].docs.map do |license|
       id = File.basename(license.basename, '.txt')
-      license.to_liquid.merge('id' => id)
+      license.to_liquid.merge('spdx-lcase' => id)
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -34,14 +34,10 @@ end
 def licenses
   SpecHelper.licenses ||= begin
     site.collections['licenses'].docs.map do |license|
-      id = File.basename(license.basename, '.txt')
-      license.to_liquid.merge('spdx-lcase' => id)
+      spdx_lcase = File.basename(license.basename, '.txt')
+      license.to_liquid.merge('spdx-lcase' => spdx_lcase)
     end
   end
-end
-
-def license_ids
-  licenses.map { |l| l['id'] }
 end
 
 def site


### PR DESCRIPTION
WIth Jekyll 3.1.6 CI is now failing. Skimming sources I'm not sure when introduced, but now the class that represents a document has a 'id' method and is considered immutable, so our tests which add an 'id' property to each license to set up the tests now fail when adding that property (see stracktrace below). So I changed the property added and used from 'id' to 'spdx-lcase' which is descriptive of the property value. Now tests/CI will pass.

cc @parkr as likely to be able to tell me if I'm missing something obvious or otherwise doing it wrong.

```
/home/travis/build/github/choosealicense.com/vendor/bundle/ruby/2.0.0/gems/jekyll-3.1.6/lib/jekyll/drops/drop.rb:78:in `[]=': Key id cannot be set in the drop. (Jekyll::Errors::DropMutationException)
    from /home/travis/build/github/choosealicense.com/vendor/bundle/ruby/2.0.0/gems/jekyll-3.1.6/lib/jekyll/drops/drop.rb:194:in `block in merge!'
    from /home/travis/build/github/choosealicense.com/vendor/bundle/ruby/2.0.0/gems/jekyll-3.1.6/lib/jekyll/drops/drop.rb:185:in `each_key'
    from /home/travis/build/github/choosealicense.com/vendor/bundle/ruby/2.0.0/gems/jekyll-3.1.6/lib/jekyll/drops/drop.rb:185:in `merge!'
    from /home/travis/build/github/choosealicense.com/vendor/bundle/ruby/2.0.0/gems/jekyll-3.1.6/lib/jekyll/drops/drop.rb:177:in `block in merge'
    from /home/travis/build/github/choosealicense.com/vendor/bundle/ruby/2.0.0/gems/jekyll-3.1.6/lib/jekyll/drops/drop.rb:175:in `tap'
    from /home/travis/build/github/choosealicense.com/vendor/bundle/ruby/2.0.0/gems/jekyll-3.1.6/lib/jekyll/drops/drop.rb:175:in `merge'
    from /home/travis/build/github/choosealicense.com/spec/spec_helper.rb:38:in `block in licenses'
    from /home/travis/build/github/choosealicense.com/spec/spec_helper.rb:36:in `map'
    from /home/travis/build/github/choosealicense.com/spec/spec_helper.rb:36:in `licenses'
    from /home/travis/build/github/choosealicense.com/spec/license_fields_spec.rb:4:in `block in <top (required)>'
    from /home/travis/build/github/choosealicense.com/vendor/bundle/ruby/2.0.0/gems/rspec-core-3.4.4/lib/rspec/core/example_group.rb:385:in `module_exec'
    from /home/travis/build/github/choosealicense.com/vendor/bundle/ruby/2.0.0/gems/rspec-core-3.4.4/lib/rspec/core/example_group.rb:385:in `subclass'
    from /home/travis/build/github/choosealicense.com/vendor/bundle/ruby/2.0.0/gems/rspec-core-3.4.4/lib/rspec/core/example_group.rb:255:in `block in define_example_group_method'
    from /home/travis/build/github/choosealicense.com/vendor/bundle/ruby/2.0.0/gems/rspec-core-3.4.4/lib/rspec/core/dsl.rb:43:in `block in expose_example_group_alias'
    from /home/travis/build/github/choosealicense.com/vendor/bundle/ruby/2.0.0/gems/rspec-core-3.4.4/lib/rspec/core/dsl.rb:82:in `block (2 levels) in expose_example_group_alias_globally'
    from /home/travis/build/github/choosealicense.com/spec/license_fields_spec.rb:3:in `<top (required)>'
    from /home/travis/build/github/choosealicense.com/vendor/bundle/ruby/2.0.0/gems/rspec-core-3.4.4/lib/rspec/core/configuration.rb:1361:in `load'
    from /home/travis/build/github/choosealicense.com/vendor/bundle/ruby/2.0.0/gems/rspec-core-3.4.4/lib/rspec/core/configuration.rb:1361:in `block in load_spec_files'
    from /home/travis/build/github/choosealicense.com/vendor/bundle/ruby/2.0.0/gems/rspec-core-3.4.4/lib/rspec/core/configuration.rb:1359:in `each'
    from /home/travis/build/github/choosealicense.com/vendor/bundle/ruby/2.0.0/gems/rspec-core-3.4.4/lib/rspec/core/configuration.rb:1359:in `load_spec_files'
    from /home/travis/build/github/choosealicense.com/vendor/bundle/ruby/2.0.0/gems/rspec-core-3.4.4/lib/rspec/core/runner.rb:106:in `setup'
    from /home/travis/build/github/choosealicense.com/vendor/bundle/ruby/2.0.0/gems/rspec-core-3.4.4/lib/rspec/core/runner.rb:92:in `run'
    from /home/travis/build/github/choosealicense.com/vendor/bundle/ruby/2.0.0/gems/rspec-core-3.4.4/lib/rspec/core/runner.rb:78:in `run'
    from /home/travis/build/github/choosealicense.com/vendor/bundle/ruby/2.0.0/gems/rspec-core-3.4.4/lib/rspec/core/runner.rb:45:in `invoke'
    from /home/travis/build/github/choosealicense.com/vendor/bundle/ruby/2.0.0/gems/rspec-core-3.4.4/exe/rspec:4:in `<main>'
```
