### PR TITLE
Don't inlcude 'you' in any rule descriptions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 source 'https://rubygems.org'
 
 require 'json'

--- a/README.md
+++ b/README.md
@@ -80,25 +80,25 @@ The license properties (rules) are stored as a bulleted list within the licenses
 
 * `commercial-use` - This software and derivatives may be used for commercial purposes.
 * `modifications` - This software may be modified.
-* `distribution` - You may distribute this software.
-* `private-use` - You may use and modify the software without distributing it.
-* `patent-use` - This license provides an express grant of patent rights from the contributor to the recipient.
+* `distribution` - This software may be distributed.
+* `private-use` - This software may be used and modifed in private.
+* `patent-use` - This license provides an express grant of patent rights from contributors.
 
 #### Conditions
 
-* `include-copyright` - Include a copy of the license and copyright notice with the software.
-* `document-changes` - Indicate changes made to the code.
-* `disclose-source` - Source code must be made available when distributing the software.
-* `network-use-disclose` - Users who interact with the software via network are given the right to receive a copy of the corresponding source code.
+* `include-copyright` - A copy of the license and copyright notice must be included with the software.
+* `document-changes` - Changes made to the code must be documented.
+* `disclose-source` - Source code must be made available the software is distributed.
+* `network-use-disclose` - Users who interact with the software via network are given the right to receive a copy of the source code.
 * `same-license` - Modifications must be released under the same license when distributing the software. In some cases a similar or related license may be used.
 * `same-license--file` - Modifications of existing files must be released under the same license when distributing the software. In some cases a similar or related license may be used.
 * `same-license--library` - Modifications must be released under the same license when distributing the software. In some cases a similar or related license may be used, or this condition may not apply to works that use the software as a library.
 
 #### Limitations
 
-* `trademark-use` - This license explicitly states that it does NOT grant you trademark rights, even though licenses without such a statement probably do not grant you any implicit trademark rights.
+* `trademark-use` - This license explicitly states that it does NOT grant trademark rights, even though licenses without such a statement probably do not grant any implicit trademark rights.
 * `liability` - This license includes a limitation of liability.
-* `patent-use` -  This license explicitly states that it does NOT grant you any rights in the patents of contributors.
+* `patent-use` - This license explicitly states that it does NOT grant any rights in the patents of contributors.
 * `warranty` - The license explicitly states that it does NOT provide any warranty.
 
 ## License

--- a/README.md
+++ b/README.md
@@ -81,14 +81,14 @@ The license properties (rules) are stored as a bulleted list within the licenses
 * `commercial-use` - This software and derivatives may be used for commercial purposes.
 * `modifications` - This software may be modified.
 * `distribution` - This software may be distributed.
-* `private-use` - This software may be used and modifed in private.
+* `private-use` - This software may be used and modified in private.
 * `patent-use` - This license provides an express grant of patent rights from contributors.
 
 #### Conditions
 
 * `include-copyright` - A copy of the license and copyright notice must be included with the software.
 * `document-changes` - Changes made to the code must be documented.
-* `disclose-source` - Source code must be made available the software is distributed.
+* `disclose-source` - Source code must be made available when the software is distributed.
 * `network-use-disclose` - Users who interact with the software via network are given the right to receive a copy of the source code.
 * `same-license` - Modifications must be released under the same license when distributing the software. In some cases a similar or related license may be used.
 * `same-license--file` - Modifications of existing files must be released under the same license when distributing the software. In some cases a similar or related license may be used.

--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'html-proofer'
 require 'rspec/core/rake_task'
 
@@ -26,7 +27,7 @@ task :approved_licenses do
   puts approved.join(', ')
   puts "\n"
 
-  potential = approved - licenses.map { |l| l['id'] }
+  potential = approved - (licenses.map { |l| l['id'] })
   puts "#{potential.count} potential additions:"
   puts potential.join(', ')
 end

--- a/_data/rules.yml
+++ b/_data/rules.yml
@@ -5,27 +5,27 @@ permissions:
 - description: This software may be modified.
   label: Modification
   tag: modifications
-- description: You may distribute this software.
+- description: This software may be distributed.
   label: Distribution
   tag: distribution
-- description: You may use and modify the software without distributing it.
+- description: This software may be used and modifed in private.
   label: Private use
   tag: private-use
-- description: This license provides an express grant of patent rights from the contributor to the recipient.
+- description: This license provides an express grant of patent rights from contributors.
   label: Patent use
   tag: patent-use
 
 conditions:
-- description: Include a copy of the license and copyright notice with the software.
+- description: A copy of the license and copyright notice must be included with the software.
   label: License and copyright notice
   tag: include-copyright
-- description: Indicate changes made to the code.
+- description: Changes made to the code must be documented.
   label: State changes
   tag: document-changes
-- description: Source code must be made available when distributing the software.
+- description: Source code must be made available the software is distributed.
   label: Disclose source
   tag: disclose-source
-- description: Users who interact with the software via network are given the right to receive a copy of the corresponding source code.
+- description: Users who interact with the software via network are given the right to receive a copy of the source code.
   label: Network use is distribution
   tag: network-use-disclose
 - description: Modifications must be released under the same license when distributing the software. In some cases a similar or related license may be used.
@@ -39,13 +39,13 @@ conditions:
   tag: same-license--library
 
 limitations:
-- description: This license explicitly states that it does NOT grant you trademark rights, even though licenses without such a statement probably do not grant you any implicit trademark rights.
+- description: This license explicitly states that it does NOT grant trademark rights, even though licenses without such a statement probably do not grant any implicit trademark rights.
   label: Trademark use
   tag: trademark-use
 - description: This license includes a limitation of liability.
   label: Liability
   tag: liability
-- description: This license explicitly states that it does NOT grant you any rights in the patents of contributors.
+- description: This license explicitly states that it does NOT grant any rights in the patents of contributors.
   label: Patent use
   tag: patent-use
 - description: The license explicitly states that it does NOT provide any warranty.

--- a/_data/rules.yml
+++ b/_data/rules.yml
@@ -8,7 +8,7 @@ permissions:
 - description: This software may be distributed.
   label: Distribution
   tag: distribution
-- description: This software may be used and modifed in private.
+- description: This software may be used and modified in private.
   label: Private use
   tag: private-use
 - description: This license provides an express grant of patent rights from contributors.
@@ -22,7 +22,7 @@ conditions:
 - description: Changes made to the code must be documented.
   label: State changes
   tag: document-changes
-- description: Source code must be made available the software is distributed.
+- description: Source code must be made available when the software is distributed.
   label: Disclose source
   tag: disclose-source
 - description: Users who interact with the software via network are given the right to receive a copy of the source code.

--- a/script/check-approval
+++ b/script/check-approval
@@ -1,5 +1,6 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
+
 # Checks if a given license meets the approval criteria to be added to choosealicense.com
 # See https://github.com/github/choosealicense.com/blob/gh-pages/CONTRIBUTING.md#adding-a-license
 # Usage: script/check-approval [SPDX LICENSE ID]

--- a/script/generate-docs
+++ b/script/generate-docs
@@ -1,5 +1,6 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
+
 # Usage: script/generate-docs
 # Reads in the fields, meta, and rules YAML files and produces markdown output
 # suitable for documenting in the project's README

--- a/spec/ci_ruby_version_spec.rb
+++ b/spec/ci_ruby_version_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'json'
 require 'open-uri'
 require 'spec_helper'

--- a/spec/license_bom_spec.rb
+++ b/spec/license_bom_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'spec_helper'
 
 describe 'byte order marks' do

--- a/spec/license_fields_spec.rb
+++ b/spec/license_fields_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'spec_helper'
 
 describe 'license fillable fields' do
@@ -6,7 +7,7 @@ describe 'license fillable fields' do
     context "The #{license['title']} license" do
       it 'should only contain supported fillable fields' do
         matches = license['content'].scan(/\[([a-z]+)\]/)
-        extra_fields = matches.flatten - fields.map { |f| f['name'] }
+        extra_fields = matches.flatten - (fields.map { |f| f['name'] })
         expect(extra_fields).to be_empty
       end
     end

--- a/spec/license_meta_spec.rb
+++ b/spec/license_meta_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'spec_helper'
 
 describe 'license meta' do
@@ -8,7 +9,7 @@ describe 'license meta' do
 
     context "The #{license['title']} license" do
       it 'should only contain supported meta fields' do
-        extra_fields = raw_fields.keys - meta.map { |m| m['name'] }
+        extra_fields = raw_fields.keys - (meta.map { |m| m['name'] })
         expect(extra_fields).to be_empty
       end
 

--- a/spec/license_rules_spec.rb
+++ b/spec/license_rules_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'spec_helper'
 
 describe 'license rules' do

--- a/spec/license_shown_spec.rb
+++ b/spec/license_shown_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'spec_helper'
 
 describe 'shown licenses' do

--- a/spec/license_spec.rb
+++ b/spec/license_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'spec_helper'
 
 describe 'licenses' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'jekyll'
 require 'open-uri'
 require 'json'
@@ -42,7 +43,7 @@ def licenses
 end
 
 def shown_licenses
-  licenses.select { |l| !l['hidden'] }
+  licenses.reject { |l| l['hidden'] }
 end
 
 def site


### PR DESCRIPTION
Descriptions should make sense whether reader is licensor or licensee.

Pointed out by @HawkonDK at https://github.com/github/choosealicense.com/issues/499#issuecomment-289321921