### PR TITLE
small link to appendix & improve for linking, guiding back to home page

### DIFF
--- a/appendix.md
+++ b/appendix.md
@@ -5,7 +5,9 @@ title: Appendix
 class: license-types
 ---
 
-All licenses described in the choosealicense.com [repository](https://github.com/github/choosealicense.com), in a table.
+For reference, all licenses described in the choosealicense.com [repository](https://github.com/github/choosealicense.com), in a table.
+
+If you're here to choose a license, **[start from the home page](/)** to see a few licenses that will work for most cases.
 
 <table border style="font-size: xx-small">
 {% assign types = "permissions|conditions|limitations" | split: "|" %}
@@ -56,11 +58,11 @@ All licenses described in the choosealicense.com [repository](https://github.com
 
 ## Legend
 
-<p>Open source licenses grant to the public <b>permissions</b> (<span class="license-permissions"><span class="license-sprite"></span></span>) to do things with licensed works copyright or other "intellectual property" laws might otherwise disallow.</p>
+<p>Open source licenses grant to the public <span class="license-permissions"><span class="license-sprite"></span></span> <b>permissions</b> to do things with licensed works copyright or other "intellectual property" laws might otherwise disallow.</p>
 
-<p>Most open source licenses' grants of permissions are subject to compliance with <b>conditions</b> (<span class="license-conditions"><span class="license-sprite"></span></span>).</p>
+<p>Most open source licenses' grants of permissions are subject to compliance with <span class="license-conditions"><span class="license-sprite"></span></span> <b>conditions</b>.</p>
 
-<p>Most open source licenses also have <b>limitations</b> (<span class="license-limitations"><span class="license-sprite"></span></span>) that usually disclaim warranty and liability and sometimes expressly exclude patent or trademark from licenses' grants.</p>
+<p>Most open source licenses also have <span class="license-limitations"><span class="license-sprite"></span></span> <b>limitations</b> that usually disclaim warranty and liability and sometimes expressly exclude patent or trademark from licenses' grants.</p>
 
 <dl>
 {% assign seen_tags = '' %}

--- a/assets/css/application.scss
+++ b/assets/css/application.scss
@@ -150,7 +150,7 @@ strong {
 
 .license-overview {
   clear: both;
-  margin-bottom: 50px;
+  margin-bottom: 40px;
 }
 
 .license-overview-heading {

--- a/licenses.html
+++ b/licenses.html
@@ -6,7 +6,7 @@ title: Licenses
 ---
 
 <p>Open source licenses grant permission to everyone to use, modify, and share licensed software for any purpose, subject to conditions preserving the provenance and openness of the software. The following licenses are arranged from one with the strongest of these conditions (GNU AGPLv3) to one with no conditions (Unlicense). Notice that the popular licenses featured on the <a href="/">home page</a> (GNU GPLv3, Apache License 2.0, and MIT License) fall within this spectrum.</p>
-<p style="font-size:small">If you were looking for a reference table of all of the licenses on choosealicense.com, see the <a href="/appendix">appendix</a>.</p>
+<p style="font-size:small; margin-bottom: 40px">If you were looking for a reference table of all of the licenses on choosealicense.com, see the <a href="/appendix">appendix</a>.</p>
 
 {% include license-overview.html license-id="agpl-3.0" %}
 {% include license-overview.html license-id="gpl-3.0" %}

--- a/licenses.html
+++ b/licenses.html
@@ -5,7 +5,8 @@ class: license-types
 title: Licenses
 ---
 
-<p style="margin-bottom:50px">Open source licenses grant permission to everyone to use, modify, and share licensed software for any purpose, subject to conditions preserving the provenance and openness of the software. The following licenses are arranged from one with the strongest of these conditions (GNU AGPLv3) to one with no conditions (Unlicense). Notice that the popular licenses featured on the <a href="/">home page</a> (GNU GPLv3, Apache License 2.0, and MIT License) fall within this spectrum.</p>
+<p>Open source licenses grant permission to everyone to use, modify, and share licensed software for any purpose, subject to conditions preserving the provenance and openness of the software. The following licenses are arranged from one with the strongest of these conditions (GNU AGPLv3) to one with no conditions (Unlicense). Notice that the popular licenses featured on the <a href="/">home page</a> (GNU GPLv3, Apache License 2.0, and MIT License) fall within this spectrum.</p>
+<p style="font-size:small">If you were looking for a reference table of all of the licenses on choosealicense.com, see the <a href="/appendix">appendix</a>.</p>
 
 {% include license-overview.html license-id="agpl-3.0" %}
 {% include license-overview.html license-id="gpl-3.0" %}


### PR DESCRIPTION
Based on feeedback from people looking for BSD licenses and wanting to use site as a reference, see #427 

I'm not thrilled with any distraction from flow of choices that work for most on home page through spectrum covering range of open source licenses without redundant ones, but obviously some people prefer seeing everything in a table, so let them find it, accommodate use as reference and people whose learning style involves poring over a reference rather than being guided.

A couple unrelated formatting tweaks made in passing.
