### PR TITLE
Require 3 detectable examples for newly added licenses

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,6 +29,7 @@ If your proposed license meets the above criteria, here's a few other things to 
 * The license files should be in the format of `_licenses/[lowercased-spdx-id].txt` (e.g., `_licenses/mit.txt`)
 * Each license has both [required and optional metadata](https://github.com/github/choosealicense.com#license-metadata) that should be included.
 * The text of the license should be wrapped to a 78 character width.
+* The text of the license should match the corresponding text found at https://spdx.org/licenses/
 * The body of the file should be the text of the license in plain text.
 
 ## Making Changes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ Choosealicense.com is intended to demystify license choices, not present or cata
    * [GNU's list of free licenses](https://www.gnu.org/licenses/license-list.en.html) (*note: the license must be listed in one of the three "free" categories*)
    * [Open Definition's list of conformant licenses](http://opendefinition.org/licenses/) (non-code)
 3. A [GitHub code search](https://github.com/search?q=MIT+filename%3ALICENSE&type=Code) must reveal at least *1,000* public repositories using the license
-4. 3 notable projects using the license with straightforward LICENSE files which serve as examples newcomers can follow and that could be detected by [licensee](https://github.com/benbalter/licensee) if it knew about the license
+4. Identification of 3 notable projects using the license with straightforward LICENSE files which serve as examples newcomers can follow and that could be detected by [licensee](https://github.com/benbalter/licensee) if it knew about the license
 
 If your proposed license meets the above criteria, here's a few other things to keep in mind as you propose the license's addition:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,6 +20,7 @@ Choosealicense.com is intended to demystify license choices, not present or cata
    * [GNU's list of free licenses](https://www.gnu.org/licenses/license-list.en.html) (*note: the license must be listed in one of the three "free" categories*)
    * [Open Definition's list of conformant licenses](http://opendefinition.org/licenses/) (non-code)
 3. A [GitHub code search](https://github.com/search?q=MIT+filename%3ALICENSE&type=Code) must reveal at least *1,000* public repositories using the license
+4. 3 notable projects using the license with straightforward LICENSE files which serve as examples newcomers can follow and that could be detected by [licensee](https://github.com/benbalter/licensee) if it knew about the license
 
 If your proposed license meets the above criteria, here's a few other things to keep in mind as you propose the license's addition:
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Licenses sit in the `/_licenses` folder. Each license has YAML front matter desc
 * `source` - The URL to the license source text
 * `description` - A human-readable description of the license
 * `how` - Instructions on how to implement the license
+* `using` - A list of 3 notable projects using the license with straightforward LICENSE files which serve as examples newcomers can follow and that can be detected by [licensee](https://github.com/benbalter/licensee) in the form of `project_name: license_file_url`
 * `permissions` - Bulleted list of permission rules
 * `conditions` - Bulleted list of condition rules
 * `limitations` - Bulleted list of limitation rules
@@ -54,7 +55,6 @@ Licenses sit in the `/_licenses` folder. Each license has YAML front matter desc
 * `hidden` - Whether the license is neither [popular](https://opensource.org/licenses) nor fills out the [spectrum of licenses](http://choosealicense.com/licenses/) from strongly conditional to unconditional (defaults to true)
 * `nickname` - Customary short name if applicable (e.g, GPLv3)
 * `note` - Additional information about the licenses
-* `using` - A list of up to 3 notable projects using the license with straightforward LICENSE files which serve as examples newcomers can follow and that can be detected by [licensee](https://github.com/benbalter/licensee) in the form of `project_name: license_file_url`
 * `redirect_from` - Relative path(s) to redirect to the license from, to prevent breaking old URLs
 
 ### Auto-populated fields

--- a/_data/meta.yml
+++ b/_data/meta.yml
@@ -33,6 +33,10 @@
   description: Bulleted list of limited rules
   required: true
 
+- name: using
+  description: 'A list of 3 notable projects using the license with straightforward LICENSE files which serve as examples newcomers can follow and that can be detected by [licensee](https://github.com/benbalter/licensee) in the form of `project_name: license_file_url`'
+  required: true
+
 # Optional fields
 
 - name: featured
@@ -49,10 +53,6 @@
 
 - name: note
   description: Additional information about the licenses
-  required: false
-
-- name: using
-  description: 'A list of up to 3 notable projects using the license with straightforward LICENSE files which serve as examples newcomers can follow and that can be detected by [licensee](https://github.com/benbalter/licensee) in the form of `project_name: license_file_url`'
   required: false
 
 - name: redirect_from

--- a/_licenses/afl-3.0.txt
+++ b/_licenses/afl-3.0.txt
@@ -7,6 +7,8 @@ description: The Academic Free License is a variant of the Open Software License
 
 how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file. Files licensed under AFL 3.0 must also include the notice "Licensed under the Academic Free License version 3.0" adjacent to the copyright notice.
 
+using:
+
 permissions:
   - commercial-use
   - modifications

--- a/_licenses/agpl-3.0.txt
+++ b/_licenses/agpl-3.0.txt
@@ -12,6 +12,8 @@ how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of 
 
 note: The Free Software Foundation recommends taking the additional step of adding a boilerplate notice to the top of each file. The boilerplate can be found at the end of the license.
 
+using:
+
 permissions:
   - commercial-use
   - modifications

--- a/_licenses/artistic-2.0.txt
+++ b/_licenses/artistic-2.0.txt
@@ -8,6 +8,8 @@ description: Heavily favored by the Perl community, the Artistic license require
 
 how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code, and copy the text of the license into the file. Do not replace the copyright notice (year, author), which refers to the license itself, not the licensed project.
 
+using:
+
 permissions:
   - commercial-use
   - modifications

--- a/_licenses/bsd-2-clause.txt
+++ b/_licenses/bsd-2-clause.txt
@@ -9,6 +9,8 @@ description: A permissive license that comes in two variants, the <a href="/lice
 
 how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file. Replace [year] with the current year and [fullname] with the name (or names) of the copyright holders.
 
+using:
+
 permissions:
   - commercial-use
   - modifications

--- a/_licenses/bsd-3-clause-clear.txt
+++ b/_licenses/bsd-3-clause-clear.txt
@@ -7,6 +7,8 @@ description: A variant of the <a href="/licenses/bsd-3-clause/">BSD 3-Clause Lic
 
 how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file. Replace [year] with the current year and [fullname] with the name (or names) of the copyright holders. Replace [project] with the project organization, if any, that sponsors this work.
 
+using:
+
 permissions:
   - commercial-use
   - modifications

--- a/_licenses/bsd-3-clause.txt
+++ b/_licenses/bsd-3-clause.txt
@@ -8,6 +8,8 @@ description: A permissive license similar to the <a href="/licenses/bsd-2-clause
 
 how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file. Replace [year] with the current year and [fullname] with the name (or names) of the copyright holders. Replace [project] with the project organization, if any, that sponsors this work.
 
+using:
+
 permissions:
   - commercial-use
   - modifications

--- a/_licenses/bsl-1.0.txt
+++ b/_licenses/bsl-1.0.txt
@@ -9,6 +9,8 @@ how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of 
 
 note: Boost recommends taking the additional step of adding a boilerplate notice to the top of each file. The boilerplate can be found at the [Boost Software License FAQ](http://www.boost.org/users/license.html#FAQ).
 
+using:
+
 permissions:
   - commercial-use
   - modifications

--- a/_licenses/cc-by-4.0.txt
+++ b/_licenses/cc-by-4.0.txt
@@ -7,6 +7,8 @@ description: Permits almost any use subject to providing credit and license noti
 
 how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file. It is also acceptable to soley supply a link to a copy of the license, usually to the <a href='https://creativecommons.org/licenses/by/4.0/'>canonical URL for the license</a>.
 
+using:
+
 permissions:
   - commercial-use
   - modifications

--- a/_licenses/cc-by-sa-4.0.txt
+++ b/_licenses/cc-by-sa-4.0.txt
@@ -7,6 +7,8 @@ description: Similar to <a href='/licenses/cc-by-4.0/'>CC-BY-4.0</a> but require
 
 how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file. It is also acceptable to soley supply a link to a copy of the license, usually to the <a href='https://creativecommons.org/licenses/by-sa/4.0/'>canonical URL for the license</a>.
 
+using:
+
 permissions:
   - commercial-use
   - modifications

--- a/_licenses/cc0-1.0.txt
+++ b/_licenses/cc0-1.0.txt
@@ -10,6 +10,8 @@ how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of 
 
 note: Creative Commons recommends taking the additional step of adding a boilerplate notice to the top of each file. The boilerplate can be <a href="https://wiki.creativecommons.org/wiki/CC0_FAQ#May_I_apply_CC0_to_computer_software.3F_If_so.2C_is_there_a_recommended_implementation.3F">found on their website</a>.
 
+using:
+
 permissions:
   - commercial-use
   - modifications

--- a/_licenses/eupl-1.1.txt
+++ b/_licenses/eupl-1.1.txt
@@ -10,6 +10,8 @@ how: Create a text file (typically named COPYING or LICENCE.txt) in the root of 
 
 note: The European Commission recommends taking the additional step of adding a [boilerplate notice](https://joinup.ec.europa.eu/sites/default/files/ckeditor_files/files/EUPL%201_1%20Guidelines%20EN%20Joinup.pdf#page=17) to the top of each file.
 
+using:
+
 permissions:
   - commercial-use
   - modifications

--- a/_licenses/lgpl-2.1.txt
+++ b/_licenses/lgpl-2.1.txt
@@ -12,6 +12,8 @@ how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of 
 
 note: The Free Software Foundation recommends taking the additional step of adding a boilerplate notice to the top of each file. The boilerplate can be found at the end of the license.
 
+using:
+
 permissions:
   - commercial-use
   - modifications

--- a/_licenses/lgpl-3.0.txt
+++ b/_licenses/lgpl-3.0.txt
@@ -12,6 +12,8 @@ how: This license is an additional set of permissions to the <a href="/licenses/
 
 note: The Free Software Foundation recommends taking the additional step of adding a boilerplate notice to the top of each file. The boilerplate can be found at the end of the <a href="/licenses/gpl-3.0">GNU GPLv3 license</a>. Insert the word “Lesser” before “General” in all three places in the boilerplate notice to make sure that you refer to the GNU LGPLv3 and not the GNU GPLv3.
 
+using:
+
 permissions:
   - commercial-use
   - modifications

--- a/_licenses/lppl-1.3c.txt
+++ b/_licenses/lppl-1.3c.txt
@@ -9,6 +9,8 @@ how: To use this license, place in each of the components of your work both an e
 
 note: An example boilerplate and more information about how to use the license can be found at the end of the license.
 
+using:
+
 permissions:
   - commercial-use
   - modifications

--- a/_licenses/ms-pl.txt
+++ b/_licenses/ms-pl.txt
@@ -7,6 +7,8 @@ description: An open source license with a patent grant.
 
 how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file.
 
+using:
+
 permissions:
   - commercial-use
   - modifications

--- a/_licenses/ms-rl.txt
+++ b/_licenses/ms-rl.txt
@@ -7,6 +7,8 @@ description: An open source license with a patent grant similar to the <a href="
 
 how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file.
 
+using:
+
 permissions:
   - commercial-use
   - modifications

--- a/_licenses/ncsa.txt
+++ b/_licenses/ncsa.txt
@@ -13,7 +13,6 @@ using:
  - ROCR-Runtime: https://github.com/RadeonOpenCompute/ROCR-Runtime/blob/master/LICENSE.txt
  - RLTK: https://github.com/chriswailes/RLTK/blob/master/LICENSE
 
-
 permissions:
   - commercial-use
   - modifications

--- a/_licenses/ofl-1.1.txt
+++ b/_licenses/ofl-1.1.txt
@@ -10,6 +10,8 @@ how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of 
 
 note: This license doesn't require source provision, but recommends it. All files derived from OFL files must remain licensed under the OFL.
 
+using:
+
 permissions:
   - private-use
   - commercial-use

--- a/_licenses/wtfpl.txt
+++ b/_licenses/wtfpl.txt
@@ -7,6 +7,8 @@ description: The easiest license out there. It gives the user permissions to do 
 
 how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file.
 
+using:
+
 permissions:
   - commercial-use
   - modifications

--- a/_licenses/zlib.txt
+++ b/_licenses/zlib.txt
@@ -7,6 +7,8 @@ description: A short permissive license, compatible with GPL. Requires altered s
 
 how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file. Replace [year] with the current year and [fullname] with the name (or names) of the copyright holders.
 
+using:
+
 permissions:
   - commercial-use
   - modifications

--- a/spec/license_meta_spec.rb
+++ b/spec/license_meta_spec.rb
@@ -18,6 +18,34 @@ describe 'license meta' do
         missing = required - raw_fields.keys
         expect(missing).to be_empty
       end
+
+      it 'using contains 3 examples' do
+        legacy = [
+          'afl-3.0',
+          'agpl-3.0',
+          'artistic-2.0',
+          'bsd-2-clause',
+          'bsd-3-clause',
+          'bsd-3-clause-clear',
+          'bsl-1.0',
+          'cc0-1.0',
+          'cc-by-4.0',
+          'cc-by-sa-4.0',
+          'eupl-1.1',
+          'gpl-2.0',
+          'lgpl-2.1',
+          'lgpl-3.0',
+          'lppl-1.3c',
+          'ms-pl',
+          'ms-rl',
+          'ofl-1.1',
+          'wtfpl',
+          'zlib'
+        ]
+        skip 'added before 3 using examples required' if legacy.include?(license['slug'])
+        examples = raw_fields['using'] || []
+        expect(examples.length).to eq(3)
+      end
     end
   end
 end


### PR DESCRIPTION
`using:` examples are documented as optional, but going forward I'd like to make them mandatory. Almost any license proposed now will be somewhat obscure, as we have all the common ones. This additional requirement ensures that anything we add has examples 'in the wild' that could be detected. This came up a couple times recently: #498 #511 

Fixes #508

Note there are 20 licenses marked as 'legacy' which test for 3 examples skips. I'd be happy to see examples added to those over time.

Note absolutely no testing is done to ensure that 3 examples could be detected (it'd be possible to rig up a test using licensee and the licenses cataloged in a branch) or even are URLs. This seems good enough as a first pass.