### PR TITLE
Document project_url field

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ The licenses on choosealicense.com are regularly imported to GitHub.com to be us
 * `project` - The repository name
 * `description` - The description of the repository
 * `year` - The current year
+* `project_url` - The repository URL or other project website
 
 ## License properties
 

--- a/_data/fields.yml
+++ b/_data/fields.yml
@@ -21,3 +21,6 @@
 
 - name: year
   description: The current year
+
+- name: project_url
+  description: The repository URL or other project website

--- a/spec/license_fields_spec.rb
+++ b/spec/license_fields_spec.rb
@@ -6,7 +6,7 @@ describe 'license fillable fields' do
   licenses.each do |license|
     context "The #{license['title']} license" do
       it 'should only contain supported fillable fields' do
-        matches = license['content'][0, 1000].scan(/\[([a-z]+)\]/)
+        matches = license['content'][1, 1000].scan(/\s+\[([a-z_]+)\]/)
         extra_fields = matches.flatten - (fields.map { |f| f['name'] })
         expect(extra_fields).to be_empty
       end

--- a/spec/license_fields_spec.rb
+++ b/spec/license_fields_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'license fillable fields' do
+  licenses.each do |license|
+    context "The #{license['title']} license" do
+      it 'should only contain supported fillable fields' do
+        matches = license['content'][0, 1000].scan(/\[([a-z]+)\]/)
+        extra_fields = matches.flatten - (fields.map { |f| f['name'] })
+        expect(extra_fields).to be_empty
+      end
+    end
+  end
+end


### PR DESCRIPTION
Should have done so at https://github.com/github/choosealicense.com/pull/497#issuecomment-289231199

Test did not flag because it didn't look at fields with underscores.

Brought back modified test from https://github.com/github/choosealicense.com/pull/547 ... it isn't needed to catch random `[foo]` text, but would be nice to have catch things that should be supported fields.