### PR TITLE
Update docs: `using:` field value should be a link to LICENSE implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Licenses sit in the `/_licenses` folder. Each license has YAML front matter desc
 * `hidden` - Whether the license is hidden from the license list (defaults to true)
 * `nickname` - Customary short name if applicable (e.g, GPLv3)
 * `note` - Additional information about the licenses
-* `using` - A list of up to 3 notable projects using the license with straightforward LICENSE files which serve as examples newcomers can follow and that can be detected by [licensee](https://github.com/benbalter/licensee) in the form of `project_name: license-file-url`
+* `using` - A list of up to 3 notable projects using the license with straightforward LICENSE files which serve as examples newcomers can follow and that can be detected by [licensee](https://github.com/benbalter/licensee) in the form of `project_name: license_file_url`
 * `redirect_from` - Relative path(s) to redirect to the license from, to prevent breaking old URLs
 
 ### Auto-populated fields

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Licenses sit in the `/_licenses` folder. Each license has YAML front matter desc
 * `hidden` - Whether the license is hidden from the license list (defaults to true)
 * `nickname` - Customary short name if applicable (e.g, GPLv3)
 * `note` - Additional information about the licenses
-* `using` - A list of up to 3 notable projects using the license and a link to each of their LICENSE files in the form of `project_name: "url"`
+* `using` - A list of up to 3 notable projects using the license with straightforward LICENSE files which serve as examples newcomers can follow and that can be detected by [licensee](https://github.com/benbalter/licensee) in the form of `project_name: "license-file-url"`
 * `redirect_from` - Relative path(s) to redirect to the license from, to prevent breaking old URLs
 
 ### Auto-populated fields

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Licenses sit in the `/_licenses` folder. Each license has YAML front matter desc
 * `hidden` - Whether the license is hidden from the license list (defaults to true)
 * `nickname` - Customary short name if applicable (e.g, GPLv3)
 * `note` - Additional information about the licenses
-* `using` - A list of notable projects using the license in the form of `project_name: "url"`
+* `using` - A list of up to 3 notable projects using the license and a link to each of their LICENSE files in the form of `project_name: "url"`
 * `redirect_from` - Relative path(s) to redirect to the license from, to prevent breaking old URLs
 
 ### Auto-populated fields

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Licenses sit in the `/_licenses` folder. Each license has YAML front matter desc
 * `hidden` - Whether the license is hidden from the license list (defaults to true)
 * `nickname` - Customary short name if applicable (e.g, GPLv3)
 * `note` - Additional information about the licenses
-* `using` - A list of up to 3 notable projects using the license with straightforward LICENSE files which serve as examples newcomers can follow and that can be detected by [licensee](https://github.com/benbalter/licensee) in the form of `project_name: "license-file-url"`
+* `using` - A list of up to 3 notable projects using the license with straightforward LICENSE files which serve as examples newcomers can follow and that can be detected by [licensee](https://github.com/benbalter/licensee) in the form of `project_name: license-file-url`
 * `redirect_from` - Relative path(s) to redirect to the license from, to prevent breaking old URLs
 
 ### Auto-populated fields

--- a/_data/meta.yml
+++ b/_data/meta.yml
@@ -52,7 +52,7 @@
   required: false
 
 - name: using
-  description: 'A list of up to 3 notable projects using the license with straightforward LICENSE files which serve as examples newcomers can follow and that can be detected by [licensee](https://github.com/benbalter/licensee) in the form of `project_name: license-file-url`'
+  description: 'A list of up to 3 notable projects using the license with straightforward LICENSE files which serve as examples newcomers can follow and that can be detected by [licensee](https://github.com/benbalter/licensee) in the form of `project_name: license_file_url`'
   required: false
 
 - name: redirect_from

--- a/_data/meta.yml
+++ b/_data/meta.yml
@@ -52,7 +52,7 @@
   required: false
 
 - name: using
-  description: 'A list of notable projects using the license in the form of `project_name: "url"`'
+  description: 'A list of up to 3 notable projects using the license and a link to each of their LICENSE files in the form of `project_name: "url"`'
   required: false
 
 - name: redirect_from

--- a/_data/meta.yml
+++ b/_data/meta.yml
@@ -52,7 +52,7 @@
   required: false
 
 - name: using
-  description: 'A list of up to 3 notable projects using the license and a link to each of their LICENSE files in the form of `project_name: "url"`'
+  description: 'A list of up to 3 notable projects using the license with straightforward LICENSE files which serve as examples newcomers can follow and that can be detected by [licensee](https://github.com/benbalter/licensee) in the form of `project_name: "license-file-url"`'
   required: false
 
 - name: redirect_from

--- a/_data/meta.yml
+++ b/_data/meta.yml
@@ -52,7 +52,7 @@
   required: false
 
 - name: using
-  description: 'A list of up to 3 notable projects using the license with straightforward LICENSE files which serve as examples newcomers can follow and that can be detected by [licensee](https://github.com/benbalter/licensee) in the form of `project_name: "license-file-url"`'
+  description: 'A list of up to 3 notable projects using the license with straightforward LICENSE files which serve as examples newcomers can follow and that can be detected by [licensee](https://github.com/benbalter/licensee) in the form of `project_name: license-file-url`'
   required: false
 
 - name: redirect_from


### PR DESCRIPTION
Practice since #358 see #372 and #377 for examples.
