### PR TITLE
Replace gems with plugins to follow up jekyll update

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -35,7 +35,7 @@ exclude:
   - assets/vendor/selectivizr/tests
   - assets/vendor/clipboard/test
 
-gems:
+plugins:
   - jekyll-sitemap
   - jekyll-redirect-from
   - jekyll-seo-tag


### PR DESCRIPTION
This applies the change of https://github.com/jekyll/jekyll/issues/4509. Now it uses `plugins` instead of `gems`. This patch removes below warning of deprecation.
```
Deprecation: The 'gems' configuration option has been renamed to 'plugins'. Please update your config file accordingly.
```