### PR TITLE
New home for John Cowan's license selection wizard

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,14 +8,14 @@ gem 'github-pages', versions['github-pages']
 
 group :development do
   gem 'colored'
-  gem 'terminal-table'
   gem 'fuzzy_match'
+  gem 'terminal-table'
 end
 
 group :test do
   gem 'html-proofer', '~> 3.0'
+  gem 'nokogiri'
   gem 'rake'
   gem 'rspec'
-  gem 'nokogiri'
   gem 'rubocop'
 end

--- a/about.md
+++ b/about.md
@@ -23,7 +23,7 @@ See our [appendix](/appendix) for a table of all of the licenses cataloged in th
 * Linux Foundation's [SPDX License List](https://spdx.org/licenses/)
 * [Comparison of free and open-source software licenses](https://en.wikipedia.org/wiki/Comparison_of_free_and_open-source_software_licenses) on English Wikipedia
 * [License differentiator](http://www.oss-watch.ac.uk/apps/licdiff/) ([source](https://github.com/ox-it/licdiff)) from [OSS Watch](http://www.oss-watch.ac.uk/)
-* [Free/Libre/Open Source license selection wizard](http://web.archive.org/web/20160801055258/http://home.ccil.org/~cowan/floss/) by John Cowan
+* [Free/Libre/Open Source license selection wizard](http://vrici.lojban.org/~cowan/floss/) by John Cowan
 
 ## Help us improve it
 


### PR DESCRIPTION
Waybacked in https://github.com/github/choosealicense.com/commit/c008a5fbef641d49c83d5d61a8a5c66428efeb40, Cowan now has a new home, updating to that.