### PR TITLE
zlib license

### DIFF
--- a/_licenses/zlib.txt
+++ b/_licenses/zlib.txt
@@ -1,0 +1,42 @@
+---
+title: zlib License
+spdx-id: Zlib
+source: https://opensource.org/licenses/Zlib
+
+description: A short permissive license, compatible with GPL. Requires altered source versions to be documented as such.
+
+how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file. Replace [year] with the current year and [fullname] with the name (or names) of the copyright holders.
+
+conditions:
+  - include-copyright
+  - document-changes
+
+permissions:
+  - commercial-use
+  - modifications
+  - distribution
+  - private-use
+
+limitations:
+  - no-liability
+---
+
+zlib License
+
+(C) [year] [fullname]
+
+This software is provided 'as-is', without any express or implied
+warranty.  In no event will the authors be held liable for any damages
+arising from the use of this software.
+
+Permission is granted to anyone to use this software for any purpose,
+including commercial applications, and to alter it and redistribute it
+freely, subject to the following restrictions:
+
+1. The origin of this software must not be misrepresented; you must not
+   claim that you wrote the original software. If you use this software
+   in a product, an acknowledgment in the product documentation would be
+   appreciated but is not required.
+2. Altered source versions must be plainly marked as such, and must not be
+   misrepresented as being the original software.
+3. This notice may not be removed or altered from any source distribution.


### PR DESCRIPTION
This pull request adds the Zlib license to choosealicense.com. It was first used by the zlib project (see the end of [its README](https://github.com/madler/zlib/blob/master/README)). It's now used by many other projects (e.g., certain syntax definitions for programming languages).

Requirements:
1. `Zlib` is the [SPDX identifier](https://spdx.org/licenses/Zlib.html).
2. Zlib is [part of the list of OSI approved licenses](https://opensource.org/licenses/Zlib) and [GNU's list of free licenses](https://www.gnu.org/licenses/license-list.en.html#ZLib).
3. [This GitHub search result](https://github.com/search?utf8=%E2%9C%93&q=misrepresented+%22Altered+versions%22+filename%3ALICENSE+%22commercial+applications%22&type=Code&ref=searchresults) displays ~2,830 Zlib licenses. I downloaded 2,534 of them, from which I counted 1,580 repositories (from 1,439 different users).
