### PR TITLE
check-approval: Fix missing license_ids variable

### DIFF
--- a/script/check-approval
+++ b/script/check-approval
@@ -52,6 +52,7 @@ approvals.each do |approver, licenses|
   rows << ["#{approver} approved", licenses.include?(license)]
 end
 
+license_ids = licenses.map { |l| l['id'] }
 current = license_ids.include?(license)
 rows << ['Current license', current]
 


### PR DESCRIPTION
Avoid:

```console
$ ./script/check-approval MIT
./script/check-approval:55:in `<main>': undefined local variable or method `license_ids' for main:Object (NameError)
```

The `license_ids` line was added in e505eb8f (#318), but `license_ids` was removed from the helper in b99e7ab0 (#424).  This commit restores the old code locally, since this script is the only consumer.