### PR TITLE
Rubocop 0.53 doesn't like kernel#open use more specific OpenURI.open_…

### DIFF
--- a/spec/license_meta_spec.rb
+++ b/spec/license_meta_spec.rb
@@ -54,7 +54,7 @@ describe 'license meta' do
           example_url = example.values[0]
 
           context "the #{example_url} URL" do
-            let(:content)  { open(example_url).read }
+            let(:content)  { OpenURI.open_uri(example_url).read }
             let(:detected) { Licensee::ProjectFiles::LicenseFile.new(content, 'LICENSE').license }
 
             if example_url.start_with?('https://github.com/')

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -73,7 +73,7 @@ end
 def spdx_list
   SpecHelper.spdx ||= begin
     url = 'https://spdx.org/licenses/licenses.json'
-    list = JSON.parse(open(url).read)['licenses']
+    list = JSON.parse(OpenURI.open_uri(url).read)['licenses']
     list.each_with_object({}) do |values, memo|
       memo[values['licenseId']] = values
     end
@@ -102,7 +102,7 @@ end
 def fsf_approved_licenses
   SpecHelper.fsf_approved_licenses ||= begin
     url = 'https://wking.github.io/fsf-api/licenses-full.json'
-    object = JSON.parse(open(url).read)
+    object = JSON.parse(OpenURI.open_uri(url).read)
     licenses = {}
     object.each_value do |meta|
       next unless (meta.include? 'identifiers') && (meta['identifiers'].include? 'spdx') && (meta.include? 'tags') && (meta['tags'].include? 'libre')
@@ -117,7 +117,7 @@ end
 def od_approved_licenses
   SpecHelper.od_approved_licenses ||= begin
     url = 'http://licenses.opendefinition.org/licenses/groups/od.json'
-    data = open(url).read
+    data = OpenURI.open_uri(url).read
     data = JSON.parse(data)
     licenses = {}
     data.each do |id, meta|


### PR DESCRIPTION
…uri instead

https://github.com/bbatsov/rubocop/blob/841569b305808e279a814c9823da30e8d1d0649a/manual/cops_security.md#securityopen

Not sure this is really a problem for tests, but easiest to just change.