### PR TITLE
Adding the University of Illinois/NCSA License 

### DIFF
--- a/_licenses/ncsa.txt
+++ b/_licenses/ncsa.txt
@@ -23,7 +23,6 @@ conditions:
   - include-copyright
 
 limitations:
-  - trademark-use
   - liability
   - warranty
 

--- a/_licenses/ncsa.txt
+++ b/_licenses/ncsa.txt
@@ -6,7 +6,7 @@ source: https://opensource.org/licenses/NCSA
 hidden: false
 featured: false
 
-description: The University of Illinois/NCSA Open Source License, or UIUC license, is a permissive free software license, based on the <a href="/license/mit/">MIT/X11 license</a>  and the <a href="/license/bsd-3-clause">BSD 3-clause License</a>. By combining parts of these two licenses, it attempts to be clearer and more concise than either. It's conditions include requiring the preservation of copyright and license notices both in source and in binary distributions and the prohibtion of using the names of the authors or the project organization to promote or endorse derived products.
+description: The University of Illinois/NCSA Open Source License, or UIUC license, is a permissive free software license, based on the <a href="/licenses/mit/">MIT/X11 license</a>  and the <a href="/licenses/bsd-3-clause/">BSD 3-clause License</a>. By combining parts of these two licenses, it attempts to be clearer and more concise than either. It's conditions include requiring the preservation of copyright and license notices both in source and in binary distributions and the prohibtion of using the names of the authors or the project organization to promote or endorse derived products.
 
 how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file. Replace [year] with the current year and [fullname] with the name (or names) of the copyright holders. Replace [project] with the project organization, if any, that sponsors this work.
 

--- a/_licenses/ncsa.txt
+++ b/_licenses/ncsa.txt
@@ -6,7 +6,7 @@ source: https://opensource.org/licenses/NCSA
 hidden: false
 featured: false
 
-description: The University of Illinois/NCSA Open Source License, or UIUC license, is a permissive free software license, based on the <a href="/license/mit/">MIT/X11 license</a>  and the <a href="/license/bsd-3-clause">BSD 3-clause License</a>. By combining parts of these two licenses, it attempts to be clearer and more concise than either.
+description: The University of Illinois/NCSA Open Source License, or UIUC license, is a permissive free software license, based on the <a href="/license/mit/">MIT/X11 license</a>  and the <a href="/license/bsd-3-clause">BSD 3-clause License</a>. By combining parts of these two licenses, it attempts to be clearer and more concise than either. It's conditions include requiring the preservation of copyright and license notices both in source and in binary distributions and the prohibtion of using the names of the authors or the project organization to promote or endorse derived products.
 
 how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file. Replace [year] with the current year and [fullname] with the name (or names) of the copyright holders. Replace [project] with the project organization, if any, that sponsors this work.
 

--- a/_licenses/ncsa.txt
+++ b/_licenses/ncsa.txt
@@ -4,7 +4,7 @@ spdx-id: NCSA
 nickname: UIUC/NCSA
 source: https://opensource.org/licenses/NCSA
 
-description: The University of Illinois/NCSA Open Source License, or UIUC license, is a permissive free software license, based on the <a href="/licenses/mit/">MIT/X11 license</a>  and the <a href="/licenses/bsd-3-clause/">BSD 3-clause License</a>. By combining parts of these two licenses, it attempts to be clearer and more concise than either. Its conditions include requiring the preservation of copyright and license notices both in source and in binary distributions and the prohibtion of using the names of the authors or the project organization to promote or endorse derived products.
+description: The University of Illinois/NCSA Open Source License, or UIUC license, is a permissive free software license, based on the <a href="/licenses/mit/">MIT/X11 license</a>  and the <a href="/licenses/bsd-3-clause/">BSD 3-clause License</a>. Its conditions include requiring the preservation of copyright and license notices both in source and in binary distributions and the prohibtion of using the names of the authors or the project organization to promote or endorse derived products.
 
 how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file. Replace [year] with the current year and [fullname] with the name (or names) of the copyright holders. Replace [project] with the project organization, if any, that sponsors this work.
 

--- a/_licenses/ncsa.txt
+++ b/_licenses/ncsa.txt
@@ -4,14 +4,15 @@ spdx-id: NCSA
 nickname: UIUC/NCSA
 source: https://opensource.org/licenses/NCSA
 
-description: The University of Illinois/NCSA Open Source License, or UIUC license, is a permissive free software license, based on the <a href="/licenses/mit/">MIT/X11 license</a>  and the <a href="/licenses/bsd-3-clause/">BSD 3-clause License</a>. By combining parts of these two licenses, it attempts to be clearer and more concise than either. It's conditions include requiring the preservation of copyright and license notices both in source and in binary distributions and the prohibtion of using the names of the authors or the project organization to promote or endorse derived products.
+description: The University of Illinois/NCSA Open Source License, or UIUC license, is a permissive free software license, based on the <a href="/licenses/mit/">MIT/X11 license</a>  and the <a href="/licenses/bsd-3-clause/">BSD 3-clause License</a>. By combining parts of these two licenses, it attempts to be clearer and more concise than either. Its conditions include requiring the preservation of copyright and license notices both in source and in binary distributions and the prohibtion of using the names of the authors or the project organization to promote or endorse derived products.
 
 how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file. Replace [year] with the current year and [fullname] with the name (or names) of the copyright holders. Replace [project] with the project organization, if any, that sponsors this work.
 
 using: 
- - Clang: https://github.com/llvm-mirror/clang/blob/master/LICENSE.TXT 
- - LLVM: https://github.com/llvm-mirror/llvm/blob/master/LICENSE.TXT
  - LLDB: https://github.com/llvm-mirror/lldb/blob/master/LICENSE.TXT
+ - ROCR-Runtime: https://github.com/RadeonOpenCompute/ROCR-Runtime/blob/master/LICENSE.txt
+ - RLTK: https://github.com/chriswailes/RLTK/blob/master/LICENSE
+
 
 permissions:
   - commercial-use

--- a/_licenses/ncsa.txt
+++ b/_licenses/ncsa.txt
@@ -3,8 +3,6 @@ title: University of Illinois/NCSA Open Source License
 spdx-id: NCSA
 nickname: UIUC/NCSA
 source: https://opensource.org/licenses/NCSA
-hidden: true
-featured: false
 
 description: The University of Illinois/NCSA Open Source License, or UIUC license, is a permissive free software license, based on the <a href="/licenses/mit/">MIT/X11 license</a>  and the <a href="/licenses/bsd-3-clause/">BSD 3-clause License</a>. By combining parts of these two licenses, it attempts to be clearer and more concise than either. It's conditions include requiring the preservation of copyright and license notices both in source and in binary distributions and the prohibtion of using the names of the authors or the project organization to promote or endorse derived products.
 

--- a/_licenses/ncsa.txt
+++ b/_licenses/ncsa.txt
@@ -18,7 +18,7 @@ using:
 permissions:
   - commercial-use
   - modifications
-  - distribute
+  - distribution
   - private-use
 
 conditions:

--- a/_licenses/ncsa.txt
+++ b/_licenses/ncsa.txt
@@ -31,12 +31,9 @@ limitations:
 
 University of Illinois/NCSA Open Source License 
 
-Copyright (c) [year], [fullname] 
-All rights reserved.
+Copyright (c) [year] [fullname]. All rights reserved. 
 
-Developed by: [fullname]
-              [project]
-              [email]
+Developed by: [fullname] [project] [email]
                   
 Permission is hereby granted, free of charge, to any person 
 obtaining a copy of this software and associated documentation files 

--- a/_licenses/ncsa.txt
+++ b/_licenses/ncsa.txt
@@ -1,0 +1,68 @@
+---
+title: University of Illinois/NCSA Open Source License
+spdx-id: NCSA
+nickname: UIUC/NCSA
+source: https://opensource.org/licenses/NCSA
+hidden: false
+featured: false
+
+description: The University of Illinois/NCSA Open Source License, or UIUC license, is a permissive free software license, based on the <a href="/license/">MIT/X11 license</a>  and the <a href="/license/">BSD 3-clause License</a>. By combining parts of these two licenses, it attempts to be clearer and more concise than either.
+
+how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file. Replace [year] with the current year and [fullname] with the name (or names) of the copyright holders. Replace [project] with the project organization, if any, that sponsors this work.
+
+using: 
+ - Clang: https://github.com/llvm-mirror/clang/blob/master/LICENSE.TXT 
+ - LLVM: https://github.com/llvm-mirror/llvm/blob/master/LICENSE.TXT
+ - LLDB: https://github.com/llvm-mirror/lldb/blob/master/LICENSE.TXT
+
+permissions:
+  - commercial-use
+  - modifications
+  - distribute
+  - private-use
+
+conditions:
+  - include-copyright
+
+limitations:
+  - trademark-use
+  - liability
+  - warranty
+
+---
+
+University of Illinois/NCSA Open Source License 
+
+Copyright (c) [year], [fullname] 
+All rights reserved.
+
+Developed by: 		[fullname]
+                  [project]
+                  [email]
+                  
+Permission is hereby granted, free of charge, to any person 
+obtaining a copy of this software and associated documentation files 
+(the "Software"), to deal with the Software without restriction, 
+including without limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of the Software, 
+and to permit persons to whom the Software is furnished to do so, 
+subject to the following conditions:
+
+* Redistributions of source code must retain the above copyright notice, 
+  this list of conditions and the following disclaimers.
+
+* Redistributions in binary form must reproduce the above copyright 
+  notice, this list of conditions and the following disclaimers in the 
+  documentation and/or other materials provided with the distribution.
+
+* Neither the names of [fullname], [project] nor the names of its 
+  contributors may be used to endorse or promote products derived from
+  this Software without specific prior written permission.
+  
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS 
+OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
+CONTRIBUTORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, 
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS WITH
+THE SOFTWARE.

--- a/_licenses/ncsa.txt
+++ b/_licenses/ncsa.txt
@@ -6,7 +6,7 @@ source: https://opensource.org/licenses/NCSA
 hidden: false
 featured: false
 
-description: The University of Illinois/NCSA Open Source License, or UIUC license, is a permissive free software license, based on the <a href="/license/">MIT/X11 license</a>  and the <a href="/license/">BSD 3-clause License</a>. By combining parts of these two licenses, it attempts to be clearer and more concise than either.
+description: The University of Illinois/NCSA Open Source License, or UIUC license, is a permissive free software license, based on the <a href="/license/mit/">MIT/X11 license</a>  and the <a href="/license/bsd-3-clause">BSD 3-clause License</a>. By combining parts of these two licenses, it attempts to be clearer and more concise than either.
 
 how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file. Replace [year] with the current year and [fullname] with the name (or names) of the copyright holders. Replace [project] with the project organization, if any, that sponsors this work.
 

--- a/_licenses/ncsa.txt
+++ b/_licenses/ncsa.txt
@@ -36,9 +36,9 @@ University of Illinois/NCSA Open Source License
 Copyright (c) [year], [fullname] 
 All rights reserved.
 
-Developed by: 		[fullname]
-                  [project]
-                  [email]
+Developed by: [fullname]
+              [project]
+              [email]
                   
 Permission is hereby granted, free of charge, to any person 
 obtaining a copy of this software and associated documentation files 

--- a/_licenses/ncsa.txt
+++ b/_licenses/ncsa.txt
@@ -33,7 +33,9 @@ University of Illinois/NCSA Open Source License
 
 Copyright (c) [year] [fullname]. All rights reserved. 
 
-Developed by: [fullname] [project] [email]
+Developed by: [fullname] 
+              [project] 
+              [project_url]
                   
 Permission is hereby granted, free of charge, to any person 
 obtaining a copy of this software and associated documentation files 

--- a/_licenses/ncsa.txt
+++ b/_licenses/ncsa.txt
@@ -3,7 +3,7 @@ title: University of Illinois/NCSA Open Source License
 spdx-id: NCSA
 nickname: UIUC/NCSA
 source: https://opensource.org/licenses/NCSA
-hidden: false
+hidden: true
 featured: false
 
 description: The University of Illinois/NCSA Open Source License, or UIUC license, is a permissive free software license, based on the <a href="/licenses/mit/">MIT/X11 license</a>  and the <a href="/licenses/bsd-3-clause/">BSD 3-clause License</a>. By combining parts of these two licenses, it attempts to be clearer and more concise than either. It's conditions include requiring the preservation of copyright and license notices both in source and in binary distributions and the prohibtion of using the names of the authors or the project organization to promote or endorse derived products.


### PR DESCRIPTION
This PR should add the University of Illinois/NCSA License into the set of licenses on choosealicense.com. Its a license that combines part of the MIT and BSD-3 Clause licenses and used in projects like Clang and LLVM (and many of my own projects).

License Requirements: 
1. [SPDX Identifier](https://spdx.org/licenses/NCSA.html): NCSA
2. Inclusion in both [OSI Approved License List](https://opensource.org/licenses/NCSA) and [GNU's list of GPL Compatible licenses](https://www.gnu.org/licenses/license-list.en.html#NCSA) 
3. [Github Search](https://github.com/search?utf8=%E2%9C%93&q=+%22University+of+Illinois%22+%22Open+Source%22+filename%3ALICENSE+%22NCSA%22&type=Code) returns 13K results (some duplicated repos)

Question about the metadata though, for limitations does trademark refer to only prohibiting the use of trademarks associated with the project or is it supposed to cover limitations on usage of developer and organization names as well? 

If it doesn't is that a limitation worth noting as its is a major condition of not only this license but also other BSD-3 Clause-like licenses? 