### PR TITLE
focus additional resources on choosing an open license, not lists of licenses

### DIFF
--- a/about.md
+++ b/about.md
@@ -18,10 +18,8 @@ See our [appendix](/appendix) for a table of all of the licenses cataloged in th
 
 {: .bullets}
 
-* Open Source Initiative's [list of licenses](https://opensource.org/licenses/) approved as conforming to the [Open Source Definition](https://opensource.org/osd)
-* Free Software Foundation's [comments on various licenses](http://www.gnu.org/licenses/license-list.html) and [advice on how to choose a license](https://www.gnu.org/licenses/license-recommendations.en.html)
-* Linux Foundation's [SPDX License List](https://spdx.org/licenses/)
-* [Comparison of free and open-source software licenses](https://en.wikipedia.org/wiki/Comparison_of_free_and_open-source_software_licenses) on English Wikipedia
+* Open Source Initiative's FAQ on [Which Open Source license should I choose to release my software under?](https://opensource.org/faq#which-license)
+* Free Software Foundation's [advice on how to choose a license](https://www.gnu.org/licenses/license-recommendations.en.html)
 * [License differentiator](http://www.oss-watch.ac.uk/apps/licdiff/) ([source](https://github.com/ox-it/licdiff)) from [OSS Watch](http://www.oss-watch.ac.uk/)
 * [Free/Libre/Open Source license selection wizard](http://vrici.lojban.org/~cowan/floss/) by John Cowan
 * [The Legal Side of Open Source](https://opensource.guide/legal/), an Open Source Guide covering licensing and related issues


### PR DESCRIPTION
Fixes #490 which was concerned that the additional resources list did not include all like items, I understand driven by concern that the SPDX license list includes non-open licenses. So does the FSF license list -- worse, it even recommends some.

This fix focuses the list on resources about choosing an open license, not resources listing a bunch of licenses. Fortunately both OSI and FSF have pages directly addressing choosing a license, neither of which recommends non-open licenses.

I've removed the SPDX and English Wikipedia lists.