### PR TITLE
spec_helper: Restore case-insensitive matching in find_spdx

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -86,7 +86,7 @@ def spdx_ids
 end
 
 def find_spdx(license)
-  spdx_list.find { |name, _properties| name == license }
+  spdx_list.find { |name, _properties| name.casecmp(license).zero? }
 end
 
 def osi_approved_licenses


### PR DESCRIPTION
The previous case-insensitive matching was removed in e5f46faa (#418).  That commit [was designed][1] to allow case-sensitive matching as discussed in #72.  But while I'm in favor of case-sensitive keys in spdx_list, the case-sensitive match breaks script/check-approval which [downcases its argument][2] since it was added in 8e56bb83 (#318).

There are more notes on SPDX's plans for case sensitivity in spdx/spdx-spec#63, so we should see a clearer policy there soon.  I'm arguing for case-sensitive *display* with optional case-insensitive matching.  I am optimistic that the SPDX will at least agree not to register short IDs that only differ by case, which is all we need to make this
case-insensitive match safe here.

[1]: https://github.com/github/choosealicense.com/pull/418#issuecomment-221404630
[2]: https://github.com/github/choosealicense.com/blob/5f83952a415186db86ecdc33b375f9eb863f286e/script/check-approval#L30