### PR TITLE
spec_helper: Adjust to new 'licenses' key in the FSF API

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -104,7 +104,7 @@ def fsf_approved_licenses
     url = 'https://wking.github.io/fsf-api/licenses-full.json'
     object = JSON.parse(OpenURI.open_uri(url).read)
     licenses = {}
-    object.each_value do |meta|
+    object['licenses'].each_value do |meta|
       next unless (meta.include? 'identifiers') && (meta['identifiers'].include? 'spdx') && (meta.include? 'tags') && (meta['tags'].include? 'libre')
       meta['identifiers']['spdx'].each do |identifier|
         licenses[identifier.downcase] = meta['name']


### PR DESCRIPTION
The old root object has been moved under `licenses` with wking/fsf-api#12 for better forward/backward compatibility.  Unfortunately, this results in another one-time incompatible change, which this commit accommodates.

The protection from future changes (which should be rare) isn't great, because we're still parsing the document as JSON.  There is [at least one][1] JSON-LD parser for Ruby, but I've stuck with vanilla JSON to avoid pullling in an external dependency just for this rather peripheral functionality.

[1]: https://github.com/ruby-rdf/json-ld/