### PR TITLE
Test against SPDX-provided list

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ script: "./script/cibuild"
 #environment
 language: ruby
 rvm:
-  - 2.4.0
+  - 2.4.2
 
 addons:
   apt:

--- a/_licenses/bsd-2-clause.txt
+++ b/_licenses/bsd-2-clause.txt
@@ -1,5 +1,5 @@
 ---
-title: BSD 2-clause "Simplified" License
+title: BSD 2-Clause "Simplified" License
 spdx-id: BSD-2-Clause
 redirect_from: /licenses/bsd/
 source: https://opensource.org/licenses/BSD-2-Clause

--- a/_licenses/bsd-3-clause-clear.txt
+++ b/_licenses/bsd-3-clause-clear.txt
@@ -1,5 +1,5 @@
 ---
-title: BSD 3-clause Clear License
+title: BSD 3-Clause Clear License
 spdx-id: BSD-3-Clause-Clear
 source: https://spdx.org/licenses/BSD-3-Clause-Clear.html
 

--- a/_licenses/bsd-3-clause.txt
+++ b/_licenses/bsd-3-clause.txt
@@ -1,5 +1,5 @@
 ---
-title: BSD 3-clause "New" or "Revised" License
+title: BSD 3-Clause "New" or "Revised" License
 spdx-id: BSD-3-Clause
 source: https://opensource.org/licenses/BSD-3-Clause
 hidden: false

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -71,8 +71,13 @@ def rule?(tag, group)
 end
 
 def spdx_list
-  url = 'https://raw.githubusercontent.com/sindresorhus/spdx-license-list/master/spdx.json'
-  SpecHelper.spdx ||= JSON.parse(open(url).read)
+  SpecHelper.spdx ||= begin
+    url = 'https://spdx.org/licenses/licenses.json'
+    list = JSON.parse(open(url).read)['licenses']
+    list.each_with_object({}) do |values, memo|
+      memo[values['licenseId']] = values
+    end
+  end
 end
 
 def spdx_ids
@@ -86,7 +91,7 @@ end
 def osi_approved_licenses
   SpecHelper.osi_approved_licenses ||= begin
     licenses = {}
-    list = spdx_list.select { |_id, meta| meta['osiApproved'] }
+    list = spdx_list.select { |_id, meta| meta['isOsiApproved'] }
     list.each do |id, meta|
       licenses[id.downcase] = meta['name']
     end


### PR DESCRIPTION
SPDX license list 3.0 is out. This switches our tests to use license data from SPDX directly rather than an intermediary and updates a few titles (capitalization only) to match.