### PR TITLE
Test this project's license

### DIFF
--- a/existing.md
+++ b/existing.md
@@ -4,7 +4,7 @@ permalink: /existing/
 title: Existing projects and communities
 ---
 
-If you're contributing to or extending an existing project, it's almost always easiest to continue using that project's license. Look for a file called `LICENSE` or `COPYING`, or a notice in the project's `README` to find out what that license is. If you can't find a license, [ask](/no-license/#for-users).
+If you're contributing to or extending an existing project, it's almost always easiest to continue using that project's license. Look for a file called `LICENSE` or `COPYING`, or a notice in the project's `README` to find out what that license is. If you can't find a license, [ask](/no-permission/#for-users).
 
 Depending on how you're building on an existing project and what its license is, using the existing project's license for your own might not just be the easiest thing to do, but a condition on which your permission to build on the existing project rests: see the "same license" condition of [some licenses](/licenses/).
 

--- a/index.html
+++ b/index.html
@@ -70,7 +70,7 @@ permalink: /
   <li>
     <h3>I don’t want to choose a license.</h3>
     <p>
-      <a href="no-license">You don’t have to</a>.
+      <a href="no-permission">You don’t have to</a>.
     </p>
   </li>
 </ul>

--- a/no-permission.md
+++ b/no-permission.md
@@ -1,7 +1,9 @@
 ---
 layout: default
-permalink: no-license/
-redirect_from: /licenses/no-license/
+permalink: no-permission/
+redirect_from:
+  - /no-license/
+  - /licenses/no-license/
 title: No License
 description: "You're under no obligation to choose a license and it's your right not to include one with your code or project. But please note that opting out of open source licenses doesn't mean you're opting out of copyright law."
 ---

--- a/spec/license_meta_spec.rb
+++ b/spec/license_meta_spec.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require 'licensee'
 require 'spec_helper'
 
 describe 'license meta' do
@@ -49,17 +48,6 @@ describe 'license meta' do
       end
 
       context 'licensee detects using examples' do
-        module Licensee
-          class License
-            class << self
-              def license_dir
-                dir = ::File.dirname(__FILE__)
-                ::File.expand_path '../_licenses', dir
-              end
-            end
-          end
-        end
-
         slug = license['slug']
 
         examples.each do |example|

--- a/spec/self_license_spec.rb
+++ b/spec/self_license_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+context 'licensee detects this project' do
+  let(:detected) { Licensee::project('.').license }
+
+  it "license as MIT" do
+    expect(detected.key).to eq('mit')
+  end
+end

--- a/spec/self_license_spec.rb
+++ b/spec/self_license_spec.rb
@@ -3,9 +3,9 @@
 require 'spec_helper'
 
 context 'licensee detects this project' do
-  let(:detected) { Licensee::project('.').license }
+  let(:detected) { Licensee.project('.').license }
 
-  it "license as MIT" do
+  it 'license as MIT' do
     expect(detected.key).to eq('mit')
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,7 @@
 
 require 'jekyll'
 require 'json'
+require 'licensee'
 require 'open-uri'
 require 'nokogiri'
 
@@ -137,4 +138,15 @@ end
 
 def approved_licenses
   (osi_approved_licenses.keys + fsf_approved_licenses.keys + od_approved_licenses.keys).flatten.uniq.sort
+end
+
+module Licensee
+  class License
+    class << self
+      def license_dir
+        dir = ::File.dirname(__FILE__)
+        ::File.expand_path '../_licenses', dir
+      end
+    end
+  end
 end


### PR DESCRIPTION
Because of `no-license.md` this project's license couldn't be detected by licensee since it (correctly) started detecting `other` in the presence of multiple license files since about https://github.com/benbalter/licensee/pull/204 (I only just noticed).

Added a test to ensure this project's license is detected, and renamed with redirect `no-license` to `no-permission`.