### PR TITLE
Check images for consistent use of http/https

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,8 +1,11 @@
 AllCops:
-  TargetRubyVersion: 2.1
+  TargetRubyVersion: 2.3
   Exclude:
     - _site/**/*
     - vendor/**/*
+
+Metrics/BlockLength:
+  Enabled: false
 
 Metrics/LineLength:
   Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 2.3
+  TargetRubyVersion: 2.1
   Exclude:
     - _site/**/*
     - vendor/**/*

--- a/Rakefile
+++ b/Rakefile
@@ -13,7 +13,7 @@ task :test do
   HTMLProofer.check_directory('./_site',
                               check_html: true,
                               validation: { ignore_script_embeds: true },
-                              url_swap: { %r{http://choosealicense.com} => '' },
+                              url_swap: { %r{https://choosealicense.com} => '' },
                               check_img_http: true).run
 end
 

--- a/Rakefile
+++ b/Rakefile
@@ -13,7 +13,8 @@ task :test do
   HTMLProofer.check_directory('./_site',
                               check_html: true,
                               validation: { ignore_script_embeds: true },
-                              url_swap: { %r{http://choosealicense.com} => '' }).run
+                              url_swap: { %r{http://choosealicense.com} => '' },
+                              check_img_http: true).run
 end
 
 task :approved_licenses do

--- a/_config.yml
+++ b/_config.yml
@@ -3,7 +3,7 @@ title: Choose a License
 description: Non-judgmental guidance on choosing a license for your open source project
 relative_permalinks: false
 markdown: kramdown
-url: "http://choosealicense.com"
+url: "https://choosealicense.com"
 
 collections:
   licenses:


### PR DESCRIPTION
https is now enforced on choosealicense.com.  This adds a test to ensure `img` tags don't generate mixed content warnings.

cc @gjtorikian 