### PR TITLE
Test examples provided in 'using:' would be detected by licensee

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,7 @@ end
 
 group :test do
   gem 'html-proofer', '~> 3.0'
+  gem 'licensee'
   gem 'nokogiri'
   gem 'rake'
   gem 'rspec'

--- a/_licenses/ecl-2.0.txt
+++ b/_licenses/ecl-2.0.txt
@@ -12,7 +12,7 @@ note: The Apereo Foundation recommends taking the additional step of adding a bo
 using:
   - Sakai: https://github.com/sakaiproject/sakai/blob/master/LICENSE
   - OAE: https://github.com/oaeproject/Hilary/blob/master/LICENSE
-  - Opencast: https://bitbucket.org/opencast-community/opencast/src/905077ba5e6483f8c49869a1fc13bf9268790a79/LICENSE?at=develop
+  - Opencast: https://bitbucket.org/opencast-community/opencast/src/905077ba5e6483f8c49869a1fc13bf9268790a79/LICENSE
 
 permissions:
   - commercial-use

--- a/_licenses/gpl-2.0.txt
+++ b/_licenses/gpl-2.0.txt
@@ -13,8 +13,9 @@ how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of 
 note: The Free Software Foundation recommends taking the additional step of adding a boilerplate notice to the top of each file. The boilerplate can be found at the end of the license.
 
 using:
-  - Linux: https://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/tree/COPYING
-  - WordPress: https://github.com/WordPress/WordPress/blob/master/license.txt
+  - AliSQL: https://github.com/alibaba/AliSQL/blob/master/COPYING
+  - Discourse: https://github.com/discourse/discourse/blob/master/LICENSE.txt
+  - Joomla!: https://github.com/joomla/joomla-cms/blob/staging/LICENSE.txt
 
 permissions:
   - commercial-use

--- a/_licenses/gpl-3.0.txt
+++ b/_licenses/gpl-3.0.txt
@@ -14,9 +14,9 @@ how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of 
 note: The Free Software Foundation recommends taking the additional step of adding a boilerplate notice to the top of each file. The boilerplate can be found at the end of the license.
 
 using:
+  - Ansible: https://github.com/ansible/ansible/blob/devel/COPYING
   - Bash: https://git.savannah.gnu.org/cgit/bash.git/tree/COPYING
   - GIMP: https://git.gnome.org/browse/gimp/tree/COPYING
-  - Privacy Badger: https://github.com/EFForg/privacybadgerfirefox/blob/master/LICENSE
 
 permissions:
   - commercial-use

--- a/_licenses/isc.txt
+++ b/_licenses/isc.txt
@@ -8,7 +8,7 @@ description: A permissive license lets people do anything with your code with pr
 how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file. Replace [year] with the current year and [fullname] with the name (or names) of the copyright holders.
 
 using:
-  - documentation.js: https://github.com/documentationjs/documentation/blob/master/LICENSE
+  - Helix: https://github.com/tildeio/helix/blob/master/LICENSE
   - Node.js semver: https://github.com/npm/node-semver/blob/master/LICENSE
   - OpenStreetMap iD: https://github.com/openstreetmap/iD/blob/master/LICENSE.md
 

--- a/_licenses/mit.txt
+++ b/_licenses/mit.txt
@@ -10,9 +10,9 @@ description: A short and simple permissive license with conditions only requirin
 how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file. Replace [year] with the current year and [fullname] with the name (or names) of the copyright holders.
 
 using:
-  - jQuery: https://github.com/jquery/jquery/blob/master/LICENSE.txt
+  - Babel: https://github.com/babel/babel/blob/master/LICENSE
   - .NET Core: https://github.com/dotnet/corefx/blob/master/LICENSE.TXT
-  - Rails: https://github.com/rails/rails/blob/master/activerecord/MIT-LICENSE
+  - Rails: https://github.com/rails/rails/blob/master/MIT-LICENSE
 
 permissions:
   - commercial-use

--- a/spec/license_meta_spec.rb
+++ b/spec/license_meta_spec.rb
@@ -72,6 +72,7 @@ describe 'license meta' do
           content = open(example_url).read
           detected = Licensee::ProjectFiles::LicenseFile.new(content, 'LICENSE').license
           it example_url do
+            skip 'NCSA and PostgreSQL licenses hard to detect' if %(ncsa postgresql).include?(license['slug'])
             expect(detected.key).to eq(license['slug'])
           end
         end

--- a/spec/license_meta_spec.rb
+++ b/spec/license_meta_spec.rb
@@ -64,6 +64,8 @@ describe 'license meta' do
           example_url = example.values[0]
           if example_url.index('https://github.com/') == 0
             example_url.gsub!(%r{\Ahttps://github.com/([\w-]+/[\w-]+)/blob/([\w-]+/\S+)\z}, 'https://raw.githubusercontent.com/\1/\2')
+          elsif example_url.index('https://git.savannah.gnu.org/') == 0 || example_url.index('https://git.gnome.org/') == 0
+            example_url.gsub!(%r{/tree/}, '/plain/')
           end
           content = open(example_url).read
           detected = Licensee::ProjectFiles::LicenseFile.new(content, 'LICENSE').license

--- a/spec/license_meta_spec.rb
+++ b/spec/license_meta_spec.rb
@@ -60,20 +60,27 @@ describe 'license meta' do
           end
         end
 
+        slug = license['slug']
+
         examples.each do |example|
           example_url = example.values[0]
-          if example_url.index('https://github.com/') == 0
-            example_url.gsub!(%r{\Ahttps://github.com/([\w-]+/[\w-]+)/blob/([\w-]+/\S+)\z}, 'https://raw.githubusercontent.com/\1/\2')
-          elsif example_url.index('https://git.savannah.gnu.org/') == 0 || example_url.index('https://git.gnome.org/') == 0
-            example_url.gsub!(%r{/tree/}, '/plain/')
-          elsif example_url.index('https://bitbucket.org/') == 0
-            example_url.gsub!(%r{/src/}, '/raw/')
-          end
-          content = open(example_url).read
-          detected = Licensee::ProjectFiles::LicenseFile.new(content, 'LICENSE').license
-          it example_url do
-            skip 'NCSA and PostgreSQL licenses hard to detect' if %(ncsa postgresql).include?(license['slug'])
-            expect(detected.key).to eq(license['slug'])
+
+          context "the #{example_url} URL" do
+            let(:content)  { open(example_url).read }
+            let(:detected) { Licensee::ProjectFiles::LicenseFile.new(content, 'LICENSE').license }
+
+            if example_url.start_with?('https://github.com/')
+              example_url.gsub!(%r{\Ahttps://github.com/([\w-]+/[\w-]+)/blob/([\w-]+/\S+)\z}, 'https://raw.githubusercontent.com/\1/\2')
+            elsif example_url.start_with?('https://git.savannah.gnu.org/', 'https://git.gnome.org/')
+              example_url.gsub!(%r{/tree/}, '/plain/')
+            elsif example_url.start_with?('https://bitbucket.org/')
+              example_url.gsub!(%r{/src/}, '/raw/')
+            end
+
+            it "is a #{slug} license" do
+              skip 'NCSA and PostgreSQL licenses hard to detect' if %(ncsa postgresql).include?(slug)
+              expect(detected.key).to eq(slug)
+            end
           end
         end
       end

--- a/spec/license_meta_spec.rb
+++ b/spec/license_meta_spec.rb
@@ -64,7 +64,7 @@ describe 'license meta' do
         examples.each do |example|
           example_url = example.values[0]
           if example_url.index('https://github.com/') == 0
-            example_url.gsub!(%r{\Ahttps://github.com/(\w+/\w+)/blob/(\w+/\S+)\z}, 'https://raw.githubusercontent.com/\1/\2')
+            example_url.gsub!(%r{\Ahttps://github.com/([\w-]+/[\w-]+)/blob/([\w-]+/\S+)\z}, 'https://raw.githubusercontent.com/\1/\2')
           end
           content = open(example_url).read
           detected = Licensee::ProjectFiles::LicenseFile.new(content, 'LICENSE').license

--- a/spec/license_meta_spec.rb
+++ b/spec/license_meta_spec.rb
@@ -35,7 +35,6 @@ describe 'license meta' do
           'cc-by-4.0',
           'cc-by-sa-4.0',
           'eupl-1.1',
-          'gpl-2.0',
           'lgpl-2.1',
           'lgpl-3.0',
           'lppl-1.3c',

--- a/spec/license_meta_spec.rb
+++ b/spec/license_meta_spec.rb
@@ -66,6 +66,8 @@ describe 'license meta' do
             example_url.gsub!(%r{\Ahttps://github.com/([\w-]+/[\w-]+)/blob/([\w-]+/\S+)\z}, 'https://raw.githubusercontent.com/\1/\2')
           elsif example_url.index('https://git.savannah.gnu.org/') == 0 || example_url.index('https://git.gnome.org/') == 0
             example_url.gsub!(%r{/tree/}, '/plain/')
+          elsif example_url.index('https://bitbucket.org/') == 0
+            example_url.gsub!(%r{/src/}, '/raw/')
           end
           content = open(example_url).read
           detected = Licensee::ProjectFiles::LicenseFile.new(content, 'LICENSE').license

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'jekyll'
-require 'open-uri'
 require 'json'
 require 'open-uri'
 require 'nokogiri'


### PR DESCRIPTION
Followup to #514 "Note absolutely no testing is done to ensure that 3 examples could be detected (it'd be possible to rig up a test using licensee and the licenses cataloged in a branch) or even are URLs."

This adds such testing. It monkeypatches licensee to use the licenses in the choosealicense.com branch being tested, which might be updated from what has been vendored by licensee (not least when a PR is made to add a license to choosealicense.com).

Prompted to to this by comments at https://github.com/github/choosealicense.com/pull/554#discussion_r153034353 suggesting that examples link to a specific commit rather than master. I don't think that solves the problem as completely as actually testing whatever is linked there, and it covers up potentially confusing examples.

These tests point out some examples that wouldn't be detected by the current version of licensee, and ought be replaced.

First though there are a few non-github.com examples, and they probably also need some URL mangling in the test in order to retrieve just the license text in question.