### PR TITLE
Remove stacktrace.js as Unlicense example

### DIFF
--- a/_licenses/unlicense.txt
+++ b/_licenses/unlicense.txt
@@ -11,6 +11,7 @@ how: Create a text file (typically named UNLICENSE or UNLICENSE.txt) in the root
 using:
   - youtube-dl: https://github.com/rg3/youtube-dl/blob/master/LICENSE
   - kakoune: https://github.com/mawww/kakoune/blob/master/UNLICENSE
+  - docopt.rs: https://github.com/docopt/docopt.rs/blob/master/UNLICENSE
 
 permissions:
   - private-use

--- a/_licenses/unlicense.txt
+++ b/_licenses/unlicense.txt
@@ -10,7 +10,6 @@ how: Create a text file (typically named UNLICENSE or UNLICENSE.txt) in the root
 
 using:
   - youtube-dl: https://github.com/rg3/youtube-dl/blob/master/LICENSE
-  - stacktrace.js: https://github.com/stacktracejs/stacktrace.js/blob/master/LICENSE
   - kakoune: https://github.com/mawww/kakoune/blob/master/UNLICENSE
 
 permissions:


### PR DESCRIPTION
They are using MIT now, see: https://github.com/stacktracejs/stacktrace.js/blob/master/LICENSE (changed in: stacktracejs/stacktrace.js@a9e4d53) 

Fixes #515 