### PR TITLE
project_url -> projecturl

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ The licenses on choosealicense.com are regularly imported to GitHub.com to be us
 * `project` - The repository name
 * `description` - The description of the repository
 * `year` - The current year
-* `project_url` - The repository URL or other project website
+* `projecturl` - The repository URL or other project website
 
 ## License properties
 

--- a/_data/fields.yml
+++ b/_data/fields.yml
@@ -22,5 +22,5 @@
 - name: year
   description: The current year
 
-- name: project_url
+- name: projecturl
   description: The repository URL or other project website

--- a/_licenses/ncsa.txt
+++ b/_licenses/ncsa.txt
@@ -34,7 +34,7 @@ Copyright (c) [year] [fullname]. All rights reserved.
 
 Developed by: [project] 
               [fullname] 
-              [project_url]
+              [projecturl]
                   
 Permission is hereby granted, free of charge, to any person 
 obtaining a copy of this software and associated documentation files 


### PR DESCRIPTION
Followup to #564 which documented `project_url`. This removes the underscore from the field name.

Not having to deal with underscores in field names makes things a bit simpler for other tooling that may or may not preprocess license texts -- I'm thinking particularly of https://github.com/benbalter/licensee/blob/4e20608c7252c93fde3972019465ab705762cf4a/lib/licensee/content_helper.rb#L14 which treats underscore as markdown markup to be stripped.