### PR TITLE
Fix source URL for ms-rl license

### DIFF
--- a/_licenses/ms-rl.txt
+++ b/_licenses/ms-rl.txt
@@ -2,7 +2,7 @@
 title: Microsoft Reciprocal License
 spdx-id: MS-RL
 
-source: http://opensource.org/licenses/ms-pl
+source: http://opensource.org/licenses/ms-rl
 
 description: An open source license with a patent grant similar to the <a href="/licenses/ms-pl/">Microsoft Public License</a>, with the additional condition that any source code for any derived file be provided under this license.
 


### PR DESCRIPTION
Currently points to the ms-pl license.
