### PR TITLE
add closed-source permission

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ The license properties (rules) are stored as a bulleted list within the licenses
 
 #### Permissions
 
-* `closed-derivatives` - You may distribute proprietary software based on this software. Pay very close attention to license conditions, especially _same license_, if present, to understand when this permission applies.
+* `closed-derivatives` - You may distribute proprietary derivatives of this software. Pay very close attention to license conditions, especially _same license_, if present, to understand when this permission applies.
 * `commercial-use` - This software and derivatives may be used for commercial purposes.
 * `modifications` - This software may be modified.
 * `distribution` - You may distribute this software.

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ The license properties (rules) are stored as a bulleted list within the licenses
 
 #### Permissions
 
-* `closed-source` - You may distribute closed source software based on this software. Pay very close attention to license conditions, especially _same license_, if present, to understand when this permission applies.
+* `closed-derivatives` - You may distribute proprietary software based on this software. Pay very close attention to license conditions, especially _same license_, if present, to understand when this permission applies.
 * `commercial-use` - This software and derivatives may be used for commercial purposes.
 * `modifications` - This software may be modified.
 * `distribution` - You may distribute this software.

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ The license properties (rules) are stored as a bulleted list within the licenses
 * `document-changes` - Indicate changes made to the code.
 * `disclose-source` - Source code must be made available when distributing the software.
 * `network-use-disclose` - Users who interact with the software via network are given the right to receive a copy of the corresponding source code.
-* `same-license` - Modifications must be released under the same license when distributing the software. In some cases a similar or related license may be used or this condition may only apply to certain kinds of modificaitons.
+* `same-license` - Modifications must be released under the same license when distributing the software. In some cases a similar or related license may be used or this condition may only apply to certain kinds of modifications.
 
 #### Limitations
 

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ The license properties (rules) are stored as a bulleted list within the licenses
 
 #### Permissions
 
+* `closed-source` - You may distribute closed source software based on this software. Pay very close attention to license conditions, especially _same license_, if present, to understand when this permission applies.
 * `commercial-use` - This software and derivatives may be used for commercial purposes.
 * `modifications` - This software may be modified.
 * `distribution` - You may distribute this software.
@@ -90,7 +91,7 @@ The license properties (rules) are stored as a bulleted list within the licenses
 * `document-changes` - Indicate changes made to the code.
 * `disclose-source` - Source code must be made available when distributing the software.
 * `network-use-disclose` - Users who interact with the software via network are given the right to receive a copy of the corresponding source code.
-* `same-license` - Modifications must be released under the same license when distributing the software. In some cases a similar or related license may be used.
+* `same-license` - Modifications must be released under the same license when distributing the software. In some cases a similar or related license may be used or this condition may only apply to certain kinds of modificaitons.
 
 #### Limitations
 

--- a/_data/rules.yml
+++ b/_data/rules.yml
@@ -6,7 +6,7 @@ permissions:
   label: Modification
   tag: modifications
 - description: You may distribute closed source software based on this software. Pay very close attention to license conditions, especially 'same license', if present, to understand when this permission applies.
-  label: Closed Source Derivatives
+  label: Closed Source
   tag: closed-source
 - description: You may distribute this software.
   label: Distribution

--- a/_data/rules.yml
+++ b/_data/rules.yml
@@ -5,7 +5,7 @@ permissions:
 - description: This software may be modified.
   label: Modification
   tag: modifications
-- description: You may distribute proprietary software based on this software. Pay very close attention to license conditions, especially 'same license', if present, to understand when this permission applies.
+- description: You may distribute proprietary derivatives of this software. Pay very close attention to license conditions, especially 'same license', if present, to understand when this permission applies.
   label: Closed Derivatives
   tag: closed-derivatives
 - description: You may distribute this software.

--- a/_data/rules.yml
+++ b/_data/rules.yml
@@ -31,7 +31,7 @@ conditions:
 - description: Users who interact with the software via network are given the right to receive a copy of the corresponding source code.
   label: Network Use is Distribution
   tag: network-use-disclose
-- description: In some cases a similar or related license may be used or this condition may only apply to certain kinds of modifications.
+- description: Modifications must be released under the same license when distributing the software. In some cases a similar or related license may be used or this condition may only apply to certain kinds of modifications.
   label: Same License
   tag: same-license
 

--- a/_data/rules.yml
+++ b/_data/rules.yml
@@ -5,6 +5,9 @@ permissions:
 - description: This software may be modified.
   label: Modification
   tag: modifications
+- description: You may distribute closed source software based on this software. Pay very close attention to license conditions, especially 'same license', if present, to understand when this permission applies.
+  label: Closed Source Derivatives
+  tag: closed-source
 - description: You may distribute this software.
   label: Distribution
   tag: distribution
@@ -28,7 +31,7 @@ conditions:
 - description: Users who interact with the software via network are given the right to receive a copy of the corresponding source code.
   label: Network Use is Distribution
   tag: network-use-disclose
-- description: Modifications must be released under the same license when distributing the software. In some cases a similar or related license may be used.
+- description: In some cases a similar or related license may be used or this condition may only apply to certain kinds of modificaitons.
   label: Same License
   tag: same-license
 

--- a/_data/rules.yml
+++ b/_data/rules.yml
@@ -5,9 +5,9 @@ permissions:
 - description: This software may be modified.
   label: Modification
   tag: modifications
-- description: You may distribute closed source software based on this software. Pay very close attention to license conditions, especially 'same license', if present, to understand when this permission applies.
-  label: Closed Source
-  tag: closed-source
+- description: You may distribute proprietary software based on this software. Pay very close attention to license conditions, especially 'same license', if present, to understand when this permission applies.
+  label: Closed Derivatives
+  tag: closed-derivatives
 - description: You may distribute this software.
   label: Distribution
   tag: distribution

--- a/_data/rules.yml
+++ b/_data/rules.yml
@@ -31,7 +31,7 @@ conditions:
 - description: Users who interact with the software via network are given the right to receive a copy of the corresponding source code.
   label: Network Use is Distribution
   tag: network-use-disclose
-- description: In some cases a similar or related license may be used or this condition may only apply to certain kinds of modificaitons.
+- description: In some cases a similar or related license may be used or this condition may only apply to certain kinds of modifications.
   label: Same License
   tag: same-license
 

--- a/_licenses/afl-3.0.txt
+++ b/_licenses/afl-3.0.txt
@@ -8,6 +8,7 @@ description: The Academic Free License is a variant of the Open Software License
 how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file. Files licensed under AFL 3.0 must also include the notice "Licensed under the Academic Free License version 3.0" adjacent to the copyright notice.
 
 permissions:
+  - closed-source
   - commercial-use
   - modifications
   - distribution

--- a/_licenses/afl-3.0.txt
+++ b/_licenses/afl-3.0.txt
@@ -8,7 +8,7 @@ description: The Academic Free License is a variant of the Open Software License
 how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file. Files licensed under AFL 3.0 must also include the notice "Licensed under the Academic Free License version 3.0" adjacent to the copyright notice.
 
 permissions:
-  - closed-source
+  - closed-derivatives
   - commercial-use
   - modifications
   - distribution

--- a/_licenses/apache-2.0.txt
+++ b/_licenses/apache-2.0.txt
@@ -18,7 +18,7 @@ using:
   - Swift: https://github.com/apple/swift/blob/master/LICENSE.txt
 
 permissions:
-  - closed-source
+  - closed-derivatives
   - commercial-use
   - modifications
   - distribution

--- a/_licenses/apache-2.0.txt
+++ b/_licenses/apache-2.0.txt
@@ -18,6 +18,7 @@ using:
   - Swift: https://github.com/apple/swift/blob/master/LICENSE.txt
 
 permissions:
+  - closed-source
   - commercial-use
   - modifications
   - distribution

--- a/_licenses/artistic-2.0.txt
+++ b/_licenses/artistic-2.0.txt
@@ -9,7 +9,7 @@ description: Heavily favored by the Perl community, the Artistic license require
 how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code, and copy the text of the license into the file. Do not replace the copyright notice (year, author), which refers to the license itself, not the licensed project.
 
 permissions:
-  - closed-source
+  - closed-derivatives
   - commercial-use
   - modifications
   - distribution

--- a/_licenses/artistic-2.0.txt
+++ b/_licenses/artistic-2.0.txt
@@ -9,6 +9,7 @@ description: Heavily favored by the Perl community, the Artistic license require
 how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code, and copy the text of the license into the file. Do not replace the copyright notice (year, author), which refers to the license itself, not the licensed project.
 
 permissions:
+  - closed-source
   - commercial-use
   - modifications
   - distribution
@@ -135,7 +136,7 @@ you do at least ONE of the following:
     (c)  allow anyone who receives a copy of the Modified Version to
     make the Source form of the Modified Version available to others
     under
-		
+
 	(i)  the Original License or
 
 	(ii)  a license that permits the licensee to freely copy,

--- a/_licenses/bsd-2-clause.txt
+++ b/_licenses/bsd-2-clause.txt
@@ -10,6 +10,7 @@ description: A permissive license that comes in two variants, the <a href="/lice
 how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file. Replace [year] with the current year and [fullname] with the name (or names) of the copyright holders.
 
 permissions:
+  - closed-source
   - commercial-use
   - modifications
   - distribution

--- a/_licenses/bsd-2-clause.txt
+++ b/_licenses/bsd-2-clause.txt
@@ -10,7 +10,7 @@ description: A permissive license that comes in two variants, the <a href="/lice
 how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file. Replace [year] with the current year and [fullname] with the name (or names) of the copyright holders.
 
 permissions:
-  - closed-source
+  - closed-derivatives
   - commercial-use
   - modifications
   - distribution

--- a/_licenses/bsd-3-clause-clear.txt
+++ b/_licenses/bsd-3-clause-clear.txt
@@ -8,7 +8,7 @@ description: A variant of the <a href="/licenses/bsd-3-clause/">BSD 3-Clause Lic
 how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file. Replace [year] with the current year and [fullname] with the name (or names) of the copyright holders. Replace [project] with the project organization, if any, that sponsors this work.
 
 permissions:
-  - closed-source
+  - closed-derivatives
   - commercial-use
   - modifications
   - distribution

--- a/_licenses/bsd-3-clause-clear.txt
+++ b/_licenses/bsd-3-clause-clear.txt
@@ -8,6 +8,7 @@ description: A variant of the <a href="/licenses/bsd-3-clause/">BSD 3-Clause Lic
 how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file. Replace [year] with the current year and [fullname] with the name (or names) of the copyright holders. Replace [project] with the project organization, if any, that sponsors this work.
 
 permissions:
+  - closed-source
   - commercial-use
   - modifications
   - distribution

--- a/_licenses/bsd-3-clause.txt
+++ b/_licenses/bsd-3-clause.txt
@@ -9,7 +9,7 @@ description: A permissive license similar to the <a href="/licenses/bsd-2-clause
 how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file. Replace [year] with the current year and [fullname] with the name (or names) of the copyright holders. Replace [project] with the project organization, if any, that sponsors this work.
 
 permissions:
-  - closed-source
+  - closed-derivatives
   - commercial-use
   - modifications
   - distribution

--- a/_licenses/bsd-3-clause.txt
+++ b/_licenses/bsd-3-clause.txt
@@ -9,6 +9,7 @@ description: A permissive license similar to the <a href="/licenses/bsd-2-clause
 how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file. Replace [year] with the current year and [fullname] with the name (or names) of the copyright holders. Replace [project] with the project organization, if any, that sponsors this work.
 
 permissions:
+  - closed-source
   - commercial-use
   - modifications
   - distribution

--- a/_licenses/bsl-1.0.txt
+++ b/_licenses/bsl-1.0.txt
@@ -10,7 +10,7 @@ how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of 
 note: Boost recommends taking the additional step of adding a boilerplate notice to the top of each file. The boilerplate can be found at the [Boost Software License FAQ](http://www.boost.org/users/license.html#FAQ).
 
 permissions:
-  - closed-source
+  - closed-derivatives
   - commercial-use
   - modifications
   - distribution

--- a/_licenses/bsl-1.0.txt
+++ b/_licenses/bsl-1.0.txt
@@ -10,6 +10,7 @@ how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of 
 note: Boost recommends taking the additional step of adding a boilerplate notice to the top of each file. The boilerplate can be found at the [Boost Software License FAQ](http://www.boost.org/users/license.html#FAQ).
 
 permissions:
+  - closed-source
   - commercial-use
   - modifications
   - distribution

--- a/_licenses/cc-by-4.0.txt
+++ b/_licenses/cc-by-4.0.txt
@@ -8,7 +8,7 @@ description: Permits almost any use subject to providing credit and license noti
 how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file. It is also acceptable to soley supply a link to a copy of the license, usually to the <a href='https://creativecommons.org/licenses/by/4.0/'>canonical URL for the license</a>.
 
 permissions:
-  - closed-source
+  - closed-derivatives
   - commercial-use
   - modifications
   - distribution

--- a/_licenses/cc-by-4.0.txt
+++ b/_licenses/cc-by-4.0.txt
@@ -8,6 +8,7 @@ description: Permits almost any use subject to providing credit and license noti
 how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file. It is also acceptable to soley supply a link to a copy of the license, usually to the <a href='https://creativecommons.org/licenses/by/4.0/'>canonical URL for the license</a>.
 
 permissions:
+  - closed-source
   - commercial-use
   - modifications
   - distribution
@@ -75,7 +76,7 @@ exhaustive, and do not form part of our licenses.
      such as asking that all changes be marked or described.
      Although not required by our licenses, you are encouraged to
      respect those requests where reasonable. More_considerations
-     for the public: 
+     for the public:
 	wiki.creativecommons.org/Considerations_for_licensees
 
 =======================================================================

--- a/_licenses/cc0-1.0.txt
+++ b/_licenses/cc0-1.0.txt
@@ -11,7 +11,7 @@ how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of 
 note: Creative Commons recommends taking the additional step of adding a boilerplate notice to the top of each file. The boilerplate can be <a href="https://wiki.creativecommons.org/wiki/CC0_FAQ#May_I_apply_CC0_to_computer_software.3F_If_so.2C_is_there_a_recommended_implementation.3F">found on their website</a>.
 
 permissions:
-  - closed-source
+  - closed-derivatives
   - commercial-use
   - modifications
   - distribution

--- a/_licenses/cc0-1.0.txt
+++ b/_licenses/cc0-1.0.txt
@@ -11,6 +11,7 @@ how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of 
 note: Creative Commons recommends taking the additional step of adding a boilerplate notice to the top of each file. The boilerplate can be <a href="https://wiki.creativecommons.org/wiki/CC0_FAQ#May_I_apply_CC0_to_computer_software.3F_If_so.2C_is_there_a_recommended_implementation.3F">found on their website</a>.
 
 permissions:
+  - closed-source
   - commercial-use
   - modifications
   - distribution

--- a/_licenses/epl-1.0.txt
+++ b/_licenses/epl-1.0.txt
@@ -15,6 +15,7 @@ using:
   - openHAB: https://github.com/openhab/openhab/blob/master/LICENSE.TXT
 
 permissions:
+  - closed-source
   - commercial-use
   - distribution
   - modifications

--- a/_licenses/epl-1.0.txt
+++ b/_licenses/epl-1.0.txt
@@ -15,7 +15,7 @@ using:
   - openHAB: https://github.com/openhab/openhab/blob/master/LICENSE.TXT
 
 permissions:
-  - closed-source
+  - closed-derivatives
   - commercial-use
   - distribution
   - modifications

--- a/_licenses/isc.txt
+++ b/_licenses/isc.txt
@@ -13,6 +13,7 @@ using:
   - OpenStreetMap iD: https://github.com/openstreetmap/iD/blob/master/LICENSE
 
 permissions:
+  - closed-source
   - commercial-use
   - distribution
   - modifications

--- a/_licenses/isc.txt
+++ b/_licenses/isc.txt
@@ -13,7 +13,7 @@ using:
   - OpenStreetMap iD: https://github.com/openstreetmap/iD/blob/master/LICENSE
 
 permissions:
-  - closed-source
+  - closed-derivatives
   - commercial-use
   - distribution
   - modifications

--- a/_licenses/lgpl-2.1.txt
+++ b/_licenses/lgpl-2.1.txt
@@ -13,7 +13,7 @@ how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of 
 note: The Free Software Foundation recommends taking the additional step of adding a boilerplate notice to the top of each file. The boilerplate can be found at the end of the license.
 
 permissions:
-  - closed-source
+  - closed-derivatives
   - commercial-use
   - modifications
   - distribution

--- a/_licenses/lgpl-2.1.txt
+++ b/_licenses/lgpl-2.1.txt
@@ -13,6 +13,7 @@ how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of 
 note: The Free Software Foundation recommends taking the additional step of adding a boilerplate notice to the top of each file. The boilerplate can be found at the end of the license.
 
 permissions:
+  - closed-source
   - commercial-use
   - modifications
   - distribution

--- a/_licenses/lgpl-3.0.txt
+++ b/_licenses/lgpl-3.0.txt
@@ -13,7 +13,7 @@ how: This license is an additional set of permissions to the <a href="/licenses/
 note: The Free Software Foundation recommends taking the additional step of adding a boilerplate notice to the top of each file. The boilerplate can be found at the end of the <a href="/licenses/gpl-3.0">GNU GPLv3 license</a>. Insert the word “Lesser” before “General” in all three places in the boilerplate notice to make sure that you refer to the GNU LGPLv3 and not the GNU GPLv3.
 
 permissions:
-  - closed-source
+  - closed-derivatives
   - commercial-use
   - modifications
   - distribution

--- a/_licenses/lgpl-3.0.txt
+++ b/_licenses/lgpl-3.0.txt
@@ -13,6 +13,7 @@ how: This license is an additional set of permissions to the <a href="/licenses/
 note: The Free Software Foundation recommends taking the additional step of adding a boilerplate notice to the top of each file. The boilerplate can be found at the end of the <a href="/licenses/gpl-3.0">GNU GPLv3 license</a>. Insert the word “Lesser” before “General” in all three places in the boilerplate notice to make sure that you refer to the GNU LGPLv3 and not the GNU GPLv3.
 
 permissions:
+  - closed-source
   - commercial-use
   - modifications
   - distribution

--- a/_licenses/lppl-1.3c.txt
+++ b/_licenses/lppl-1.3c.txt
@@ -10,7 +10,7 @@ how: To use this license, place in each of the components of your work both an e
 note: An example boilerplate and more information about how to use the license can be found at the end of the license.
 
 permissions:
-  - closed-source
+  - closed-derivatives
   - commercial-use
   - modifications
   - distribution

--- a/_licenses/lppl-1.3c.txt
+++ b/_licenses/lppl-1.3c.txt
@@ -3,13 +3,14 @@ title: LaTeX Project Public License v1.3c
 spdx-id: LPPL-1.3c
 source: https://latex-project.org/lppl/lppl-1-3c.html
 
-description: The LaTeX Project Public License (LPPL) is the primary license under which the LaTeX kernel and the base LaTeX packages are distributed. 
+description: The LaTeX Project Public License (LPPL) is the primary license under which the LaTeX kernel and the base LaTeX packages are distributed.
 
 how: To use this license, place in each of the components of your work both an explicit copyright notice including your name and the year the work was authored and/or last substantially modified. Include also a statement that the distribution and/or modification of that component is constrained by the conditions in this license.
 
 note: An example boilerplate and more information about how to use the license can be found at the end of the license.
 
 permissions:
+  - closed-source
   - commercial-use
   - modifications
   - distribution
@@ -17,9 +18,9 @@ permissions:
 
 conditions:
   - include-copyright
-  - document-changes 
+  - document-changes
   - disclose-source
-  
+
 limitations:
   - no-liability
 
@@ -43,8 +44,8 @@ which the LaTeX kernel and the base LaTeX packages are distributed.
 
 You may use this license for any work of which you hold the copyright
 and which you wish to distribute.  This license may be particularly
-suitable if your work is TeX-related (such as a LaTeX package), but 
-it is written in such a way that you can use it even if your work is 
+suitable if your work is TeX-related (such as a LaTeX package), but
+it is written in such a way that you can use it even if your work is
 unrelated to TeX.
 
 The section `WHETHER AND HOW TO DISTRIBUTE WORKS UNDER THIS LICENSE',
@@ -71,11 +72,11 @@ In this license document the following terms are used:
 
    `Work'
     Any work being distributed under this License.
-    
+
    `Derived Work'
     Any work that under any applicable law is derived from the Work.
 
-   `Modification' 
+   `Modification'
     Any procedure that produces a Derived Work under any applicable
     law -- for example, the production of a file containing an
     original file associated with the Work or a significant portion of
@@ -85,7 +86,7 @@ In this license document the following terms are used:
    `Modify'
     To apply any procedure that produces a Derived Work under any
     applicable law.
-    
+
    `Distribution'
     Making copies of the Work available from one person to another, in
     whole or in part.  Distribution includes (but is not limited to)
@@ -106,16 +107,16 @@ In this license document the following terms are used:
     no such explicit nomination then it is the `Copyright Holder' under
     any applicable law.
 
-   `Base Interpreter' 
+   `Base Interpreter'
     A program or process that is normally needed for running or
-    interpreting a part or the whole of the Work.    
+    interpreting a part or the whole of the Work.
 
     A Base Interpreter may depend on external components but these
     are not considered part of the Base Interpreter provided that each
     external component clearly identifies itself whenever it is used
     interactively.  Unless explicitly specified when applying the
     license to the Work, the only applicable Base Interpreter is a
-    `LaTeX-Format' or in the case of files belonging to the 
+    `LaTeX-Format' or in the case of files belonging to the
     `LaTeX-format' a program implementing the `TeX language'.
 
 
@@ -156,8 +157,8 @@ the Derived Work.
 distribute a Derived Work provided the following conditions are met
 for every component of the Work unless that component clearly states
 in the copyright notice that it is exempt from that condition.  Only
-the Current Maintainer is allowed to add such statements of exemption 
-to a component of the Work. 
+the Current Maintainer is allowed to add such statements of exemption
+to a component of the Work.
 
   a. If a component of this Derived Work can be a direct replacement
      for a component of the Work when that component is used with the
@@ -167,13 +168,13 @@ to a component of the Work.
      clearly and unambiguously identifies itself as a modified version
      of this component to the user when used interactively with that
      Base Interpreter.
-     
+
   b. Every component of the Derived Work contains prominent notices
      detailing the nature of the changes to that component, or a
      prominent reference to another file that is distributed as part
      of the Derived Work and that contains a complete and accurate log
      of the changes.
-  
+
   c. No information in the Derived Work implies that any persons,
      including (but not limited to) the authors of the original version
      of the Work, provide any support, including (but not limited to)
@@ -183,7 +184,7 @@ to a component of the Work.
 
   d. You distribute at least one of the following with the Derived Work:
 
-       1. A complete, unmodified copy of the Work; 
+       1. A complete, unmodified copy of the Work;
           if your distribution of a modified component is made by
           offering access to copy the modified component from a
           designated place, then offering equivalent access to copy
@@ -210,15 +211,15 @@ format, where the Work or that Derived Work (in whole or in part) is
 then produced by applying some process to that format, does not relax or
 nullify any sections of this license as they pertain to the results of
 applying that process.
-     
+
 10. a. A Derived Work may be distributed under a different license
        provided that license itself honors the conditions listed in
        Clause 6 above, in regard to the Work, though it does not have
        to honor the rest of the conditions in this license.
-      
+
     b. If a Derived Work is distributed under a different license, that
        Derived Work must provide sufficient documentation as part of
-       itself to allow each recipient of that Derived Work to honor the 
+       itself to allow each recipient of that Derived Work to honor the
        restrictions in Clause 6 above, concerning changes from the Work.
 
 11. This license places no restrictions on works that are unrelated to
@@ -287,7 +288,7 @@ the Work through the following steps:
 
   a. If it is being maintained, then ask the Current Maintainer
      to update their communication data within one month.
-     
+
   b. If the search is unsuccessful or no action to resume active
      maintenance is taken by the Current Maintainer, then announce
      within the pertinent community your intention to take over
@@ -297,17 +298,17 @@ the Work through the following steps:
  3a. If the Current Maintainer is reachable and agrees to pass
      maintenance of the Work to you, then this takes effect
      immediately upon announcement.
-     
+
   b. If the Current Maintainer is not reachable and the Copyright
      Holder agrees that maintenance of the Work be passed to you,
-     then this takes effect immediately upon announcement.  
-    
+     then this takes effect immediately upon announcement.
+
  4.  If you make an `intention announcement' as described in 2b. above
      and after three months your intention is challenged neither by
      the Current Maintainer nor by the Copyright Holder nor by other
      people, then you may arrange for the Work to be changed so as
      to name you as the (new) Current Maintainer.
-     
+
  5.  If the previously unreachable Current Maintainer becomes
      reachable once more within three months of a change completed
      under the terms of 3b) or 4), then that Current Maintainer must
@@ -390,7 +391,7 @@ Here is an example of such a notice and statement:
   % version 2005/12/01 or later.
   %
   % This work has the LPPL maintenance status `maintained'.
-  % 
+  %
   % The Current Maintainer of this work is M. Y. Name.
   %
   % This work consists of the files pig.dtx and pig.ins
@@ -404,7 +405,7 @@ referring to any `LaTeX-Format', and both `Copyright Holder' and
 `Current Maintainer' referring to the person `M. Y. Name'.
 
 If you do not want the Maintenance section of LPPL to apply to your
-Work, change `maintained' above into `author-maintained'.  
+Work, change `maintained' above into `author-maintained'.
 However, we recommend that you use `maintained', as the Maintenance
 section was added in order to ensure that your Work remains useful to
 the community even when you can no longer maintain and support it
@@ -434,10 +435,9 @@ Important Recommendations
    using a line such as:
 
     % This work consists of all files listed in manifest.txt.
-   
+
    in that place.  In the absence of an unequivocal list it might be
    impossible for the licensee to determine what is considered by you
    to comprise the Work and, in such a case, the licensee would be
    entitled to make reasonable conjectures as to which files comprise
    the Work.
-

--- a/_licenses/mit.txt
+++ b/_licenses/mit.txt
@@ -15,6 +15,7 @@ using:
   - Rails: https://github.com/rails/rails/blob/master/activerecord/MIT-LICENSE
 
 permissions:
+  - closed-source
   - commercial-use
   - modifications
   - distribution

--- a/_licenses/mit.txt
+++ b/_licenses/mit.txt
@@ -15,7 +15,7 @@ using:
   - Rails: https://github.com/rails/rails/blob/master/activerecord/MIT-LICENSE
 
 permissions:
-  - closed-source
+  - closed-derivatives
   - commercial-use
   - modifications
   - distribution

--- a/_licenses/mpl-2.0.txt
+++ b/_licenses/mpl-2.0.txt
@@ -17,6 +17,7 @@ using:
   - LibreOffice: https://cgit.freedesktop.org/libreoffice/core/tree/COPYING.MPL
 
 permissions:
+  - closed-source
   - commercial-use
   - modifications
   - distribution

--- a/_licenses/mpl-2.0.txt
+++ b/_licenses/mpl-2.0.txt
@@ -17,7 +17,7 @@ using:
   - LibreOffice: https://cgit.freedesktop.org/libreoffice/core/tree/COPYING.MPL
 
 permissions:
-  - closed-source
+  - closed-derivatives
   - commercial-use
   - modifications
   - distribution

--- a/_licenses/ms-pl.txt
+++ b/_licenses/ms-pl.txt
@@ -8,7 +8,7 @@ description: An open source license with a patent grant.
 how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file.
 
 permissions:
-  - closed-source
+  - closed-derivatives
   - commercial-use
   - modifications
   - distribution

--- a/_licenses/ms-pl.txt
+++ b/_licenses/ms-pl.txt
@@ -8,6 +8,7 @@ description: An open source license with a patent grant.
 how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file.
 
 permissions:
+  - closed-source
   - commercial-use
   - modifications
   - distribution

--- a/_licenses/ms-rl.txt
+++ b/_licenses/ms-rl.txt
@@ -8,6 +8,7 @@ description: An open source license with a patent grant similar to the <a href="
 how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file.
 
 permissions:
+  - closed-source
   - commercial-use
   - modifications
   - distribution

--- a/_licenses/ms-rl.txt
+++ b/_licenses/ms-rl.txt
@@ -8,7 +8,7 @@ description: An open source license with a patent grant similar to the <a href="
 how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file.
 
 permissions:
-  - closed-source
+  - closed-derivatives
   - commercial-use
   - modifications
   - distribution

--- a/_licenses/unlicense.txt
+++ b/_licenses/unlicense.txt
@@ -14,7 +14,7 @@ using:
   - kakoune: https://github.com/mawww/kakoune/blob/master/UNLICENSE
 
 permissions:
-  - closed-source
+  - closed-derivatives
   - private-use
   - commercial-use
   - modifications

--- a/_licenses/unlicense.txt
+++ b/_licenses/unlicense.txt
@@ -14,6 +14,7 @@ using:
   - kakoune: https://github.com/mawww/kakoune/blob/master/UNLICENSE
 
 permissions:
+  - closed-source
   - private-use
   - commercial-use
   - modifications

--- a/_licenses/wtfpl.txt
+++ b/_licenses/wtfpl.txt
@@ -8,6 +8,7 @@ description: The easiest license out there. It gives the user permissions to do 
 how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file.
 
 permissions:
+  - closed-source
   - commercial-use
   - modifications
   - distribution

--- a/_licenses/wtfpl.txt
+++ b/_licenses/wtfpl.txt
@@ -8,7 +8,7 @@ description: The easiest license out there. It gives the user permissions to do 
 how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file.
 
 permissions:
-  - closed-source
+  - closed-derivatives
   - commercial-use
   - modifications
   - distribution

--- a/_licenses/zlib.txt
+++ b/_licenses/zlib.txt
@@ -8,7 +8,7 @@ description: A short permissive license, compatible with GPL. Requires altered s
 how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file. Replace [year] with the current year and [fullname] with the name (or names) of the copyright holders.
 
 permissions:
-  - closed-source
+  - closed-derivatives
   - commercial-use
   - modifications
   - distribution

--- a/_licenses/zlib.txt
+++ b/_licenses/zlib.txt
@@ -8,6 +8,7 @@ description: A short permissive license, compatible with GPL. Requires altered s
 how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file. Replace [year] with the current year and [fullname] with the name (or names) of the copyright holders.
 
 permissions:
+  - closed-source
   - commercial-use
   - modifications
   - distribution


### PR DESCRIPTION
Present for all licenses except strong copyleft ones (weak copyleft ones have this permission and same-license condition), attenuation left to description.

Fixes #410 (model l/gpl differences) while keeping completely flat/unqualified tags, simplified version of option (1) there.

Also exposes most practical licensing consideration (whether work can be used to make closed source applications), presently only mentioned in free-form license descriptions.

I'm not particularly committed to this, it is just the simplest option to to fix #410. Feedback wanted.