### PR TITLE
hidden: false for 'popular' licenses

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Licenses sit in the `/_licenses` folder. Each license has YAML front matter desc
 #### Optional fields
 
 * `featured` - Whether the license should be featured on the main page (defaults to false)
-* `hidden` - Whether the license is hidden from the license list (defaults to true)
+* `hidden` - Whether the license is neither [popular](https://opensource.org/licenses) nor fills out the [spectrum of licenses](http://choosealicense.com/licenses/) from strongly conditional to unconditional (defaults to true)
 * `nickname` - Customary short name if applicable (e.g, GPLv3)
 * `note` - Additional information about the licenses
 * `using` - A list of up to 3 notable projects using the license with straightforward LICENSE files which serve as examples newcomers can follow and that can be detected by [licensee](https://github.com/benbalter/licensee) in the form of `project_name: license_file_url`

--- a/_data/meta.yml
+++ b/_data/meta.yml
@@ -40,7 +40,7 @@
   required: false
 
 - name: hidden
-  description: Whether the license is hidden from the license list (defaults to true)
+  description: Whether the license is neither [popular](https://opensource.org/licenses) nor fills out the [spectrum of licenses](http://choosealicense.com/licenses/) from strongly conditional to unconditional (defaults to true)
   required: false
 
 - name: nickname

--- a/_licenses/bsd-2-clause.txt
+++ b/_licenses/bsd-2-clause.txt
@@ -3,6 +3,7 @@ title: BSD 2-clause "Simplified" License
 spdx-id: BSD-2-Clause
 redirect_from: /licenses/bsd/
 source: http://opensource.org/licenses/BSD-2-Clause
+hidden: false
 
 description: A permissive license that comes in two variants, the <a href="/licenses/bsd-2-clause/">BSD 2-Clause</a> and <a href="/licenses/bsd-3-clause/">BSD 3-Clause</a>. Both have very minute differences to the MIT license.
 

--- a/_licenses/bsd-3-clause.txt
+++ b/_licenses/bsd-3-clause.txt
@@ -2,6 +2,7 @@
 title: BSD 3-clause "New" or "Revised" License
 spdx-id: BSD-3-Clause
 source: http://opensource.org/licenses/BSD-3-Clause
+hidden: false
 
 description: A permissive license similar to the <a href="/licenses/bsd-2-clause/">BSD 2-Clause License</a>, but with a 3rd clause that prohibits others from using the name of the project or its contributors to promote derived products without written consent.
 

--- a/_licenses/epl-1.0.txt
+++ b/_licenses/epl-1.0.txt
@@ -3,6 +3,7 @@ title: Eclipse Public License 1.0
 spdx-id: EPL-1.0
 redirect_from: /licenses/eclipse/
 source: https://www.eclipse.org/legal/epl-v10.html
+hidden: false
 
 description: This commercially-friendly copyleft license provides the ability to commercially license binaries; a modern royalty-free patent license grant; and the ability for linked works to use other licenses, including commercial ones.
 

--- a/_licenses/gpl-2.0.txt
+++ b/_licenses/gpl-2.0.txt
@@ -4,6 +4,7 @@ spdx-id: GPL-2.0
 nickname: GNU GPLv2
 redirect_from: /licenses/gpl-v2/
 source: http://www.gnu.org/licenses/gpl-2.0.txt
+hidden: false
 
 description: The GNU GPL is the most widely used free software license and has a strong copyleft requirement. When distributing derived works, the source code of the work must be made available under the same license. There are multiple variants of the GNU GPL, each with different requirements.
 

--- a/_licenses/lgpl-2.1.txt
+++ b/_licenses/lgpl-2.1.txt
@@ -4,6 +4,7 @@ spdx-id: LGPL-2.1
 nickname: GNU LGPLv2.1
 redirect_from: /licenses/lgpl-v2.1/
 source: http://www.gnu.org/licenses/lgpl-2.1.txt
+hidden: false
 
 description: Primarily used for software libraries, the GNU LGPL requires that derived works be licensed under the same license, but works that only link to it do not fall under this restriction. There are two commonly used versions of the GNU LGPL.
 

--- a/spec/license_shown_spec.rb
+++ b/spec/license_shown_spec.rb
@@ -6,7 +6,12 @@ describe 'shown licenses' do
   SHOWN_LICENSES = %w(
     agpl-3.0
     apache-2.0
+    bsd-2-clause
+    bsd-3-clause
+    epl-1.0
+    gpl-2.0
     gpl-3.0
+    lgpl-2.1
     lgpl-3.0
     mit
     mpl-2.0
@@ -14,7 +19,7 @@ describe 'shown licenses' do
   ).freeze
 
   it 'has the expected number of shown licenses' do
-    expect(shown_licenses.count).to eql(7)
+    expect(shown_licenses.count).to eql(12)
   end
 
   shown_licenses.each do |license|


### PR DESCRIPTION
- document criteria for whether a license is hidden
  - needed for license spectrum on /licenses OR
  - on 'popular' list at https://opensource.org/licenses (some other list could be used in the future)
- adjust license properties and tests accordingly

This gets non-hidden list back close to what it was before #386 and (pending licensee vendoring this change, licensee release, and github.com licensee dependency version bump) some commonly requested licenses (eg #413 #449) will reappear in the github.com license drop-down.

cc @arfon 
