### PR TITLE
Change copyright date 2004 -> [year] in wtfpl

### DIFF
--- a/_licenses/wtfpl.txt
+++ b/_licenses/wtfpl.txt
@@ -22,7 +22,7 @@ limitations: []
             DO WHAT THE FUCK YOU WANT TO PUBLIC LICENSE
                     Version 2, December 2004
 
- Copyright (C) 2004 [fullname] <[email]>
+ Copyright (C) [year] [fullname] <[email]>
 
  Everyone is permitted to copy and distribute verbatim or modified
  copies of this license document, and changing it is allowed as long

--- a/_licenses/wtfpl.txt
+++ b/_licenses/wtfpl.txt
@@ -22,7 +22,7 @@ limitations: []
             DO WHAT THE FUCK YOU WANT TO PUBLIC LICENSE
                     Version 2, December 2004
 
- Copyright (C) [year] [fullname] <[email]>
+ Copyright (C) 2004 Sam Hocevar <sam@hocevar.net>
 
  Everyone is permitted to copy and distribute verbatim or modified
  copies of this license document, and changing it is allowed as long


### PR DESCRIPTION
I believe this one is supposed to be the year that the software under the license is published, not the year the license itself was written. But I'm not positive. If I'm wrong please feel free to close!