### PR TITLE
Fix some licenses substitutions

### DIFF
--- a/_licenses/apache-2.0.txt
+++ b/_licenses/apache-2.0.txt
@@ -223,7 +223,7 @@ limitations:
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright [year] [fullname]
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/_licenses/cc-by-4.0.txt
+++ b/_licenses/cc-by-4.0.txt
@@ -1,5 +1,5 @@
 ---
-title: Creative Commons Attribution 4.0
+title: Creative Commons Attribution 4.0 International
 spdx-id: CC-BY-4.0
 source: https://creativecommons.org/licenses/by/4.0/legalcode.txt
 

--- a/_licenses/cc-by-sa-4.0.txt
+++ b/_licenses/cc-by-sa-4.0.txt
@@ -1,5 +1,5 @@
 ---
-title: Creative Commons Attribution Share Alike 4.0
+title: Creative Commons Attribution Share Alike 4.0 International
 spdx-id: CC-BY-SA-4.0
 source: https://creativecommons.org/licenses/by-sa/4.0/legalcode.txt
 

--- a/_licenses/ecl-2.0.txt
+++ b/_licenses/ecl-2.0.txt
@@ -223,7 +223,7 @@ also recommend that a file or class name and description of purpose be
 included on the same "printed page" as the copyright notice for easier
 identification within third-party archives.
 
-Copyright [yyyy] [name of copyright owner] Licensed under the Educational
+Copyright [year] [fullname] Licensed under the Educational
 Community License, Version 2.0 (the "License"); you may not use this file
 except in compliance with the License. You may obtain a copy of the License at
 


### PR DESCRIPTION
Github use some substitutions in license text:

- `[year]` -- current year.
- `[fullname]` -- name of repository owner.

Apache 2.0 and ECL 2.0 licenses contains this wrong substitutions: `[yyyy] [name of copyright owner]`. Many people forget fix it manually. For example, [yapf](https://github.com/google/yapf/blob/master/LICENSE#L190).