### PR TITLE
*GPL -or-later and -only in sidebar instructions

### DIFF
--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -1,7 +1,7 @@
 <div class="sidebar">
 
   <a href="#" data-clipboard-target="#license-text" data-proofer-ignore="true" class="js-clipboard-button button">Copy license text to clipboard</a>
-    
+
   <div class="how-to-apply">
     <h3>How to apply this license</h3>
     <p>
@@ -14,7 +14,7 @@
     {% endif %}
     {% assign xgpl = false %}
     {% if page.spdx-id contains 'GPL' %}{% assign xgpl = true %}{% endif %}
-    <p class="note"><strong>Optional: </strong> Add <strong><code>{{ page.spdx-id }}</code>{% if xgpl %}+{% endif %}</strong>{% if xgpl %} (or <strong><code>{{ page.spdx-id }}</code></strong> to disallow future versions){% endif %} to your project's package description, if applicable (e.g., <a href="https://docs.npmjs.com/files/package.json#license">Node.js</a>, <a href="http://guides.rubygems.org/specification-reference/#license=">Ruby</a>, and <a href="http://doc.crates.io/manifest.html#package-metadata">Rust</a>). This will ensure the license is displayed in package directories.</p>
+    <p class="note"><strong>Optional: </strong> Add <strong><code>{{ page.spdx-id }}{% if xgpl %}-or-later{% endif %}</code></strong>{% if xgpl %} (or <strong><code>{{ page.spdx-id }}-only</code></strong> to disallow future versions){% endif %} to your project's package description, if applicable (e.g., <a href="https://docs.npmjs.com/files/package.json#license">Node.js</a>, <a href="http://guides.rubygems.org/specification-reference/#license=">Ruby</a>, and <a href="http://doc.crates.io/manifest.html#package-metadata">Rust</a>). This will ensure the license is displayed in package directories.</p>
   </div>
 
   {% if page.source %}

--- a/_licenses/apache-2.0.txt
+++ b/_licenses/apache-2.0.txt
@@ -13,8 +13,8 @@ how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of 
 note: The Apache Foundation recommends taking the additional step of adding a boilerplate notice to the header of each source file. You can find the notice at the very end of the license in the appendix.
 
 using:
-  - Elasticsearch: https://github.com/elastic/elasticsearch/blob/master/LICENSE.txt
   - Kubernetes: https://github.com/kubernetes/kubernetes/blob/master/LICENSE
+  - PDF.js: https://github.com/mozilla/pdf.js/blob/master/LICENSE
   - Swift: https://github.com/apple/swift/blob/master/LICENSE.txt
 
 permissions:

--- a/spec/license_meta_spec.rb
+++ b/spec/license_meta_spec.rb
@@ -58,7 +58,7 @@ describe 'license meta' do
             let(:detected) { Licensee::ProjectFiles::LicenseFile.new(content, 'LICENSE').license }
 
             if example_url.start_with?('https://github.com/')
-              example_url.gsub!(%r{\Ahttps://github.com/([\w-]+/[\w-]+)/blob/([\w-]+/\S+)\z}, 'https://raw.githubusercontent.com/\1/\2')
+              example_url.gsub!(%r{\Ahttps://github.com/([\w-]+/[\w\.-]+)/blob/([\w-]+/\S+)\z}, 'https://raw.githubusercontent.com/\1/\2')
             elsif example_url.start_with?('https://git.savannah.gnu.org/', 'https://git.gnome.org/')
               example_url.gsub!(%r{/tree/}, '/plain/')
             elsif example_url.start_with?('https://bitbucket.org/')


### PR DESCRIPTION
SPDX license list 3.0 uses -or-later and -only over + and no modifier

Reflect that update in sidebar instructions for *GPL as seen e.g. at https://choosealicense.com/licenses/agpl-3.0/