### PR TITLE
Wrap license text at ~78 columns

### DIFF
--- a/_licenses/afl-3.0.txt
+++ b/_licenses/afl-3.0.txt
@@ -70,19 +70,19 @@ copy of the Source Code in an information repository reasonably calculated to
 permit inexpensive and convenient access by You for as long as Licensor
 continues to distribute the Original Work.
 
- 4) Exclusions From License Grant. Neither the names of Licensor, nor the
- names of any contributors to the Original Work, nor any of their trademarks
- or service marks, may be used to endorse or promote products derived from
- this Original Work without express prior permission of the Licensor. Except
- as expressly stated herein, nothing in this License grants any license to
- Licensor’s trademarks, copyrights, patents, trade secrets or any other
- intellectual property. No patent license is granted to make, use, sell, offer
- for sale, have made, or import embodiments of any patent claims other than
- the licensed claims defined in Section 2. No license is granted to the
- trademarks of Licensor even if such marks are included in the Original Work.
- Nothing in this License shall be interpreted to prohibit Licensor from
- licensing under terms different from this License any Original Work that
- Licensor otherwise would have a right to license.
+4) Exclusions From License Grant. Neither the names of Licensor, nor the names
+of any contributors to the Original Work, nor any of their trademarks or
+service marks, may be used to endorse or promote products derived from this
+Original Work without express prior permission of the Licensor. Except as
+expressly stated herein, nothing in this License grants any license to
+Licensor’s trademarks, copyrights, patents, trade secrets or any other
+intellectual property. No patent license is granted to make, use, sell, offer
+for sale, have made, or import embodiments of any patent claims other than the
+licensed claims defined in Section 2. No license is granted to the trademarks
+of Licensor even if such marks are included in the Original Work. Nothing in
+this License shall be interpreted to prohibit Licensor from licensing under
+terms different from this License any Original Work that Licensor otherwise
+would have a right to license.
 
 5) External Deployment. The term "External Deployment" means the use,
 distribution, or communication of the Original Work or Derivative Works in any

--- a/_licenses/afl-3.0.txt
+++ b/_licenses/afl-3.0.txt
@@ -34,23 +34,25 @@ authorship (the "Original Work") whose owner (the "Licensor") has placed the
 following licensing notice adjacent to the copyright notice for the Original
 Work:
 
-Licensed under the Academic Free License version 3.0
+     Licensed under the Academic Free License version 3.0
 
 1) Grant of Copyright License. Licensor grants You a worldwide, royalty-free,
 non-exclusive, sublicensable license, for the duration of the copyright, to do
 the following:
 
-a) to reproduce the Original Work in copies, either alone or as part of a
-collective work;
-b) to translate, adapt, alter, transform, modify, or arrange the Original
-Work, thereby creating derivative works ("Derivative Works") based upon the
-Original Work;
-c) to distribute or communicate copies of the Original Work and Derivative
-Works to the public, under any license of your choice that does not contradict
-the terms and conditions, including Licensor’s reserved rights and remedies,
-in this Academic Free License;
-d) to perform the Original Work publicly; and
-e) to display the Original Work publicly.
+     a) to reproduce the Original Work in copies, either alone or as part of a
+     collective work;
+
+     b) to translate, adapt, alter, transform, modify, or arrange the Original
+     Work, thereby creating derivative works ("Derivative Works") based upon
+     the Original Work;
+
+     c) to distribute or communicate copies of the Original Work and
+     Derivative Works to the public, under any license of your choice that
+     does not contradict the terms and conditions, including Licensor’s
+     reserved rights and remedies, in this Academic Free License;
+     d) to perform the Original Work publicly; and
+     e) to display the Original Work publicly.
 
 2) Grant of Patent License. Licensor grants You a worldwide, royalty-free,
 non-exclusive, sublicensable license, under patent claims owned or controlled
@@ -68,19 +70,19 @@ copy of the Source Code in an information repository reasonably calculated to
 permit inexpensive and convenient access by You for as long as Licensor
 continues to distribute the Original Work.
 
-4) Exclusions From License Grant. Neither the names of Licensor, nor the names
-of any contributors to the Original Work, nor any of their trademarks or
-service marks, may be used to endorse or promote products derived from this
-Original Work without express prior permission of the Licensor. Except as
-expressly stated herein, nothing in this License grants any license to
-Licensor’s trademarks, copyrights, patents, trade secrets or any other
-intellectual property. No patent license is granted to make, use, sell, offer
-for sale, have made, or import embodiments of any patent claims other than the
-licensed claims defined in Section 2. No license is granted to the trademarks
-of Licensor even if such marks are included in the Original Work. Nothing in
-this License shall be interpreted to prohibit Licensor from licensing under
-terms different from this License any Original Work that Licensor otherwise
-would have a right to license.
+ 4) Exclusions From License Grant. Neither the names of Licensor, nor the
+ names of any contributors to the Original Work, nor any of their trademarks
+ or service marks, may be used to endorse or promote products derived from
+ this Original Work without express prior permission of the Licensor. Except
+ as expressly stated herein, nothing in this License grants any license to
+ Licensor’s trademarks, copyrights, patents, trade secrets or any other
+ intellectual property. No patent license is granted to make, use, sell, offer
+ for sale, have made, or import embodiments of any patent claims other than
+ the licensed claims defined in Section 2. No license is granted to the
+ trademarks of Licensor even if such marks are included in the Original Work.
+ Nothing in this License shall be interpreted to prohibit Licensor from
+ licensing under terms different from this License any Original Work that
+ Licensor otherwise would have a right to license.
 
 5) External Deployment. The term "External Deployment" means the use,
 distribution, or communication of the Original Work or Derivative Works in any

--- a/_licenses/afl-3.0.txt
+++ b/_licenses/afl-3.0.txt
@@ -29,44 +29,169 @@ limitations:
 
 Academic Free License (“AFL”) v. 3.0
 
-This Academic Free License (the "License") applies to any original work of authorship (the "Original Work") whose owner (the "Licensor") has placed the following licensing notice adjacent to the copyright notice for the Original Work:
+This Academic Free License (the "License") applies to any original work of
+authorship (the "Original Work") whose owner (the "Licensor") has placed the
+following licensing notice adjacent to the copyright notice for the Original
+Work:
 
 Licensed under the Academic Free License version 3.0
 
-1) Grant of Copyright License. Licensor grants You a worldwide, royalty-free, non-exclusive, sublicensable license, for the duration of the copyright, to do the following:
+1) Grant of Copyright License. Licensor grants You a worldwide, royalty-free,
+non-exclusive, sublicensable license, for the duration of the copyright, to do
+the following:
 
-  a) to reproduce the Original Work in copies, either alone or as part of a collective work;
-  b) to translate, adapt, alter, transform, modify, or arrange the Original Work, thereby creating derivative works ("Derivative Works") based upon the Original Work;
-  c) to distribute or communicate copies of the Original Work and Derivative Works to the public, under any license of your choice that does not contradict the terms and conditions, including Licensor’s reserved rights and remedies, in this Academic Free License;
-  d) to perform the Original Work publicly; and
-  e) to display the Original Work publicly.
+a) to reproduce the Original Work in copies, either alone or as part of a
+collective work;
+b) to translate, adapt, alter, transform, modify, or arrange the Original
+Work, thereby creating derivative works ("Derivative Works") based upon the
+Original Work;
+c) to distribute or communicate copies of the Original Work and Derivative
+Works to the public, under any license of your choice that does not contradict
+the terms and conditions, including Licensor’s reserved rights and remedies,
+in this Academic Free License;
+d) to perform the Original Work publicly; and
+e) to display the Original Work publicly.
 
-2) Grant of Patent License. Licensor grants You a worldwide, royalty-free, non-exclusive, sublicensable license, under patent claims owned or controlled by the Licensor that are embodied in the Original Work as furnished by the Licensor, for the duration of the patents, to make, use, sell, offer for sale, have made, and import the Original Work and Derivative Works.
+2) Grant of Patent License. Licensor grants You a worldwide, royalty-free,
+non-exclusive, sublicensable license, under patent claims owned or controlled
+by the Licensor that are embodied in the Original Work as furnished by the
+Licensor, for the duration of the patents, to make, use, sell, offer for sale,
+have made, and import the Original Work and Derivative Works.
 
-3) Grant of Source Code License. The term "Source Code" means the preferred form of the Original Work for making modifications to it and all available documentation describing how to modify the Original Work. Licensor agrees to provide a machine-readable copy of the Source Code of the Original Work along with each copy of the Original Work that Licensor distributes. Licensor reserves the right to satisfy this obligation by placing a machine-readable copy of the Source Code in an information repository reasonably calculated to permit inexpensive and convenient access by You for as long as Licensor continues to distribute the Original Work.
+3) Grant of Source Code License. The term "Source Code" means the preferred
+form of the Original Work for making modifications to it and all available
+documentation describing how to modify the Original Work. Licensor agrees to
+provide a machine-readable copy of the Source Code of the Original Work along
+with each copy of the Original Work that Licensor distributes. Licensor
+reserves the right to satisfy this obligation by placing a machine-readable
+copy of the Source Code in an information repository reasonably calculated to
+permit inexpensive and convenient access by You for as long as Licensor
+continues to distribute the Original Work.
 
-4) Exclusions From License Grant. Neither the names of Licensor, nor the names of any contributors to the Original Work, nor any of their trademarks or service marks, may be used to endorse or promote products derived from this Original Work without express prior permission of the Licensor. Except as expressly stated herein, nothing in this License grants any license to Licensor’s trademarks, copyrights, patents, trade secrets or any other intellectual property. No patent license is granted to make, use, sell, offer for sale, have made, or import embodiments of any patent claims other than the licensed claims defined in Section 2. No license is granted to the trademarks of Licensor even if such marks are included in the Original Work. Nothing in this License shall be interpreted to prohibit Licensor from licensing under terms different from this License any Original Work that Licensor otherwise would have a right to license.
+4) Exclusions From License Grant. Neither the names of Licensor, nor the names
+of any contributors to the Original Work, nor any of their trademarks or
+service marks, may be used to endorse or promote products derived from this
+Original Work without express prior permission of the Licensor. Except as
+expressly stated herein, nothing in this License grants any license to
+Licensor’s trademarks, copyrights, patents, trade secrets or any other
+intellectual property. No patent license is granted to make, use, sell, offer
+for sale, have made, or import embodiments of any patent claims other than the
+licensed claims defined in Section 2. No license is granted to the trademarks
+of Licensor even if such marks are included in the Original Work. Nothing in
+this License shall be interpreted to prohibit Licensor from licensing under
+terms different from this License any Original Work that Licensor otherwise
+would have a right to license.
 
-5) External Deployment. The term "External Deployment" means the use, distribution, or communication of the Original Work or Derivative Works in any way such that the Original Work or Derivative Works may be used by anyone other than You, whether those works are distributed or communicated to those persons or made available as an application intended for use over a network. As an express condition for the grants of license hereunder, You must treat any External Deployment by You of the Original Work or a Derivative Work as a distribution under section 1(c).
+5) External Deployment. The term "External Deployment" means the use,
+distribution, or communication of the Original Work or Derivative Works in any
+way such that the Original Work or Derivative Works may be used by anyone
+other than You, whether those works are distributed or communicated to those
+persons or made available as an application intended for use over a network.
+As an express condition for the grants of license hereunder, You must treat
+any External Deployment by You of the Original Work or a Derivative Work as a
+distribution under section 1(c).
 
-6) Attribution Rights. You must retain, in the Source Code of any Derivative Works that You create, all copyright, patent, or trademark notices from the Source Code of the Original Work, as well as any notices of licensing and any descriptive text identified therein as an "Attribution Notice." You must cause the Source Code for any Derivative Works that You create to carry a prominent Attribution Notice reasonably calculated to inform recipients that You have modified the Original Work.
+6) Attribution Rights. You must retain, in the Source Code of any Derivative
+Works that You create, all copyright, patent, or trademark notices from the
+Source Code of the Original Work, as well as any notices of licensing and any
+descriptive text identified therein as an "Attribution Notice." You must cause
+the Source Code for any Derivative Works that You create to carry a prominent
+Attribution Notice reasonably calculated to inform recipients that You have
+modified the Original Work.
 
-7) Warranty of Provenance and Disclaimer of Warranty. Licensor warrants that the copyright in and to the Original Work and the patent rights granted herein by Licensor are owned by the Licensor or are sublicensed to You under the terms of this License with the permission of the contributor(s) of those copyrights and patent rights. Except as expressly stated in the immediately preceding sentence, the Original Work is provided under this License on an "AS IS" BASIS and WITHOUT WARRANTY, either express or implied, including, without limitation, the warranties of non-infringement, merchantability or fitness for a particular purpose. THE ENTIRE RISK AS TO THE QUALITY OF THE ORIGINAL WORK IS WITH YOU. This DISCLAIMER OF WARRANTY constitutes an essential part of this License. No license to the Original Work is granted by this License except under this disclaimer.
+7) Warranty of Provenance and Disclaimer of Warranty. Licensor warrants that
+the copyright in and to the Original Work and the patent rights granted herein
+by Licensor are owned by the Licensor or are sublicensed to You under the
+terms of this License with the permission of the contributor(s) of those
+copyrights and patent rights. Except as expressly stated in the immediately
+preceding sentence, the Original Work is provided under this License on an "AS
+IS" BASIS and WITHOUT WARRANTY, either express or implied, including, without
+limitation, the warranties of non-infringement, merchantability or fitness for
+a particular purpose. THE ENTIRE RISK AS TO THE QUALITY OF THE ORIGINAL WORK
+IS WITH YOU. This DISCLAIMER OF WARRANTY constitutes an essential part of this
+License. No license to the Original Work is granted by this License except
+under this disclaimer.
 
-8) Limitation of Liability. Under no circumstances and under no legal theory, whether in tort (including negligence), contract, or otherwise, shall the Licensor be liable to anyone for any indirect, special, incidental, or consequential damages of any character arising as a result of this License or the use of the Original Work including, without limitation, damages for loss of goodwill, work stoppage, computer failure or malfunction, or any and all other commercial damages or losses. This limitation of liability shall not apply to the extent applicable law prohibits such limitation.
+8) Limitation of Liability. Under no circumstances and under no legal theory,
+whether in tort (including negligence), contract, or otherwise, shall the
+Licensor be liable to anyone for any indirect, special, incidental, or
+consequential damages of any character arising as a result of this License or
+the use of the Original Work including, without limitation, damages for loss
+of goodwill, work stoppage, computer failure or malfunction, or any and all
+other commercial damages or losses. This limitation of liability shall not
+apply to the extent applicable law prohibits such limitation.
 
-9) Acceptance and Termination. If, at any time, You expressly assented to this License, that assent indicates your clear and irrevocable acceptance of this License and all of its terms and conditions. If You distribute or communicate copies of the Original Work or a Derivative Work, You must make a reasonable effort under the circumstances to obtain the express assent of recipients to the terms of this License. This License conditions your rights to undertake the activities listed in Section 1, including your right to create Derivative Works based upon the Original Work, and doing so without honoring these terms and conditions is prohibited by copyright law and international treaty. Nothing in this License is intended to affect copyright exceptions and limitations (including “fair use” or “fair dealing”). This License shall terminate immediately and You may no longer exercise any of the rights granted to You by this License upon your failure to honor the conditions in Section 1(c).
+9) Acceptance and Termination. If, at any time, You expressly assented to this
+License, that assent indicates your clear and irrevocable acceptance of this
+License and all of its terms and conditions. If You distribute or communicate
+copies of the Original Work or a Derivative Work, You must make a reasonable
+effort under the circumstances to obtain the express assent of recipients to
+the terms of this License. This License conditions your rights to undertake
+the activities listed in Section 1, including your right to create Derivative
+Works based upon the Original Work, and doing so without honoring these terms
+and conditions is prohibited by copyright law and international treaty.
+Nothing in this License is intended to affect copyright exceptions and
+limitations (including “fair use” or “fair dealing”). This License shall
+terminate immediately and You may no longer exercise any of the rights granted
+to You by this License upon your failure to honor the conditions in Section
+1(c).
 
-10) Termination for Patent Action. This License shall terminate automatically and You may no longer exercise any of the rights granted to You by this License as of the date You commence an action, including a cross-claim or counterclaim, against Licensor or any licensee alleging that the Original Work infringes a patent. This termination provision shall not apply for an action alleging patent infringement by combinations of the Original Work with other software or hardware.
+10) Termination for Patent Action. This License shall terminate automatically
+and You may no longer exercise any of the rights granted to You by this
+License as of the date You commence an action, including a cross-claim or
+counterclaim, against Licensor or any licensee alleging that the Original Work
+infringes a patent. This termination provision shall not apply for an action
+alleging patent infringement by combinations of the Original Work with other
+software or hardware.
 
-11) Jurisdiction, Venue and Governing Law. Any action or suit relating to this License may be brought only in the courts of a jurisdiction wherein the Licensor resides or in which Licensor conducts its primary business, and under the laws of that jurisdiction excluding its conflict-of-law provisions. The application of the United Nations Convention on Contracts for the International Sale of Goods is expressly excluded. Any use of the Original Work outside the scope of this License or after its termination shall be subject to the requirements and penalties of copyright or patent law in the appropriate jurisdiction. This section shall survive the termination of this License.
+11) Jurisdiction, Venue and Governing Law. Any action or suit relating to this
+License may be brought only in the courts of a jurisdiction wherein the
+Licensor resides or in which Licensor conducts its primary business, and under
+the laws of that jurisdiction excluding its conflict-of-law provisions. The
+application of the United Nations Convention on Contracts for the
+International Sale of Goods is expressly excluded. Any use of the Original
+Work outside the scope of this License or after its termination shall be
+subject to the requirements and penalties of copyright or patent law in the
+appropriate jurisdiction. This section shall survive the termination of this
+License.
 
-12) Attorneys’ Fees. In any action to enforce the terms of this License or seeking damages relating thereto, the prevailing party shall be entitled to recover its costs and expenses, including, without limitation, reasonable attorneys' fees and costs incurred in connection with such action, including any appeal of such action. This section shall survive the termination of this License.
+12) Attorneys’ Fees. In any action to enforce the terms of this License or
+seeking damages relating thereto, the prevailing party shall be entitled to
+recover its costs and expenses, including, without limitation, reasonable
+attorneys' fees and costs incurred in connection with such action, including
+any appeal of such action. This section shall survive the termination of this
+License.
 
-13) Miscellaneous. If any provision of this License is held to be unenforceable, such provision shall be reformed only to the extent necessary to make it enforceable.
+13) Miscellaneous. If any provision of this License is held to be
+unenforceable, such provision shall be reformed only to the extent necessary
+to make it enforceable.
 
-14) Definition of "You" in This License. "You" throughout this License, whether in upper or lower case, means an individual or a legal entity exercising rights under, and complying with all of the terms of, this License. For legal entities, "You" includes any entity that controls, is controlled by, or is under common control with you. For purposes of this definition, "control" means (i) the power, direct or indirect, to cause the direction or management of such entity, whether by contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the outstanding shares, or (iii) beneficial ownership of such entity.
+14) Definition of "You" in This License. "You" throughout this License,
+whether in upper or lower case, means an individual or a legal entity
+exercising rights under, and complying with all of the terms of, this License.
+For legal entities, "You" includes any entity that controls, is controlled by,
+or is under common control with you. For purposes of this definition,
+"control" means (i) the power, direct or indirect, to cause the direction or
+management of such entity, whether by contract or otherwise, or (ii) ownership
+of fifty percent (50%) or more of the outstanding shares, or (iii) beneficial
+ownership of such entity.
 
-15) Right to Use. You may use the Original Work in all ways not otherwise restricted or conditioned by this License or by law, and Licensor promises not to interfere with or be responsible for such uses by You.
+15) Right to Use. You may use the Original Work in all ways not otherwise
+restricted or conditioned by this License or by law, and Licensor promises not
+to interfere with or be responsible for such uses by You.
 
-16) Modification of This License. This License is Copyright © 2005 Lawrence Rosen. Permission is granted to copy, distribute, or communicate this License without modification. Nothing in this License permits You to modify this License as applied to the Original Work or to Derivative Works. However, You may modify the text of this License and copy, distribute or communicate your modified version (the "Modified License") and apply it to other original works of authorship subject to the following conditions: (i) You may not indicate in any way that your Modified License is the "Academic Free License" or "AFL" and you may not use those names in the name of your Modified License; (ii) You must replace the notice specified in the first paragraph above with the notice "Licensed under <insert your license name here>" or with a notice of your own that is not confusingly similar to the notice in this License; and (iii) You may not claim that your original works are open source software unless your Modified License has been approved by Open Source Initiative (OSI) and You comply with its license review and certification process.
+16) Modification of This License. This License is Copyright © 2005 Lawrence
+Rosen. Permission is granted to copy, distribute, or communicate this License
+without modification. Nothing in this License permits You to modify this
+License as applied to the Original Work or to Derivative Works. However, You
+may modify the text of this License and copy, distribute or communicate your
+modified version (the "Modified License") and apply it to other original works
+of authorship subject to the following conditions: (i) You may not indicate in
+any way that your Modified License is the "Academic Free License" or "AFL" and
+you may not use those names in the name of your Modified License; (ii) You
+must replace the notice specified in the first paragraph above with the notice
+"Licensed under <insert your license name here>" or with a notice of your own
+that is not confusingly similar to the notice in this License; and (iii) You
+may not claim that your original works are open source software unless your
+Modified License has been approved by Open Source Initiative (OSI) and You
+comply with its license review and certification process.

--- a/_licenses/bsd-3-clause-clear.txt
+++ b/_licenses/bsd-3-clause-clear.txt
@@ -41,9 +41,9 @@ below) provided that the following conditions are met:
      notice, this list of conditions and the following disclaimer in the
      documentation and/or other materials provided with the distribution.
 
-     * Neither the name of [fullname] nor the names of its contributors may be
-     used to endorse or promote products derived from this software without
-     specific prior written permission.
+     * Neither the name of the copyright holder nor the names of its
+     contributors may be used to endorse or promote products derived from this
+     software without specific prior written permission.
 
 NO EXPRESS OR IMPLIED LICENSES TO ANY PARTY'S PATENT RIGHTS ARE GRANTED BY
 THIS LICENSE. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND

--- a/_licenses/bsd-3-clause-clear.txt
+++ b/_licenses/bsd-3-clause-clear.txt
@@ -27,7 +27,7 @@ limitations:
 
 The Clear BSD License
 
-Copyright (c) [year], [fullname]
+Copyright (c) [year] [fullname]
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -35,25 +35,25 @@ modification, are permitted (subject to the limitations in the disclaimer
 below) provided that the following conditions are met:
 
 * Redistributions of source code must retain the above copyright notice, this
-  list of conditions and the following disclaimer.
+list of conditions and the following disclaimer.
 
 * Redistributions in binary form must reproduce the above copyright notice,
-  this list of conditions and the following disclaimer in the documentation
-  and/or other materials provided with the distribution.
+this list of conditions and the following disclaimer in the documentation
+and/or other materials provided with the distribution.
 
-* Neither the name of the copyright holder nor the names of its contributors may be used
-  to endorse or promote products derived from this software without specific
-  prior written permission.
+* Neither the name of [fullname] nor the names of its contributors may be used
+to endorse or promote products derived from this software without specific
+prior written permission.
 
-NO EXPRESS OR IMPLIED LICENSES TO ANY PARTY'S PATENT RIGHTS ARE GRANTED BY THIS
-LICENSE. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
-THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
-GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
-HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
-LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
-OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
-DAMAGE.
+NO EXPRESS OR IMPLIED LICENSES TO ANY PARTY'S PATENT RIGHTS ARE GRANTED BY
+THIS LICENSE. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.

--- a/_licenses/bsd-3-clause-clear.txt
+++ b/_licenses/bsd-3-clause-clear.txt
@@ -34,16 +34,16 @@ Redistribution and use in source and binary forms, with or without
 modification, are permitted (subject to the limitations in the disclaimer
 below) provided that the following conditions are met:
 
-* Redistributions of source code must retain the above copyright notice, this
-list of conditions and the following disclaimer.
+     * Redistributions of source code must retain the above copyright notice,
+     this list of conditions and the following disclaimer.
 
-* Redistributions in binary form must reproduce the above copyright notice,
-this list of conditions and the following disclaimer in the documentation
-and/or other materials provided with the distribution.
+     * Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
 
-* Neither the name of [fullname] nor the names of its contributors may be used
-to endorse or promote products derived from this software without specific
-prior written permission.
+     * Neither the name of [fullname] nor the names of its contributors may be
+     used to endorse or promote products derived from this software without
+     specific prior written permission.
 
 NO EXPRESS OR IMPLIED LICENSES TO ANY PARTY'S PATENT RIGHTS ARE GRANTED BY
 THIS LICENSE. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND

--- a/_licenses/epl-1.0.txt
+++ b/_licenses/epl-1.0.txt
@@ -41,21 +41,19 @@ CONSTITUTES RECIPIENT'S ACCEPTANCE OF THIS AGREEMENT.
 1. DEFINITIONS
 
 "Contribution" means:
+     a) in the case of the initial Contributor, the initial code and
+     documentation distributed under this Agreement, and
+     b) in the case of each subsequent Contributor:
+          i) changes to the Program, and
+          ii) additions to the Program;
 
-a) in the case of the initial Contributor, the initial code and documentation
-   distributed under this Agreement, and
-b) in the case of each subsequent Contributor:
-    i) changes to the Program, and
-   ii) additions to the Program;
-
-   where such changes and/or additions to the Program originate from and are
-   distributed by that particular Contributor. A Contribution 'originates'
-   from a Contributor if it was added to the Program by such Contributor
-   itself or anyone acting on such Contributor's behalf. Contributions do not
-   include additions to the Program which: (i) are separate modules of
-   software distributed in conjunction with the Program under their own
-   license agreement, and (ii) are not derivative works of the Program.
-
+where such changes and/or additions to the Program originate from and are
+distributed by that particular Contributor. A Contribution 'originates' from a
+Contributor if it was added to the Program by such Contributor itself or
+anyone acting on such Contributor's behalf. Contributions do not include
+additions to the Program which: (i) are separate modules of software
+distributed in conjunction with the Program under their own license agreement,
+and (ii) are not derivative works of the Program.
 "Contributor" means any person or entity that distributes the Program.
 
 "Licensed Patents" mean patent claims licensable by a Contributor which are
@@ -69,12 +67,14 @@ Agreement.
 including all Contributors.
 
 2. GRANT OF RIGHTS
-  a) Subject to the terms of this Agreement, each Contributor hereby grants
+
+     a) Subject to the terms of this Agreement, each Contributor hereby grants
      Recipient a non-exclusive, worldwide, royalty-free copyright license to
      reproduce, prepare derivative works of, publicly display, publicly
      perform, distribute and sublicense the Contribution of such Contributor,
      if any, and such derivative works, in source code and object code form.
-  b) Subject to the terms of this Agreement, each Contributor hereby grants
+
+     b) Subject to the terms of this Agreement, each Contributor hereby grants
      Recipient a non-exclusive, worldwide, royalty-free patent license under
      Licensed Patents to make, use, sell, offer to sell, import and otherwise
      transfer the Contribution of such Contributor, if any, in source code and
@@ -84,56 +84,60 @@ including all Contributors.
      combination to be covered by the Licensed Patents. The patent license
      shall not apply to any other combinations which include the Contribution.
      No hardware per se is licensed hereunder.
-  c) Recipient understands that although each Contributor grants the licenses
-     to its Contributions set forth herein, no assurances are provided by any
-     Contributor that the Program does not infringe the patent or other
-     intellectual property rights of any other entity. Each Contributor
-     disclaims any liability to Recipient for claims brought by any other
-     entity based on infringement of intellectual property rights or
+
+     c) Recipient understands that although each Contributor grants the
+     licenses to its Contributions set forth herein, no assurances are
+     provided by any Contributor that the Program does not infringe the patent
+     or other intellectual property rights of any other entity. Each
+     Contributor disclaims any liability to Recipient for claims brought by
+     any other entity based on infringement of intellectual property rights or
      otherwise. As a condition to exercising the rights and licenses granted
      hereunder, each Recipient hereby assumes sole responsibility to secure
      any other intellectual property rights needed, if any. For example, if a
      third party patent license is required to allow Recipient to distribute
      the Program, it is Recipient's responsibility to acquire that license
      before distributing the Program.
-  d) Each Contributor represents that to its knowledge it has sufficient
+
+     d) Each Contributor represents that to its knowledge it has sufficient
      copyright rights in its Contribution, if any, to grant the copyright
      license set forth in this Agreement.
 
 3. REQUIREMENTS
-
 A Contributor may choose to distribute the Program in object code form under
 its own license agreement, provided that:
 
-  a) it complies with the terms and conditions of this Agreement; and
-  b) its license agreement:
-      i) effectively disclaims on behalf of all Contributors all warranties
-         and conditions, express and implied, including warranties or
-         conditions of title and non-infringement, and implied warranties or
-         conditions of merchantability and fitness for a particular purpose;
-     ii) effectively excludes on behalf of all Contributors all liability for
-         damages, including direct, indirect, special, incidental and
-         consequential damages, such as lost profits;
-    iii) states that any provisions which differ from this Agreement are
-         offered by that Contributor alone and not by any other party; and
-     iv) states that source code for the Program is available from such
-         Contributor, and informs licensees how to obtain it in a reasonable
-         manner on or through a medium customarily used for software exchange.
+     a) it complies with the terms and conditions of this Agreement; and
+
+     b) its license agreement:
+          i) effectively disclaims on behalf of all Contributors all
+          warranties and conditions, express and implied, including warranties
+          or conditions of title and non-infringement, and implied warranties
+          or conditions of merchantability and fitness for a particular
+          purpose;
+          ii) effectively excludes on behalf of all Contributors all liability
+          for damages, including direct, indirect, special, incidental and
+          consequential damages, such as lost profits;
+          iii) states that any provisions which differ from this Agreement are
+          offered by that Contributor alone and not by any other party; and
+          iv) states that source code for the Program is available from such
+          Contributor, and informs licensees how to obtain it in a reasonable
+          manner on or through a medium customarily used for software
+          exchange.
 
 When the Program is made available in source code form:
 
-  a) it must be made available under this Agreement; and
-  b) a copy of this Agreement must be included with each copy of the Program.
-     Contributors may not remove or alter any copyright notices contained
-     within the Program.
+     a) it must be made available under this Agreement; and
+
+     b) a copy of this Agreement must be included with each copy of the
+     Program.
+Contributors may not remove or alter any copyright notices contained within
+the Program.
 
 Each Contributor must identify itself as the originator of its Contribution,
-if
-any, in a manner that reasonably allows subsequent Recipients to identify the
-originator of the Contribution.
+if any, in a manner that reasonably allows subsequent Recipients to identify
+the originator of the Contribution.
 
 4. COMMERCIAL DISTRIBUTION
-
 Commercial distributors of software may accept certain responsibilities with
 respect to end users, business partners and the like. While this license is
 intended to facilitate the commercial use of the Program, the Contributor who
@@ -148,12 +152,11 @@ Contributor to the extent caused by the acts or omissions of such Commercial
 Contributor in connection with its distribution of the Program in a commercial
 product offering. The obligations in this section do not apply to any claims
 or Losses relating to any actual or alleged intellectual property
-infringement. In order to qualify, an Indemnified Contributor must:
-a) promptly notify the Commercial Contributor in writing of such claim, and
-b) allow the Commercial Contributor to control, and cooperate with the
-Commercial Contributor in, the defense and any related settlement
-negotiations. The Indemnified Contributor may participate in any such claim at
-its own expense.
+infringement. In order to qualify, an Indemnified Contributor must: a)
+promptly notify the Commercial Contributor in writing of such claim, and b)
+allow the Commercial Contributor to control, and cooperate with the Commercial
+Contributor in, the defense and any related settlement negotiations. The
+Indemnified Contributor may participate in any such claim at its own expense.
 
 For example, a Contributor might include the Program in a commercial product
 offering, Product X. That Contributor is then a Commercial Contributor. If
@@ -166,7 +169,6 @@ court requires any other Contributor to pay any damages as a result, the
 Commercial Contributor must pay those damages.
 
 5. NO WARRANTY
-
 EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, THE PROGRAM IS PROVIDED ON AN
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
 IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS OF TITLE,
@@ -179,7 +181,6 @@ or loss of data, programs or equipment, and unavailability or interruption of
 operations.
 
 6. DISCLAIMER OF LIABILITY
-
 EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, NEITHER RECIPIENT NOR ANY
 CONTRIBUTORS SHALL HAVE ANY LIABILITY FOR ANY DIRECT, INDIRECT, INCIDENTAL,
 SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING WITHOUT LIMITATION
@@ -233,5 +234,5 @@ Program not expressly granted under this Agreement are reserved.
 This Agreement is governed by the laws of the State of New York and the
 intellectual property laws of the United States of America. No party to this
 Agreement will bring a legal action under this Agreement more than one year
-after the cause of action arose. Each party waives its rights to a jury trial in
-any resulting litigation.
+after the cause of action arose. Each party waives its rights to a jury trial
+in any resulting litigation.

--- a/_licenses/ms-pl.txt
+++ b/_licenses/ms-pl.txt
@@ -31,7 +31,7 @@ This license governs use of the accompanying software. If you use the
 software, you accept this license. If you do not accept the license, do not
 use the software.
 
-1. Definitions
+1.  Definitions
 The terms "reproduce," "reproduction," "derivative works," and "distribution"
 have the same meaning here as under U.S. copyright law. A "contribution" is
 the original software, or any additions or changes to the software. A
@@ -39,41 +39,41 @@ the original software, or any additions or changes to the software. A
 license. "Licensed patents" are a contributor's patent claims that read
 directly on its contribution.
 
-2. Grant of Rights
-(A) Copyright Grant- Subject to the terms of this license, including the
-license conditions and limitations in section 3, each contributor grants you a
-non-exclusive, worldwide, royalty-free copyright license to reproduce its
-contribution, prepare derivative works of its contribution, and distribute its
-contribution or any derivative works that you create.
+2.  Grant of Rights
+     (A) Copyright Grant- Subject to the terms of this license, including the
+     license conditions and limitations in section 3, each contributor grants
+     you a non-exclusive, worldwide, royalty-free copyright license to
+     reproduce its contribution, prepare derivative works of its contribution,
+     and distribute its contribution or any derivative works that you create.
 
-(B) Patent Grant- Subject to the terms of this license, including the license
-conditions and limitations in section 3, each contributor grants you a
-non-exclusive, worldwide, royalty-free license under its licensed patents to
-make, have made, use, sell, offer for sale, import, and/or otherwise dispose
-of its contribution in the software or derivative works of the contribution in
-the software.
+     (B) Patent Grant- Subject to the terms of this license, including the
+     license conditions and limitations in section 3, each contributor grants
+     you a non-exclusive, worldwide, royalty-free license under its licensed
+     patents to make, have made, use, sell, offer for sale, import, and/or
+     otherwise dispose of its contribution in the software or derivative works
+     of the contribution in the software.
 
-3. Conditions and Limitations
-(A) No Trademark License- This license does not grant you rights to use any
-contributors' name, logo, or trademarks.
+3.  Conditions and Limitations
+     (A) No Trademark License- This license does not grant you rights to use
+     any contributors' name, logo, or trademarks.
 
-(B) If you bring a patent claim against any contributor over patents that you
-claim are infringed by the software, your patent license from such contributor
-to the software ends automatically.
+     (B) If you bring a patent claim against any contributor over patents that
+     you claim are infringed by the software, your patent license from such
+     contributor to the software ends automatically.
 
-(C) If you distribute any portion of the software, you must retain all
-copyright, patent, trademark, and attribution notices that are present in the
-software.
+     (C) If you distribute any portion of the software, you must retain all
+     copyright, patent, trademark, and attribution notices that are present in
+     the software.
 
-(D) If you distribute any portion of the software in source code form, you may
-do so only under this license by including a complete copy of this license
-with your distribution. If you distribute any portion of the software in
-compiled or object code form, you may only do so under a license that complies
-with this license.
+     (D) If you distribute any portion of the software in source code form,
+     you may do so only under this license by including a complete copy of
+     this license with your distribution. If you distribute any portion of the
+     software in compiled or object code form, you may only do so under a
+     license that complies with this license.
 
-(E) The software is licensed "as-is." You bear the risk of using it. The
-contributors give no express warranties, guarantees, or conditions. You may
-have additional consumer rights under your local laws which this license
-cannot change. To the extent permitted under your local laws, the contributors
-exclude the implied warranties of merchantability, fitness for a particular
-purpose and non-infringement.
+     (E) The software is licensed "as-is." You bear the risk of using it. The
+     contributors give no express warranties, guarantees, or conditions. You
+     may have additional consumer rights under your local laws which this
+     license cannot change. To the extent permitted under your local laws, the
+     contributors exclude the implied warranties of merchantability, fitness
+     for a particular purpose and non-infringement.

--- a/_licenses/ms-pl.txt
+++ b/_licenses/ms-pl.txt
@@ -25,25 +25,55 @@ limitations:
 
 ---
 
-Microsoft Public License (MS-PL)
+Microsoft Public License (Ms-PL)
 
-This license governs use of the accompanying software. If you use the software, you
-accept this license. If you do not accept the license, do not use the software.
+This license governs use of the accompanying software. If you use the
+software, you accept this license. If you do not accept the license, do not
+use the software.
 
 1. Definitions
-The terms "reproduce," "reproduction," "derivative works," and "distribution" have the
-same meaning here as under U.S. copyright law.
-A "contribution" is the original software, or any additions or changes to the software.
-A "contributor" is any person that distributes its contribution under this license.
-"Licensed patents" are a contributor's patent claims that read directly on its contribution.
+The terms "reproduce," "reproduction," "derivative works," and "distribution"
+have the same meaning here as under U.S. copyright law. A "contribution" is
+the original software, or any additions or changes to the software. A
+"contributor" is any person that distributes its contribution under this
+license. "Licensed patents" are a contributor's patent claims that read
+directly on its contribution.
 
 2. Grant of Rights
-(A) Copyright Grant- Subject to the terms of this license, including the license conditions and limitations in section 3, each contributor grants you a non-exclusive, worldwide, royalty-free copyright license to reproduce its contribution, prepare derivative works of its contribution, and distribute its contribution or any derivative works that you create.
-(B) Patent Grant- Subject to the terms of this license, including the license conditions and limitations in section 3, each contributor grants you a non-exclusive, worldwide, royalty-free license under its licensed patents to make, have made, use, sell, offer for sale, import, and/or otherwise dispose of its contribution in the software or derivative works of the contribution in the software.
+(A) Copyright Grant- Subject to the terms of this license, including the
+license conditions and limitations in section 3, each contributor grants you a
+non-exclusive, worldwide, royalty-free copyright license to reproduce its
+contribution, prepare derivative works of its contribution, and distribute its
+contribution or any derivative works that you create.
+
+(B) Patent Grant- Subject to the terms of this license, including the license
+conditions and limitations in section 3, each contributor grants you a
+non-exclusive, worldwide, royalty-free license under its licensed patents to
+make, have made, use, sell, offer for sale, import, and/or otherwise dispose
+of its contribution in the software or derivative works of the contribution in
+the software.
 
 3. Conditions and Limitations
-(A) No Trademark License- This license does not grant you rights to use any contributors' name, logo, or trademarks.
-(B) If you bring a patent claim against any contributor over patents that you claim are infringed by the software, your patent license from such contributor to the software ends automatically.
-(C) If you distribute any portion of the software, you must retain all copyright, patent, trademark, and attribution notices that are present in the software.
-(D) If you distribute any portion of the software in source code form, you may do so only under this license by including a complete copy of this license with your distribution. If you distribute any portion of the software in compiled or object code form, you may only do so under a license that complies with this license.
-(E) The software is licensed "as-is." You bear the risk of using it. The contributors give no express warranties, guarantees or conditions. You may have additional consumer rights under your local laws which this license cannot change. To the extent permitted under your local laws, the contributors exclude the implied warranties of merchantability, fitness for a particular purpose and non-infringement.
+(A) No Trademark License- This license does not grant you rights to use any
+contributors' name, logo, or trademarks.
+
+(B) If you bring a patent claim against any contributor over patents that you
+claim are infringed by the software, your patent license from such contributor
+to the software ends automatically.
+
+(C) If you distribute any portion of the software, you must retain all
+copyright, patent, trademark, and attribution notices that are present in the
+software.
+
+(D) If you distribute any portion of the software in source code form, you may
+do so only under this license by including a complete copy of this license
+with your distribution. If you distribute any portion of the software in
+compiled or object code form, you may only do so under a license that complies
+with this license.
+
+(E) The software is licensed "as-is." You bear the risk of using it. The
+contributors give no express warranties, guarantees, or conditions. You may
+have additional consumer rights under your local laws which this license
+cannot change. To the extent permitted under your local laws, the contributors
+exclude the implied warranties of merchantability, fitness for a particular
+purpose and non-infringement.

--- a/_licenses/ms-rl.txt
+++ b/_licenses/ms-rl.txt
@@ -33,7 +33,7 @@ This license governs use of the accompanying software. If you use the
 software, you accept this license. If you do not accept the license, do not
 use the software.
 
-1. Definitions
+1.  Definitions
 The terms "reproduce," "reproduction," "derivative works," and "distribution"
 have the same meaning here as under U.S. copyright law.
 
@@ -46,47 +46,48 @@ license.
 "Licensed patents" are a contributor's patent claims that read directly on its
 contribution.
 
-2. Grant of Rights
-(A) Copyright Grant- Subject to the terms of this license, including the
-license conditions and limitations in section 3, each contributor grants you a
-non-exclusive, worldwide, royalty-free copyright license to reproduce its
-contribution, prepare derivative works of its contribution, and distribute its
-contribution or any derivative works that you create.
+2.  Grant of Rights
+     (A) Copyright Grant- Subject to the terms of this license, including the
+     license conditions and limitations in section 3, each contributor grants
+     you a non-exclusive, worldwide, royalty-free copyright license to
+     reproduce its contribution, prepare derivative works of its contribution,
+     and distribute its contribution or any derivative works that you create.
 
-(B) Patent Grant- Subject to the terms of this license, including the license
-conditions and limitations in section 3, each contributor grants you a
-non-exclusive, worldwide, royalty-free license under its licensed patents to
-make, have made, use, sell, offer for sale, import, and/or otherwise dispose
-of its contribution in the software or derivative works of the contribution in
-the software.
+     (B) Patent Grant- Subject to the terms of this license, including the
+     license conditions and limitations in section 3, each contributor grants
+     you a non-exclusive, worldwide, royalty-free license under its licensed
+     patents to make, have made, use, sell, offer for sale, import, and/or
+     otherwise dispose of its contribution in the software or derivative works
+     of the contribution in the software.
 
-3. Conditions and Limitations
-(A) Reciprocal Grants- For any file you distribute that contains code from the
-software (in source code or binary format), you must provide recipients the
-source code to that file along with a copy of this license, which license will
-govern that file. You may license other files that are entirely your own work
-and do not contain code from the software under any terms you choose.
+3.  Conditions and Limitations
+     (A) Reciprocal Grants- For any file you distribute that contains code
+     from the software (in source code or binary format), you must provide
+     recipients the source code to that file along with a copy of this
+     license, which license will govern that file. You may license other files
+     that are entirely your own work and do not contain code from the software
+     under any terms you choose.
 
-(B) No Trademark License- This license does not grant you rights to use any
-contributors' name, logo, or trademarks.
+     (B) No Trademark License- This license does not grant you rights to use
+     any contributors' name, logo, or trademarks.
 
-(C) If you bring a patent claim against any contributor over patents that you
-claim are infringed by the software, your patent license from such contributor
-to the software ends automatically.
+     (C) If you bring a patent claim against any contributor over patents that
+     you claim are infringed by the software, your patent license from such
+     contributor to the software ends automatically.
 
-(D) If you distribute any portion of the software, you must retain all
-copyright, patent, trademark, and attribution notices that are present in the
-software.
+     (D) If you distribute any portion of the software, you must retain all
+     copyright, patent, trademark, and attribution notices that are present in
+     the software.
 
-(E) If you distribute any portion of the software in source code form, you may
-do so only under this license by including a complete copy of this license
-with your distribution. If you distribute any portion of the software in
-compiled or object code form, you may only do so under a license that complies
-with this license.
+     (E) If you distribute any portion of the software in source code form,
+     you may do so only under this license by including a complete copy of
+     this license with your distribution. If you distribute any portion of the
+     software in compiled or object code form, you may only do so under a
+     license that complies with this license.
 
-(F) The software is licensed "as-is." You bear the risk of using it. The
-contributors give no express warranties, guarantees, or conditions. You may
-have additional consumer rights under your local laws which this license
-cannot change. To the extent permitted under your local laws, the contributors
-exclude the implied warranties of merchantability, fitness for a particular
-purpose and non-infringement.
+     (F) The software is licensed "as-is." You bear the risk of using it. The
+     contributors give no express warranties, guarantees, or conditions. You
+     may have additional consumer rights under your local laws which this
+     license cannot change. To the extent permitted under your local laws, the
+     contributors exclude the implied warranties of merchantability, fitness
+     for a particular purpose and non-infringement.

--- a/_licenses/ms-rl.txt
+++ b/_licenses/ms-rl.txt
@@ -27,24 +27,66 @@ limitations:
 
 ---
 
-Microsoft Reciprocal License (MS-RL)
+Microsoft Reciprocal License (Ms-RL)
 
-This license governs use of the accompanying software. If you use the software, you accept this license. If you do not accept the license, do not use the software.
+This license governs use of the accompanying software. If you use the
+software, you accept this license. If you do not accept the license, do not
+use the software.
 
 1. Definitions
-The terms "reproduce," "reproduction," "derivative works," and "distribution" have the same meaning here as under U.S. copyright law.
-A "contribution" is the original software, or any additions or changes to the software.
-A "contributor" is any person that distributes its contribution under this license.
-"Licensed patents" are a contributor's patent claims that read directly on its contribution.
+The terms "reproduce," "reproduction," "derivative works," and "distribution"
+have the same meaning here as under U.S. copyright law.
+
+A "contribution" is the original software, or any additions or changes to the
+software.
+
+A "contributor" is any person that distributes its contribution under this
+license.
+
+"Licensed patents" are a contributor's patent claims that read directly on its
+contribution.
 
 2. Grant of Rights
-(A) Copyright Grant- Subject to the terms of this license, including the license conditions and limitations in section 3, each contributor grants you a non-exclusive, worldwide, royalty-free copyright license to reproduce its contribution, prepare derivative works of its contribution, and distribute its contribution or any derivative works that you create.
-(B) Patent Grant- Subject to the terms of this license, including the license conditions and limitations in section 3, each contributor grants you a non-exclusive, worldwide, royalty-free license under its licensed patents to make, have made, use, sell, offer for sale, import, and/or otherwise dispose of its contribution in the software or derivative works of the contribution in the software.
+(A) Copyright Grant- Subject to the terms of this license, including the
+license conditions and limitations in section 3, each contributor grants you a
+non-exclusive, worldwide, royalty-free copyright license to reproduce its
+contribution, prepare derivative works of its contribution, and distribute its
+contribution or any derivative works that you create.
+
+(B) Patent Grant- Subject to the terms of this license, including the license
+conditions and limitations in section 3, each contributor grants you a
+non-exclusive, worldwide, royalty-free license under its licensed patents to
+make, have made, use, sell, offer for sale, import, and/or otherwise dispose
+of its contribution in the software or derivative works of the contribution in
+the software.
 
 3. Conditions and Limitations
-(A) Reciprocal Grants- For any file you distribute that contains code from the software (in source code or binary format), you must provide recipients the source code to that file along with a copy of this license, which license will govern that file. You may license other files that are entirely your own work and do not contain code from the software under any terms you choose.
-(B) No Trademark License- This license does not grant you rights to use any contributors' name, logo, or trademarks.
-(C) If you bring a patent claim against any contributor over patents that you claim are infringed by the software, your patent license from such contributor to the software ends automatically.
-(D) If you distribute any portion of the software, you must retain all copyright, patent, trademark, and attribution notices that are present in the software.
-(E) If you distribute any portion of the software in source code form, you may do so only under this license by including a complete copy of this license with your distribution. If you distribute any portion of the software in compiled or object code form, you may only do so under a license that complies with this license.
-(F) The software is licensed "as-is." You bear the risk of using it. The contributors give no express warranties, guarantees or conditions. You may have additional consumer rights under your local laws which this license cannot change. To the extent permitted under your local laws, the contributors exclude the implied warranties of merchantability, fitness for a particular purpose and non-infringement.
+(A) Reciprocal Grants- For any file you distribute that contains code from the
+software (in source code or binary format), you must provide recipients the
+source code to that file along with a copy of this license, which license will
+govern that file. You may license other files that are entirely your own work
+and do not contain code from the software under any terms you choose.
+
+(B) No Trademark License- This license does not grant you rights to use any
+contributors' name, logo, or trademarks.
+
+(C) If you bring a patent claim against any contributor over patents that you
+claim are infringed by the software, your patent license from such contributor
+to the software ends automatically.
+
+(D) If you distribute any portion of the software, you must retain all
+copyright, patent, trademark, and attribution notices that are present in the
+software.
+
+(E) If you distribute any portion of the software in source code form, you may
+do so only under this license by including a complete copy of this license
+with your distribution. If you distribute any portion of the software in
+compiled or object code form, you may only do so under a license that complies
+with this license.
+
+(F) The software is licensed "as-is." You bear the risk of using it. The
+contributors give no express warranties, guarantees, or conditions. You may
+have additional consumer rights under your local laws which this license
+cannot change. To the extent permitted under your local laws, the contributors
+exclude the implied warranties of merchantability, fitness for a particular
+purpose and non-infringement.

--- a/spec/license_bom_spec.rb
+++ b/spec/license_bom_spec.rb
@@ -3,7 +3,7 @@
 require 'spec_helper'
 
 describe 'byte order marks' do
-  Dir["#{licenses_path}/*.html"].each do |file|
+  Dir["#{licenses_path}/*.txt"].each do |file|
     context "the #{File.basename(file, '.txt')} license" do
       it 'does not begin with a byte order mark' do
         bom = File.open(file).read.start_with?("\u0000EF\u0000BB\u0000BF")

--- a/spec/license_wrap_spec.rb
+++ b/spec/license_wrap_spec.rb
@@ -3,22 +3,12 @@
 require 'spec_helper'
 
 describe 'word wrapping' do
-  Dir["#{licenses_path}/*.txt"].each do |file|
-    context "the #{File.basename(file, '.txt')} license" do
-      it 'does not wrap at line length 78' do
-        file_content = File.read(file, encoding: 'utf-8')
-        license_text = file_content.match(/\A(?:---\n.*\n---\n+)?(.*)/m)[1]
-        max_line_length = 0
-        max_line = ''
-        license_text.lines.each do |line|
-          line.chomp!
-          if line.length > max_line_length
-            max_line_length = line.length
-            max_line = line
-          end
-        end
-        msg = "Longest line is #{max_line_length} characters: #{max_line}"
-        expect(max_line_length).to be <= 78, msg
+  licenses.each do |license|
+    context "the #{license['slug']} license" do
+      it 'wraps at line length 78' do
+        max_line = license['content'].lines.max_by { |line| line.chomp!.length }
+        msg = "Longest line is #{max_line.length} characters: #{max_line}"
+        expect(max_line.length).to be <= 78, msg
       end
     end
   end

--- a/spec/license_wrap_spec.rb
+++ b/spec/license_wrap_spec.rb
@@ -11,6 +11,7 @@ describe 'word wrapping' do
         max_line_length = 0
         max_line = ""
         license_text.lines.each do |line|
+          line.chomp!
           if line.length > max_line_length
             max_line_length = line.length
             max_line = line

--- a/spec/license_wrap_spec.rb
+++ b/spec/license_wrap_spec.rb
@@ -9,7 +9,7 @@ describe 'word wrapping' do
         file_content = File.read(file, encoding: 'utf-8')
         license_text = file_content.match(/\A(?:---\n.*\n---\n+)?(.*)/m)[1]
         max_line_length = 0
-        max_line = ""
+        max_line = ''
         license_text.lines.each do |line|
           line.chomp!
           if line.length > max_line_length

--- a/spec/license_wrap_spec.rb
+++ b/spec/license_wrap_spec.rb
@@ -18,7 +18,6 @@ describe 'word wrapping' do
           end
         end
         msg = "Longest line is #{max_line_length} characters: #{max_line}"
-        skip msg if max_line_length > 78 && max_line_length < 81
         expect(max_line_length).to be <= 78, msg
       end
     end

--- a/spec/license_wrap_spec.rb
+++ b/spec/license_wrap_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'word wrapping' do
+  Dir["#{licenses_path}/*.txt"].each do |file|
+    context "the #{File.basename(file, '.txt')} license" do
+      it 'does not wrap at line length 78' do
+        file_content = File.read(file, encoding: 'utf-8')
+        license_text = file_content.match(/\A(?:---\n.*\n---\n+)?(.*)/m)[1]
+        max_line_length = 0
+        max_line = ""
+        license_text.lines.each do |line|
+          if line.length > max_line_length
+            max_line_length = line.length
+            max_line = line
+          end
+        end
+        msg = "Longest line is #{max_line_length} characters: #{max_line}"
+        skip msg if max_line_length > 78 && max_line_length < 81
+        expect(max_line_length).to be <= 78, msg
+      end
+    end
+  end
+end


### PR DESCRIPTION
As noted at https://github.com/github/choosealicense.com/pull/551#issuecomment-345471560 `CONTRIBUTING.md` says to wrap at 78 columns, but there's no test for it.

EPL-1.0 has an 80 character line, which may or may not be worth changing; haven't checked the canonical version yet.

Four little used licenses have longer lines.

I haven't tried to detect probable wrapping at <78 columns, which involves a bit more record keeping and guesswork (it's hard to tell for certain whether lines not separated by a blank line can be combined).

```
Pending: (Failures listed here are expected and do not affect your suite's status)
  1) word wrapping the epl-1.0 license does not wrap at line length 78
     # Longest line is 80 characters: after the cause of action arose. Each party waives its rights to a jury trial in
     # ./spec/license_wrap_spec.rb:8
[...]
Failures:
  1) word wrapping the afl-3.0 license does not wrap at line length 78
     Failure/Error: expect(max_line_length).to be <= 78, msg
       Longest line is 1135 characters: 16) Modification of This License. This License is Copyright © 2005 Lawrence Rosen. Permission is granted to copy, distribute, or communicate this License without modification. Nothing in this License permits You to modify this License as applied to the Original Work or to Derivative Works. However, You may modify the text of this License and copy, distribute or communicate your modified version (the "Modified License") and apply it to other original works of authorship subject to the following conditions: (i) You may not indicate in any way that your Modified License is the "Academic Free License" or "AFL" and you may not use those names in the name of your Modified License; (ii) You must replace the notice specified in the first paragraph above with the notice "Licensed under <insert your license name here>" or with a notice of your own that is not confusingly similar to the notice in this License; and (iii) You may not claim that your original works are open source software unless your Modified License has been approved by Open Source Initiative (OSI) and You comply with its license review and certification process.
     # ./spec/license_wrap_spec.rb:22:in `block (4 levels) in <top (required)>'
  2) word wrapping the ms-pl license does not wrap at line length 78
     Failure/Error: expect(max_line_length).to be <= 78, msg
       Longest line is 405 characters: (E) The software is licensed "as-is." You bear the risk of using it. The contributors give no express warranties, guarantees or conditions. You may have additional consumer rights under your local laws which this license cannot change. To the extent permitted under your local laws, the contributors exclude the implied warranties of merchantability, fitness for a particular purpose and non-infringement.
     # ./spec/license_wrap_spec.rb:22:in `block (4 levels) in <top (required)>'
  3) word wrapping the bsd-3-clause-clear license does not wrap at line length 78
     Failure/Error: expect(max_line_length).to be <= 78, msg
       Longest line is 88 characters: * Neither the name of the copyright holder nor the names of its contributors may be used[0m
     # ./spec/license_wrap_spec.rb:22:in `block (4 levels) in <top (required)>'
  4) word wrapping the ms-rl license does not wrap at line length 78
     Failure/Error: expect(max_line_length).to be <= 78, msg
       Longest line is 405 characters: (F) The software is licensed "as-is." You bear the risk of using it. The contributors give no express warranties, guarantees or conditions. You may have additional consumer rights under your local laws which this license cannot change. To the extent permitted under your local laws, the contributors exclude the implied warranties of merchantability, fitness for a particular purpose and non-infringement.
     # ./spec/license_wrap_spec.rb:22:in `block (4 levels) in <top (required)>'
```