### PR TITLE
libcurl4-openssl-dev to maybe avoid SSL errors in tests?

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,11 @@ language: ruby
 rvm:
   - 2.4.0
 
+addons:
+  apt:
+    packages:
+    - libcurl4-openssl-dev
+
 branches:
   only:
     - gh-pages

--- a/_licenses/eupl-1.1.txt
+++ b/_licenses/eupl-1.1.txt
@@ -2,7 +2,7 @@
 title: European Union Public License 1.1
 spdx-id: EUPL-1.1
 redirect_from: /licenses/eupl-v1.1/
-source: https://joinup.ec.europa.eu/community/eupl/og_page/eupl-text-11-12
+source: https://joinup.ec.europa.eu/page/eupl-text-11-12
 
 description: The “European Union Public Licence” (EUPL) is a copyleft free/open source software license created on the initiative of and approved by the European Commission in 22 official languages of the European Union.
 


### PR DESCRIPTION
errors like https://github.com/github/choosealicense.com/pull/539#issuecomment-333402497

possible fix found at https://github.com/gjtorikian/html-proofer/issues/376#issuecomment-332770021