### PR TITLE
UPL-1.0 (c) line use [year] and [fullname] fields

### DIFF
--- a/_licenses/upl-1.0.txt
+++ b/_licenses/upl-1.0.txt
@@ -30,7 +30,7 @@ limitations:
 
 ---
 
-Copyright (c) <year> <copyright holders>
+Copyright (c) [year] [fullname]
 
 The Universal Permissive License (UPL), Version 1.0
 


### PR DESCRIPTION
After merging #580 and looking at https://choosealicense.com/licenses/upl-1.0/ I realized the (c) line should use `[year]` and `[fullname]` as do MIT, ISC, and the BSD licenses cataloged here so that they could be filled in when deployed via GitHub's community profile with a URL like https://github.com/ORG/REPO/community/license/new?branch=master&template=upl-1.0 once github.com becomes UPL-1.0-aware.

cc @Djelibeybi