### PR TITLE
spec_helper: Extract FSF approval from wking.github.io/fsf-api

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,6 @@ end
 group :test do
   gem 'html-proofer', '~> 3.0'
   gem 'licensee'
-  gem 'nokogiri'
   gem 'rake'
   gem 'rspec'
   gem 'rubocop'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,7 +4,6 @@ require 'jekyll'
 require 'json'
 require 'licensee'
 require 'open-uri'
-require 'nokogiri'
 
 module SpecHelper
   class << self
@@ -102,23 +101,15 @@ end
 
 def fsf_approved_licenses
   SpecHelper.fsf_approved_licenses ||= begin
-    url = 'https://www.gnu.org/licenses/license-list.en.html'
-    doc = Nokogiri::HTML(open(url).read)
-    list = doc.css('.green dt')
+    url = 'https://wking.github.io/fsf-api/licenses-full.json'
+    object = JSON.parse(open(url).read)
     licenses = {}
-    list.each do |license|
-      a = license.css('a').find { |link| !link.text.nil? && !link.text.empty? && link.attr('id') }
-      next if a.nil?
-      id = a.attr('id').downcase
-      name = a.text.strip
-      licenses[id] = name
+    object.each_value do |meta|
+      next unless (meta.include? 'identifiers') && (meta['identifiers'].include? 'spdx') && (meta.include? 'tags') && (meta['tags'].include? 'libre')
+      meta['identifiers']['spdx'].each do |identifier|
+        licenses[identifier.downcase] = meta['name']
+      end
     end
-
-    # FSF approved the Clear BSD, but doesn't use its SPDX ID or Name
-    if licenses.keys.include? 'clearbsd'
-      licenses['bsd-3-clause-clear'] = licenses['clearbsd']
-    end
-
     licenses
   end
 end


### PR DESCRIPTION
Ideally the FSF would be maintaining the API (or any API), but until someone can talk them into that I think we can save work by collaborating on the mock API (discussion in #561).  Using a JSON API also allows us to drop the Nokogiri dependency.

The parens feel excessive, and I'm not familiar with Ruby, so they might be.  However, removing the parens from the libre check resulted in:

```console
$ ./script/check-approval ISC
./script/check-approval:8:in `require_relative': /.../choosealicense.com/spec/spec_helper.rb:108: syntax error, unexpected tSTRING_BEG, expecting keyword_then or ';' or '\n' (SyntaxError)
...gs') && meta['tags'].include? 'libre'
...                               ^
/.../choosealicense.com/spec/spec_helper.rb:116: syntax error, unexpected keyword_end, expecting end-of-input
        from ./script/check-approval:8:in `<main>'
```

If you want to test with `./script/check-approval ISC` and similar, you should merge #567 and #568 to fix unrelated `check-approval` issues.

Fixes #561.