### PR TITLE
Fix a syntax warning from Liquid

### DIFF
--- a/appendix.md
+++ b/appendix.md
@@ -25,7 +25,7 @@ If you're here to choose a license, **[start from the home page](/)** to see a f
     {% endfor %}
   {% endfor %}
 </tr>
-{% assign licenses = site.licenses sort: "path" %}
+{% assign licenses = site.licenses | sort: "path" %}
 {% for license in licenses %}
   <tr style="height: 3em"><th scope="row"><a href="{{ license.id }}">{{ license.title }}</a></th>
   {% assign seen_tags = '' %}


### PR DESCRIPTION
When I run `script/server`, I got an error.
```
Liquid Warning: Liquid syntax error (line 21): Expected end_of_string but found id in "{{site.licenses sort: "path" }}" in appendix.md
```
So I fixed it.