### PR TITLE
re-add optional hidden field, default to true

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Licenses sit in the `/_licenses` folder. Each license has YAML front matter desc
 #### Optional fields
 
 * `featured` - Whether the license should be featured on the main page (defaults to false)
+* `hidden` - Whether the license is hidden from the license list (defaults to true)
 * `nickname` - Customary short name if applicable (e.g, GPLv3)
 * `note` - Additional information about the licenses
 * `using` - A list of notable projects using the license in the form of `project_name: "url"`

--- a/_config.yml
+++ b/_config.yml
@@ -16,6 +16,7 @@ defaults:
       path: ""
       type: "licenses"
     values:
+      hidden: true
       layout: license
 
 exclude:

--- a/_data/meta.yml
+++ b/_data/meta.yml
@@ -39,6 +39,10 @@
   description: Whether the license should be featured on the main page (defaults to false)
   required: false
 
+- name: hidden
+  description: Whether the license is hidden from the license list (defaults to true)
+  required: false
+
 - name: nickname
   description: Customary short name if applicable (e.g, GPLv3)
   required: false

--- a/_licenses/agpl-3.0.txt
+++ b/_licenses/agpl-3.0.txt
@@ -4,6 +4,7 @@ spdx-id: AGPL-3.0
 nickname: GNU AGPLv3
 redirect_from: /licenses/agpl/
 source: http://www.gnu.org/licenses/agpl-3.0.txt
+hidden: false
 
 description: Permissions of this strongest copyleft license are conditioned on making available complete source code of licensed works and modifications, which include larger works using a licensed work, under the same license. Copyright and license notices must be preserved. Contributors provide an express grant of patent rights. When a modified version is used to provide a service over a network, the complete source code of the modified version must be made available.
 

--- a/_licenses/apache-2.0.txt
+++ b/_licenses/apache-2.0.txt
@@ -4,6 +4,7 @@ spdx-id: Apache-2.0
 redirect_from: /licenses/apache/
 source: http://www.apache.org/licenses/LICENSE-2.0.html
 featured: true
+hidden: false
 
 description: A permissive license whose main conditions require preservation of copyright and license notices. Contributors provide an express grant of patent rights. Licensed works, modifications, and larger works may be distributed under different terms and without source code.
 

--- a/_licenses/gpl-3.0.txt
+++ b/_licenses/gpl-3.0.txt
@@ -5,6 +5,7 @@ nickname: GNU GPLv3
 redirect_from: /licenses/gpl-v3/
 source: http://www.gnu.org/licenses/gpl-3.0.txt
 featured: true
+hidden: false
 
 description: Permissions of this strong copyleft license are conditioned on making available complete source code of licensed works and modifications, which include larger works using a licensed work, under the same license. Copyright and license notices must be preserved. Contributors provide an express grant of patent rights.
 

--- a/_licenses/lgpl-3.0.txt
+++ b/_licenses/lgpl-3.0.txt
@@ -4,6 +4,7 @@ spdx-id: LGPL-3.0
 nickname: GNU LGPLv3
 redirect_from: /licenses/lgpl-v3/
 source: http://www.gnu.org/licenses/lgpl-3.0.txt
+hidden: false
 
 description: Permissions of this copyleft license are conditioned on making available complete source code of licensed works and modifications under the same license or the GNU GPLv3. Copyright and license notices must be preserved. Contributors provide an express grant of patent rights. However, a larger work using the licensed work through interfaces provided by the licensed work may be distributed under different terms and without source code for the larger work.
 

--- a/_licenses/mit.txt
+++ b/_licenses/mit.txt
@@ -3,6 +3,7 @@ title: MIT License
 spdx-id: MIT
 source: https://opensource.org/licenses/MIT
 featured: true
+hidden: false
 
 description: A short and simple permissive license with conditions only requiring preservation of copyright and license notices. Licensed works, modifications, and larger works may be distributed under different terms and without source code.
 

--- a/_licenses/mpl-2.0.txt
+++ b/_licenses/mpl-2.0.txt
@@ -3,6 +3,7 @@ title: Mozilla Public License 2.0
 spdx-id: MPL-2.0
 redirect_from: /licenses/mozilla/
 source: https://www.mozilla.org/media/MPL/2.0/index.txt
+hidden: false
 
 description: Permissions of this weak copyleft license are conditioned on making available source code of licensed files and modifications of those files under the same license (or in certain cases, one of the GNU licenses). Copyright and license notices must be preserved. Contributors provide an express grant of patent rights. However, a larger work using the licensed work may be distributed under different terms and without source code for files added in the larger work.
 

--- a/_licenses/unlicense.txt
+++ b/_licenses/unlicense.txt
@@ -2,6 +2,7 @@
 title: The Unlicense
 spdx-id: Unlicense
 source: http://unlicense.org/UNLICENSE
+hidden: false
 
 description: A license with no conditions whatsoever which dedicates works to the public domain. Unlicensed works, modifications, and larger works may be distributed under different terms and without source code.
 

--- a/spec/license_shown_spec.rb
+++ b/spec/license_shown_spec.rb
@@ -1,0 +1,27 @@
+require 'spec_helper'
+
+describe 'shown licenses' do
+  # Whitelist of popular licenses that are shown (non-hidden)
+  # Note: most new licenses that are added should be hidden by default
+  SHOWN_LICENSES = %w(
+    agpl-3.0
+    apache-2.0
+    gpl-3.0
+    lgpl-3.0
+    mit
+    mpl-2.0
+    unlicense
+  ).freeze
+
+  it 'has the expected number of shown licenses' do
+    expect(shown_licenses.count).to eql(7)
+  end
+
+  shown_licenses.each do |license|
+    context "the #{license['title']} license" do
+      it 'is whitelisted to be shown' do
+        expect(SHOWN_LICENSES).to include(license['spdx-lcase'])
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -40,6 +40,10 @@ def licenses
   end
 end
 
+def shown_licenses
+  licenses.select { |l| !l['hidden'] }
+end
+
 def site
   SpecHelper.site ||= begin
     site = Jekyll::Site.new(config)


### PR DESCRIPTION
licenses on /licenses have `hidden: false` set

fixes #434
