### PR TITLE
Update ruby version in travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ script: "./script/cibuild"
 #environment
 language: ruby
 rvm:
-  - 2.1.0
+  - 2.3.3
 
 branches:
   only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ script: "./script/cibuild"
 #environment
 language: ruby
 rvm:
-  - 2.0.0
+  - 2.1.0
 
 branches:
   only:


### PR DESCRIPTION
Nokogiri requires ruby >= 2.1.0 to be used, and fails to complete travis build