### PR TITLE
Use HTTPS for licences if available

### DIFF
--- a/_licenses/afl-3.0.txt
+++ b/_licenses/afl-3.0.txt
@@ -1,7 +1,7 @@
 ---
 title: Academic Free License v3.0
 spdx-id: AFL-3.0
-source: http://opensource.org/licenses/afl-3.0
+source: https://opensource.org/licenses/afl-3.0
 
 description: The Academic Free License is a variant of the Open Software License that does not require that the source code of derivative works be disclosed. It contains explicit copyright and patent grants and reserves trademark rights in the author.
 

--- a/_licenses/agpl-3.0.txt
+++ b/_licenses/agpl-3.0.txt
@@ -3,7 +3,7 @@ title: GNU Affero General Public License v3.0
 spdx-id: AGPL-3.0
 nickname: GNU AGPLv3
 redirect_from: /licenses/agpl/
-source: http://www.gnu.org/licenses/agpl-3.0.txt
+source: https://www.gnu.org/licenses/agpl-3.0.txt
 hidden: false
 
 description: Permissions of this strongest copyleft license are conditioned on making available complete source code of licensed works and modifications, which include larger works using a licensed work, under the same license. Copyright and license notices must be preserved. Contributors provide an express grant of patent rights. When a modified version is used to provide a service over a network, the complete source code of the modified version must be made available.

--- a/_licenses/apache-2.0.txt
+++ b/_licenses/apache-2.0.txt
@@ -2,7 +2,7 @@
 title: Apache License 2.0
 spdx-id: Apache-2.0
 redirect_from: /licenses/apache/
-source: http://www.apache.org/licenses/LICENSE-2.0.html
+source: https://www.apache.org/licenses/LICENSE-2.0.html
 featured: true
 hidden: false
 

--- a/_licenses/bsd-2-clause.txt
+++ b/_licenses/bsd-2-clause.txt
@@ -2,7 +2,7 @@
 title: BSD 2-clause "Simplified" License
 spdx-id: BSD-2-Clause
 redirect_from: /licenses/bsd/
-source: http://opensource.org/licenses/BSD-2-Clause
+source: https://opensource.org/licenses/BSD-2-Clause
 hidden: false
 
 description: A permissive license that comes in two variants, the <a href="/licenses/bsd-2-clause/">BSD 2-Clause</a> and <a href="/licenses/bsd-3-clause/">BSD 3-Clause</a>. Both have very minute differences to the MIT license.

--- a/_licenses/bsd-3-clause.txt
+++ b/_licenses/bsd-3-clause.txt
@@ -1,7 +1,7 @@
 ---
 title: BSD 3-clause "New" or "Revised" License
 spdx-id: BSD-3-Clause
-source: http://opensource.org/licenses/BSD-3-Clause
+source: https://opensource.org/licenses/BSD-3-Clause
 hidden: false
 
 description: A permissive license similar to the <a href="/licenses/bsd-2-clause/">BSD 2-Clause License</a>, but with a 3rd clause that prohibits others from using the name of the project or its contributors to promote derived products without written consent.

--- a/_licenses/cc0-1.0.txt
+++ b/_licenses/cc0-1.0.txt
@@ -2,9 +2,9 @@
 title: Creative Commons Zero v1.0 Universal
 spdx-id: CC0-1.0
 redirect_from: /licenses/cc0/
-source: http://creativecommons.org/publicdomain/zero/1.0/
+source: https://creativecommons.org/publicdomain/zero/1.0/
 
-description: The <a href="http://creativecommons.org/publicdomain/zero/1.0/">Creative Commons CC0 Public Domain Dedication</a> waives copyright interest in any a work you've created and dedicates it to the world-wide public domain. Use CC0 to opt out of copyright entirely and ensure your work has the widest reach. As with the Unlicense and typical software licenses, CC0 disclaims warranties. CC0 is very similar to the Unlicense.
+description: The <a href="https://creativecommons.org/publicdomain/zero/1.0/">Creative Commons CC0 Public Domain Dedication</a> waives copyright interest in any a work you've created and dedicates it to the world-wide public domain. Use CC0 to opt out of copyright entirely and ensure your work has the widest reach. As with the Unlicense and typical software licenses, CC0 disclaims warranties. CC0 is very similar to the Unlicense.
 
 how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the CC0 into the file.
 

--- a/_licenses/gpl-2.0.txt
+++ b/_licenses/gpl-2.0.txt
@@ -3,7 +3,7 @@ title: GNU General Public License v2.0
 spdx-id: GPL-2.0
 nickname: GNU GPLv2
 redirect_from: /licenses/gpl-v2/
-source: http://www.gnu.org/licenses/gpl-2.0.txt
+source: https://www.gnu.org/licenses/gpl-2.0.txt
 hidden: false
 
 description: The GNU GPL is the most widely used free software license and has a strong copyleft requirement. When distributing derived works, the source code of the work must be made available under the same license. There are multiple variants of the GNU GPL, each with different requirements.

--- a/_licenses/gpl-3.0.txt
+++ b/_licenses/gpl-3.0.txt
@@ -3,7 +3,7 @@ title: GNU General Public License v3.0
 spdx-id: GPL-3.0
 nickname: GNU GPLv3
 redirect_from: /licenses/gpl-v3/
-source: http://www.gnu.org/licenses/gpl-3.0.txt
+source: https://www.gnu.org/licenses/gpl-3.0.txt
 featured: true
 hidden: false
 
@@ -14,7 +14,7 @@ how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of 
 note: The Free Software Foundation recommends taking the additional step of adding a boilerplate notice to the top of each file. The boilerplate can be found at the end of the license.
 
 using:
-  - Bash: http://git.savannah.gnu.org/cgit/bash.git/tree/COPYING
+  - Bash: https://git.savannah.gnu.org/cgit/bash.git/tree/COPYING
   - GIMP: https://git.gnome.org/browse/gimp/tree/COPYING
   - Privacy Badger: https://github.com/EFForg/privacybadgerfirefox/blob/master/LICENSE
 

--- a/_licenses/isc.txt
+++ b/_licenses/isc.txt
@@ -1,7 +1,7 @@
 ---
 title: ISC License
 spdx-id: ISC
-source: http://opensource.org/licenses/isc-license
+source: https://opensource.org/licenses/isc-license
 
 description: A permissive license lets people do anything with your code with proper attribution and without warranty. The ISC license is functionally equivalent to the <a href="/licenses/bsd-2-clause/">BSD 2-Clause</a> and <a href="/licenses/mit/">MIT</a> licenses, removing some language that is no longer necessary.
 

--- a/_licenses/lgpl-2.1.txt
+++ b/_licenses/lgpl-2.1.txt
@@ -3,7 +3,7 @@ title: GNU Lesser General Public License v2.1
 spdx-id: LGPL-2.1
 nickname: GNU LGPLv2.1
 redirect_from: /licenses/lgpl-v2.1/
-source: http://www.gnu.org/licenses/lgpl-2.1.txt
+source: https://www.gnu.org/licenses/lgpl-2.1.txt
 hidden: false
 
 description: Primarily used for software libraries, the GNU LGPL requires that derived works be licensed under the same license, but works that only link to it do not fall under this restriction. There are two commonly used versions of the GNU LGPL.

--- a/_licenses/lgpl-3.0.txt
+++ b/_licenses/lgpl-3.0.txt
@@ -3,7 +3,7 @@ title: GNU Lesser General Public License v3.0
 spdx-id: LGPL-3.0
 nickname: GNU LGPLv3
 redirect_from: /licenses/lgpl-v3/
-source: http://www.gnu.org/licenses/lgpl-3.0.txt
+source: https://www.gnu.org/licenses/lgpl-3.0.txt
 hidden: false
 
 description: Permissions of this copyleft license are conditioned on making available complete source code of licensed works and modifications under the same license or the GNU GPLv3. Copyright and license notices must be preserved. Contributors provide an express grant of patent rights. However, a larger work using the licensed work through interfaces provided by the licensed work may be distributed under different terms and without source code for the larger work.

--- a/_licenses/ms-pl.txt
+++ b/_licenses/ms-pl.txt
@@ -1,7 +1,7 @@
 ---
 title: Microsoft Public License
 spdx-id: MS-PL
-source: http://opensource.org/licenses/ms-pl
+source: https://opensource.org/licenses/ms-pl
 
 description: An open source license with a patent grant.
 

--- a/_licenses/ms-rl.txt
+++ b/_licenses/ms-rl.txt
@@ -1,7 +1,7 @@
 ---
 title: Microsoft Reciprocal License
 spdx-id: MS-RL
-source: http://opensource.org/licenses/ms-rl
+source: https://opensource.org/licenses/ms-rl
 
 description: An open source license with a patent grant similar to the <a href="/licenses/ms-pl/">Microsoft Public License</a>, with the additional condition that any source code for any derived file be provided under this license.
 

--- a/_licenses/osl-3.0.txt
+++ b/_licenses/osl-3.0.txt
@@ -1,7 +1,7 @@
 ---
 title: Open Software License 3.0
 spdx-id: OSL-3.0
-source: http://opensource.org/licenses/OSL-3.0
+source: https://opensource.org/licenses/OSL-3.0
 
 description: OSL 3.0 is a copyleft license that does not require reciprocal licensing on linked works. It also provides an express grant of patent rights from contributors to users, with a termination clause triggered if a user files a patent infringement lawsuit.
 

--- a/_licenses/unlicense.txt
+++ b/_licenses/unlicense.txt
@@ -1,7 +1,7 @@
 ---
 title: The Unlicense
 spdx-id: Unlicense
-source: http://unlicense.org/UNLICENSE
+source: https://unlicense.org/UNLICENSE
 hidden: false
 
 description: A license with no conditions whatsoever which dedicates works to the public domain. Unlicensed works, modifications, and larger works may be distributed under different terms and without source code.
@@ -50,4 +50,4 @@ OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
 ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 OTHER DEALINGS IN THE SOFTWARE.
 
-For more information, please refer to <https://unlicense.org>
+For more information, please refer to <http://unlicense.org>

--- a/existing.md
+++ b/existing.md
@@ -14,6 +14,6 @@ Some communities have strong preferences for particular licenses. If you want to
 
 * [Apache](https://www.apache.org/licenses/) requires [Apache License 2.0](/licenses/apache-2.0/)
 * [GNU](https://www.gnu.org/licenses/license-recommendations.html) recommends [GNU GPLv3](/licenses/gpl-3.0/) for most programs
-* [OpenBSD](http://www.openbsd.org/policy.html) prefers [ISC](/licenses/isc/)
+* [OpenBSD](https://www.openbsd.org/policy.html) prefers [ISC](/licenses/isc/)
 
 Communities come in all shapes and sizes. The examples above are *very* well established. If the community you see your project as a part of doesn't have set-in-stone licensing traditions, or you don't see your project as part of any particular community, that's just fine: [make your own choice of an open source license](/).

--- a/non-software.md
+++ b/non-software.md
@@ -4,7 +4,7 @@ layout: default
 permalink: /non-software/
 ---
 
-Open source software licenses can be used for non-software works, and often are the best choice. This is particularly the case when the works in question can be edited and versioned as source, e.g., [open source hardware](http://www.oshwa.org/definition/) designs. Choose an [open source license](/licenses/).
+Open source software licenses can be used for non-software works, and often are the best choice. This is particularly the case when the works in question can be edited and versioned as source, e.g., [open source hardware](https://www.oshwa.org/definition/) designs. Choose an [open source license](/licenses/).
 
 ### Data, media, etc.
 


### PR DESCRIPTION
I checked if the links in the licenses are reachable with HTTPS (including if they have valid certificate). If they are I changed the url to use HTTPS, but kept the other ones to plain HTTP like: `http://www.wtfpl.net/`