### PR TITLE
make wtfpl source: field point to url with license text

### DIFF
--- a/_licenses/apache-2.0.txt
+++ b/_licenses/apache-2.0.txt
@@ -13,8 +13,8 @@ how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of 
 note: The Apache Foundation recommends taking the additional step of adding a boilerplate notice to the header of each source file. You can find the notice at the very end of the license in the appendix.
 
 using:
-  - Android: https://github.com/android/platform_system_core/blob/master/NOTICE
-  - Apache: https://svn.apache.org/viewvc/httpd/httpd/trunk/LICENSE?view=markup
+  - Elasticsearch: https://github.com/elastic/elasticsearch/blob/master/LICENSE.txt
+  - Kubernetes: https://github.com/kubernetes/kubernetes/blob/master/LICENSE
   - Swift: https://github.com/apple/swift/blob/master/LICENSE.txt
 
 permissions:

--- a/_licenses/wtfpl.txt
+++ b/_licenses/wtfpl.txt
@@ -1,7 +1,7 @@
 ---
 title: "Do What The F*ck You Want To Public License"
 spdx-id: WTFPL
-source: http://www.wtfpl.net/
+source: http://www.wtfpl.net/txt/copying/
 
 description: The easiest license out there. It gives the user permissions to do whatever they want with your code.
 


### PR DESCRIPTION
The WTFPL homepage doesn't include the license text. Should be http://www.wtfpl.net/txt/copying/ per https://spdx.org/licenses/WTFPL.html

Noted at https://github.com/benbalter/licensee/pull/238#discussion_r150688220