### PR TITLE
NCSA "developed by" ordering

### DIFF
--- a/_licenses/ncsa.txt
+++ b/_licenses/ncsa.txt
@@ -32,8 +32,8 @@ University of Illinois/NCSA Open Source License
 
 Copyright (c) [year] [fullname]. All rights reserved. 
 
-Developed by: [fullname] 
-              [project] 
+Developed by: [project] 
+              [fullname] 
               [project_url]
                   
 Permission is hereby granted, free of charge, to any person 


### PR DESCRIPTION
"Development Group" comes before "Name of Institution", so `project` should come before `fullname` as these most closely correspond.

As noted in https://github.com/spdx/license-list-XML/pull/556

Will leave this open until above is resolved, just opening so I don't forget.