### PR TITLE
make rubocop ruby version match pages ruby version

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 2.1
+  TargetRubyVersion: 2.3
   Exclude:
     - _site/**/*
     - vendor/**/*

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 source 'https://rubygems.org'
 
 require 'json'

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'html-proofer'
 require 'rspec/core/rake_task'
 

--- a/script/check-approval
+++ b/script/check-approval
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 # Checks if a given license meets the approval criteria to be added to choosealicense.com
 # See https://github.com/github/choosealicense.com/blob/gh-pages/CONTRIBUTING.md#adding-a-license
 # Usage: script/check-approval [SPDX LICENSE ID]

--- a/script/generate-docs
+++ b/script/generate-docs
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 # Usage: script/generate-docs
 # Reads in the fields, meta, and rules YAML files and produces markdown output
 # suitable for documenting in the project's README

--- a/spec/ci_ruby_version_spec.rb
+++ b/spec/ci_ruby_version_spec.rb
@@ -1,14 +1,14 @@
+# frozen_string_literal: true
 require 'json'
 require 'open-uri'
 require 'spec_helper'
 require 'yaml'
 
-describe 'ci ruby version' do
+describe 'ruby version' do
   pages_versions = JSON.parse(open('https://pages.github.com/versions.json').read)
   pages_ruby_version = pages_versions['ruby']
 
   ci_config_file = '.travis.yml'
-
   ci_config = YAML.load_file(ci_config_file)
   ci_ruby_version = ci_config['rvm'][0]
 
@@ -16,6 +16,18 @@ describe 'ci ruby version' do
     it 'match' do
       msg = "#{ci_ruby_version} != #{pages_ruby_version}; please add a commit bumping in #{ci_config_file}"
       expect(ci_ruby_version).to eql(pages_ruby_version), msg
+    end
+  end
+
+  rubocop_config_file = '.rubocop.yml'
+  rubocop_config = YAML.load_file(rubocop_config_file)
+  rubocop_ruby_version = rubocop_config['AllCops']['TargetRubyVersion']
+  pages_ruby_version_minor = pages_ruby_version.match('^(\d+)\.(\d+)')[0]
+
+  context "in #{rubocop_config_file} and pages ruby minor version" do
+    it 'match' do
+      msg = "#{rubocop_ruby_version} != #{pages_ruby_version_minor}; please add a commit bumping in #{rubocop_config_file}"
+      expect(rubocop_ruby_version.to_s).to eql(pages_ruby_version_minor), msg
     end
   end
 end

--- a/spec/license_bom_spec.rb
+++ b/spec/license_bom_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 describe 'byte order marks' do

--- a/spec/license_fields_spec.rb
+++ b/spec/license_fields_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 describe 'license fillable fields' do

--- a/spec/license_meta_spec.rb
+++ b/spec/license_meta_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 describe 'license meta' do

--- a/spec/license_rules_spec.rb
+++ b/spec/license_rules_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 describe 'license rules' do

--- a/spec/license_shown_spec.rb
+++ b/spec/license_shown_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 describe 'shown licenses' do

--- a/spec/license_spec.rb
+++ b/spec/license_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 describe 'licenses' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'jekyll'
 require 'open-uri'
 require 'json'


### PR DESCRIPTION
This is probably a bit silly and over the top for this project, but added after naively bumping rubocop's target ruby version in #476 and reverting due to errors (corrected here, supposed to help projects prepare for ruby 3.0 when it arrives eventually), after noticing and fixing CI/pages ruby versions not matching in #473.