### PR TITLE
rm default valued metadata for one license

### DIFF
--- a/_licenses/epl-1.0.txt
+++ b/_licenses/epl-1.0.txt
@@ -2,7 +2,6 @@
 title: Eclipse Public License 1.0
 spdx-id: EPL-1.0
 source: https://www.eclipse.org/legal/epl-v10.html
-hidden: true
 
 description: This commercially-friendly copyleft license provides the ability to commercially license binaries; a modern royalty-free patent license grant; and the ability for linked works to use other licenses, including commercial ones.
 


### PR DESCRIPTION
line should've been removed rather than modified in https://github.com/github/choosealicense.com/pull/554