### PR TITLE
Add 'or later' to AGPLv3, GPLv2, and GPLv3 license names.

### DIFF
--- a/_licenses/agpl-3.0.txt
+++ b/_licenses/agpl-3.0.txt
@@ -1,7 +1,7 @@
 ---
-title: GNU Affero General Public License v3.0
+title: GNU Affero General Public License v3.0 or later
 spdx-id: AGPL-3.0
-nickname: GNU AGPLv3
+nickname: GNU AGPLv3+
 redirect_from: /licenses/agpl/
 source: http://www.gnu.org/licenses/agpl-3.0.txt
 

--- a/_licenses/gpl-2.0.txt
+++ b/_licenses/gpl-2.0.txt
@@ -1,7 +1,7 @@
 ---
-title: GNU General Public License v2.0
+title: GNU General Public License v2.0 or later
 spdx-id: GPL-2.0
-nickname: GNU GPLv2
+nickname: GNU GPLv2+
 redirect_from: /licenses/gpl-v2/
 source: http://www.gnu.org/licenses/gpl-2.0.txt
 

--- a/_licenses/gpl-3.0.txt
+++ b/_licenses/gpl-3.0.txt
@@ -1,7 +1,7 @@
 ---
-title: GNU General Public License v3.0
+title: GNU General Public License v3.0 or later
 spdx-id: GPL-3.0
-nickname: GNU GPLv3
+nickname: GNU GPLv3+
 redirect_from: /licenses/gpl-v3/
 source: http://www.gnu.org/licenses/gpl-3.0.txt
 featured: true


### PR DESCRIPTION
As discussed in [an issue in the Licensee repo](https://github.com/benbalter/licensee/issues/97), the FSF/GNU Project recommends calling the versions of the AGPL and GPL licenses "vN or later" rather than just "vN". 

The reason for this is that all three of these licenses have clauses explicitly declaring that users are free to re-license the software under any future versions of the same license.

From [GPLv2](http://www.gnu.org/licenses/old-licenses/gpl-2.0.en.html):

"9. The Free Software Foundation may publish revised and/or new versions of the General Public License from time to time. Such new versions will be similar in spirit to the present version, but may differ in detail to address new problems or concerns.

Each version is given a distinguishing version number. If the Program specifies a version number of this License which applies to it and "any later version", you have the option of following the terms and conditions either of that version or of any later version published by the Free Software Foundation. If the Program does not specify a version number of this License, you may choose any version ever published by the Free Software Foundation."

From [GPLv3](http://www.gnu.org/licenses/gpl.html):

"14. Revised Versions of this License.

The Free Software Foundation may publish revised and/or new versions of the GNU General Public License from time to time. Such new versions will be similar in spirit to the present version, but may differ in detail to address new problems or concerns.

Each version is given a distinguishing version number. If the Program specifies that a certain numbered version of the GNU General Public License “or any later version” applies to it, you have the option of following the terms and conditions either of that numbered version or of any later version published by the Free Software Foundation. If the Program does not specify a version number of the GNU General Public License, you may choose any version ever published by the Free Software Foundation.

If the Program specifies that a proxy can decide which future versions of the GNU General Public License can be used, that proxy's public statement of acceptance of a version permanently authorizes you to choose that version for the Program.

Later license versions may give you additional or different permissions. However, no additional obligations are imposed on any author or copyright holder as a result of your choosing to follow a later version."

From the [AGPLv3](http://www.gnu.org/licenses/agpl-3.0.en.html):

"14. Revised Versions of this License.

The Free Software Foundation may publish revised and/or new versions of the GNU Affero General Public License from time to time. Such new versions will be similar in spirit to the present version, but may differ in detail to address new problems or concerns.

Each version is given a distinguishing version number. If the Program specifies that a certain numbered version of the GNU Affero General Public License "or any later version" applies to it, you have the option of following the terms and conditions either of that numbered version or of any later version published by the Free Software Foundation. If the Program does not specify a version number of the GNU Affero General Public License, you may choose any version ever published by the Free Software Foundation.

If the Program specifies that a proxy can decide which future versions of the GNU Affero General Public License can be used, that proxy's public statement of acceptance of a version permanently authorizes you to choose that version for the Program.

Later license versions may give you additional or different permissions. However, no additional obligations are imposed on any author or copyright holder as a result of your choosing to follow a later version."

Thanks, Connor Shea
