### PR TITLE
De-capitalize one mistakenly-capitalized 'License'

### DIFF
--- a/_data/rules.yml
+++ b/_data/rules.yml
@@ -29,7 +29,7 @@ conditions:
   label: Network use is distribution
   tag: network-use-disclose
 - description: Modifications must be released under the same license when distributing the software. In some cases a similar or related license may be used.
-  label: Same License
+  label: Same license
   tag: same-license
 - description: Modifications of existing files must be released under the same license when distributing the software. In some cases a similar or related license may be used.
   label: Same license (file)

--- a/spec/license_shown_spec.rb
+++ b/spec/license_shown_spec.rb
@@ -5,7 +5,7 @@ require 'spec_helper'
 describe 'shown licenses' do
   # Whitelist of popular licenses that are shown (non-hidden)
   # Note: most new licenses that are added should be hidden by default
-  SHOWN_LICENSES = %w(
+  SHOWN_LICENSES = %w[
     agpl-3.0
     apache-2.0
     bsd-2-clause
@@ -18,7 +18,7 @@ describe 'shown licenses' do
     mit
     mpl-2.0
     unlicense
-  ).freeze
+  ].freeze
 
   it 'has the expected number of shown licenses' do
     expect(shown_licenses.count).to eql(12)


### PR DESCRIPTION
The surround text (and following items) use the phrase "Same license" and no evidence is present of capitalization of License as a proper noun in this text.

See also benbalter/licensee#184