### PR TITLE
Putdown one-use downcase script

### DIFF
--- a/script/downcase
+++ b/script/downcase
@@ -1,7 +1,0 @@
-#! /usr/bin/env ruby
-# downcases all licenses in a git-friendly way
-
-Dir['_licenses/*'].each do |file|
-  system "git mv #{file} #{file.downcase}2"
-  system "git mv #{file.downcase}2 #{file.downcase}"
-end


### PR DESCRIPTION
Seems to be one-time use https://github.com/github/choosealicense.com/pull/221 and doesn't need to stick around.

Side note: I wondered what was going on with the double rename. I guess to make work with case insensitive file systems, which I had forgotten about.