### PR TITLE
same-license--variations

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,6 @@ The license properties (rules) are stored as a bulleted list within the licenses
 * `same-license` - Modifications must be released under the same license when distributing the software. In some cases a similar or related license may be used.
 * `same-license--file` - Modifications of existing files must be released under the same license when distributing the software. In some cases a similar or related license may be used.
 * `same-license--library` - Modifications must be released under the same license when distributing the software. In some cases a similar or related license may be used, or this condition may not apply to works that use the software as a library.
-* `same-license--source` - Modifications must be released under the same license when distributing the software in source form.
 
 #### Limitations
 

--- a/README.md
+++ b/README.md
@@ -91,6 +91,9 @@ The license properties (rules) are stored as a bulleted list within the licenses
 * `disclose-source` - Source code must be made available when distributing the software.
 * `network-use-disclose` - Users who interact with the software via network are given the right to receive a copy of the corresponding source code.
 * `same-license` - Modifications must be released under the same license when distributing the software. In some cases a similar or related license may be used.
+* `same-license--file` - Modifications of existing files must be released under the same license when distributing the software. In some cases a similar or related license may be used.
+* `same-license--library` - Modifications must be released under the same license when distributing the software. In some cases a similar or related license may be used, or this condition may not apply to works that use the software as a library.
+* `same-license--source` - Modifications must be released under the same license when distributing the software in source form.
 
 #### Limitations
 

--- a/_data/rules.yml
+++ b/_data/rules.yml
@@ -31,6 +31,15 @@ conditions:
 - description: Modifications must be released under the same license when distributing the software. In some cases a similar or related license may be used.
   label: Same License
   tag: same-license
+- description: Modifications of existing files must be released under the same license when distributing the software. In some cases a similar or related license may be used.
+  label: Same License (File)
+  tag: same-license--file
+- description: Modifications must be released under the same license when distributing the software. In some cases a similar or related license may be used, or this condition may not apply to works that use the software as a library.
+  label: Same License (Library)
+  tag: same-license--library
+- description: Modifications must be released under the same license when distributing the software in source form.
+  label: Same License (Source)
+  tag: same-license--source
 
 limitations:
 - description: This license explicitly states that it does NOT grant you trademark rights, even though licenses without such a statement probably do not grant you any implicit trademark rights.

--- a/_data/rules.yml
+++ b/_data/rules.yml
@@ -37,9 +37,6 @@ conditions:
 - description: Modifications must be released under the same license when distributing the software. In some cases a similar or related license may be used, or this condition may not apply to works that use the software as a library.
   label: Same License (Library)
   tag: same-license--library
-- description: Modifications must be released under the same license when distributing the software in source form.
-  label: Same License (Source)
-  tag: same-license--source
 
 limitations:
 - description: This license explicitly states that it does NOT grant you trademark rights, even though licenses without such a statement probably do not grant you any implicit trademark rights.

--- a/_licenses/epl-1.0.txt
+++ b/_licenses/epl-1.0.txt
@@ -24,7 +24,7 @@ permissions:
 conditions:
   - disclose-source
   - include-copyright
-  - same-license--source
+  - same-license
 
 limitations:
   - liability

--- a/_licenses/epl-1.0.txt
+++ b/_licenses/epl-1.0.txt
@@ -24,7 +24,7 @@ permissions:
 conditions:
   - disclose-source
   - include-copyright
-  - same-license
+  - same-license--source
 
 limitations:
   - liability

--- a/_licenses/lgpl-2.1.txt
+++ b/_licenses/lgpl-2.1.txt
@@ -22,7 +22,7 @@ conditions:
   - include-copyright
   - disclose-source
   - document-changes
-  - same-license
+  - same-license--library
 
 limitations:
   - liability

--- a/_licenses/lgpl-3.0.txt
+++ b/_licenses/lgpl-3.0.txt
@@ -23,7 +23,7 @@ conditions:
   - include-copyright
   - disclose-source
   - document-changes
-  - same-license
+  - same-license--library
 
 limitations:
   - liability

--- a/_licenses/mpl-2.0.txt
+++ b/_licenses/mpl-2.0.txt
@@ -26,7 +26,7 @@ permissions:
 conditions:
   - disclose-source
   - include-copyright
-  - same-license
+  - same-license--file
 
 limitations:
   - liability

--- a/_licenses/ms-rl.txt
+++ b/_licenses/ms-rl.txt
@@ -17,7 +17,7 @@ permissions:
 conditions:
   - disclose-source
   - include-copyright
-  - same-license
+  - same-license--file
 
 limitations:
   - warranty

--- a/appendix.md
+++ b/appendix.md
@@ -17,7 +17,7 @@ If you're here to choose a license, **[start from the home page](/)** to see a f
   {% for type in types %}
     {% assign rules = site.data.rules[type] | sort: "label" %}
     {% for rule_obj in rules %}
-      {% if seen_tags contains rule_obj.tag %}
+      {% if seen_tags contains rule_obj.tag or rule_obj.tag contains '--' %}
         {% continue %}
       {% endif %}
       {% capture seen_tags %}{{ seen_tags | append:rule_obj.tag }}{% endcapture %}
@@ -33,20 +33,22 @@ If you're here to choose a license, **[start from the home page](/)** to see a f
     {% assign rules = site.data.rules[type] | sort: "label" %}
     {% for rule_obj in rules %}
       {% assign req = rule_obj.tag %}
-      {% if seen_tags contains req %}
+      {% if seen_tags contains req  or rule_obj.tag contains '--' %}
         {% continue %}
       {% endif %}
       {% capture seen_tags %}{{ seen_tags | append:req }}{% endcapture %}
       {% assign seen_req = false %}
       {% for t in types %}
-        {% if license[t] contains req %}
-          <td class="license-{{ t }}" style="text-align:center">
-            <span class="{{ req }}">
-              <span class="license-sprite {{ req }}"></span>
-            </span>
-          </td>
-          {% assign seen_req = true %}
-        {% endif %}
+        {% for r in license[t] %}
+          {% if r contains req %}
+            <td class="license-{{ t }}" style="text-align:center">
+              <span class="{{ r }}">
+                <span class="license-sprite {{ r }}"></span>
+              </span>
+            </td>
+            {% assign seen_req = true %}
+          {% endif %}
+        {% endfor %}
       {% endfor %}
       {% unless seen_req %}
         <td></td>


### PR DESCRIPTION
Adds 3 variations on `same-license`:

* `same-license--file` (MPL-2.0 and MS-RL)
* `same-license--library` (LGPL-2.1 and -3.0)
* ~~`same-license--source` (EPL-1.0)~~ (Not useful enough distinction in practice to include here; maybe [eventual](https://dev.eclipse.org/mhonarc/lists/epl-discuss/msg00112.html) EPL-2.0 will clearly fit with `same-license--file`)

This is an alternative to #470 for which also would fix #410 

This alternative doesn't highlight closed derivatives as a choice point, which is a plus (avoids redundancy, maybe some controversy and misunderstanding) and a minus (leaving the most important choice point for many licensing decisions implied).

I think I like this alternative better overall, in part because it conveys information about the variations in weaker copylefts that are hard to learn about, and avoids minus above.

The two alternatives aren't mutually exclusive, but I think if we go for this one I'd not feel any pull to implement the one in #410.

Screen shot of LGPL-3.0 with this one:

<img width="798" alt="screen shot 2017-02-19 at 2 51 48 pm" src="https://cloud.githubusercontent.com/assets/40415/23107496/ff875a32-f6b2-11e6-8288-6502dd1a56f7.png">
