### PR TITLE
Bring gpl-2,3.0 and lgpl-2.1 texts closer to source versions

### DIFF
--- a/_licenses/gpl-2.0.txt
+++ b/_licenses/gpl-2.0.txt
@@ -326,8 +326,8 @@ to attach them to the start of each source file to most effectively
 convey the exclusion of warranty; and each file should have at least
 the "copyright" line and a pointer to where the full notice is found.
 
-    {description}
-    Copyright (C) {year}  {fullname}
+    <description>
+    Copyright (C) <year>  <fullname>
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -365,7 +365,7 @@ necessary.  Here is a sample; alter the names:
   Yoyodyne, Inc., hereby disclaims all copyright interest in the program
   `Gnomovision' (which makes passes at compilers) written by James Hacker.
 
-  {signature of Ty Coon}, 1 April 1989
+  <signature of Ty Coon>, 1 April 1989
   Ty Coon, President of Vice
 
 This General Public License does not permit incorporating your program into

--- a/_licenses/gpl-2.0.txt
+++ b/_licenses/gpl-2.0.txt
@@ -326,8 +326,8 @@ to attach them to the start of each source file to most effectively
 convey the exclusion of warranty; and each file should have at least
 the "copyright" line and a pointer to where the full notice is found.
 
-    <description>
-    Copyright (C) <year>  <fullname>
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/_licenses/gpl-2.0.txt
+++ b/_licenses/gpl-2.0.txt
@@ -37,7 +37,7 @@ limitations:
                     GNU GENERAL PUBLIC LICENSE
                        Version 2, June 1991
 
- Copyright (C) 1989, 1991 Free Software Foundation, Inc., <http://fsf.org/>
+ Copyright (C) 1989, 1991 Free Software Foundation, Inc.,
  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  Everyone is permitted to copy and distribute verbatim copies
  of this license document, but changing it is not allowed.

--- a/_licenses/gpl-3.0.txt
+++ b/_licenses/gpl-3.0.txt
@@ -691,7 +691,7 @@ Also add information on how to contact you by electronic and paper mail.
   If the program does terminal interaction, make it output a short
 notice like this when it starts in an interactive mode:
 
-    <project>  Copyright (C) <year>  <fullname>
+    <program>  Copyright (C) <year>  <name of author>
     This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
     This is free software, and you are welcome to redistribute it
     under certain conditions; type `show c' for details.

--- a/_licenses/gpl-3.0.txt
+++ b/_licenses/gpl-3.0.txt
@@ -670,8 +670,8 @@ to attach them to the start of each source file to most effectively
 state the exclusion of warranty; and each file should have at least
 the "copyright" line and a pointer to where the full notice is found.
 
-    {one line to give the program's name and a brief idea of what it does.}
-    Copyright (C) {year}  {name of author}
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -691,7 +691,7 @@ Also add information on how to contact you by electronic and paper mail.
   If the program does terminal interaction, make it output a short
 notice like this when it starts in an interactive mode:
 
-    {project}  Copyright (C) {year}  {fullname}
+    <project>  Copyright (C) <year>  <fullname>
     This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
     This is free software, and you are welcome to redistribute it
     under certain conditions; type `show c' for details.

--- a/_licenses/lgpl-2.1.txt
+++ b/_licenses/lgpl-2.1.txt
@@ -504,8 +504,8 @@ safest to attach them to the start of each source file to most effectively
 convey the exclusion of warranty; and each file should have at least the
 "copyright" line and a pointer to where the full notice is found.
 
-    {description}
-    Copyright (C) {year} {fullname}
+    <description>
+    Copyright (C) <year> <fullname>
 
     This library is free software; you can redistribute it and/or
     modify it under the terms of the GNU Lesser General Public
@@ -532,7 +532,7 @@ necessary.  Here is a sample; alter the names:
   library `Frob' (a library for tweaking knobs) written by James Random
   Hacker.
 
-  {signature of Ty Coon}, 1 April 1990
+  <signature of Ty Coon>, 1 April 1990
   Ty Coon, President of Vice
 
 That's all there is to it!

--- a/_licenses/lgpl-2.1.txt
+++ b/_licenses/lgpl-2.1.txt
@@ -504,8 +504,8 @@ safest to attach them to the start of each source file to most effectively
 convey the exclusion of warranty; and each file should have at least the
 "copyright" line and a pointer to where the full notice is found.
 
-    <description>
-    Copyright (C) <year> <fullname>
+    <one line to give the library's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
 
     This library is free software; you can redistribute it and/or
     modify it under the terms of the GNU Lesser General Public

--- a/_licenses/osl-3.0.txt
+++ b/_licenses/osl-3.0.txt
@@ -11,7 +11,7 @@ note: OSL 3.0's author has <a href="http://rosenlaw.com/OSL3.0-explained.htm">pr
 
 using:
   - appserver.io: https://github.com/appserver-io/appserver/blob/master/LICENSE.txt
-  - Magento 2: https://github.com/magento/magento2/blob/develop/LICENSE.txt
+  - JsonMapper: https://github.com/cweiske/jsonmapper/blob/master/LICENSE
   - Restyaboard: https://github.com/RestyaPlatform/board/blob/master/LICENSE.txt
 
 permissions:


### PR DESCRIPTION
As promised at https://github.com/github/choosealicense.com/issues/542#issuecomment-337755749

There are still a couple differences:

- https://www.gnu.org/licenses/lgpl-2.1.txt has a parenthetical in square brackets near the top, our version has parens; maybe could be changed later depending on outcome of #542 
- https://www.gnu.org/licenses/gpl-3.0.txt has gnu.org and fsf.org links with https as does https://www.gnu.org/licenses/agpl-3.0.txt ... that seems to have been introduced only last month between http://web.archive.org/web/20170908053542/http://www.gnu.org/licenses/gpl-3.0.txt and  http://web.archive.org/web/20170930072152/http://www.gnu.org/licenses/gpl-3.0.txt ... unfortunate in my view

cc @wking I imagine you might have comments.