### PR TITLE
Update licenses.html to reflect the change of the home page

### DIFF
--- a/about.md
+++ b/about.md
@@ -10,7 +10,7 @@ If you already know what you're doing and have a license you prefer to use, that
 
 ## Not comprehensive
 
-This site is not a comprehensive directory of open source licenses. On the [homepage](/), we break it down into just three licenses. The vast majority of projects will likely be fine choosing from one of these three. Just in case you have specific needs not covered by those three, we also highlight a [few other licenses to consider](/licenses/), and have a page about [licenses for non-software projects](/non-software/).
+This site is not a comprehensive directory of open source licenses. On the [homepage](/), we break it down into just two licenses. The vast majority of projects will likely be fine choosing from one of these two. Just in case you have specific needs not covered by those two, we also highlight a [few other licenses to consider](/licenses/), and have a page about [licenses for non-software projects](/non-software/).
 
 See our [appendix](/appendix/) for a table of all of the licenses cataloged in the choosealicense.com repository and the links below for *even more licenses* that you **do not** need to learn about when choosing a license for your project.
 

--- a/licenses.html
+++ b/licenses.html
@@ -5,7 +5,7 @@ class: license-types
 title: Licenses
 ---
 
-<p>Open source licenses grant permission to everyone to use, modify, and share licensed software for any purpose, subject to conditions preserving the provenance and openness of the software. The following licenses are arranged from one with the strongest of these conditions (GNU AGPLv3) to one with no conditions (Unlicense). Notice that the popular licenses featured on the <a href="/">home page</a> (GNU GPLv3, and MIT License) fall within this spectrum.</p>
+<p>Open source licenses grant permission to everyone to use, modify, and share licensed software for any purpose, subject to conditions preserving the provenance and openness of the software. The following licenses are arranged from one with the strongest of these conditions (GNU AGPLv3) to one with no conditions (Unlicense). Notice that the popular licenses featured on the <a href="/">home page</a> (GNU GPLv3 and MIT) fall within this spectrum.</p>
 <p style="font-size:small; margin-bottom: 40px">If you were looking for a reference table of all of the licenses on choosealicense.com, see the <a href="/appendix">appendix</a>.</p>
 
 {% include license-overview.html license-id="agpl-3.0" %}

--- a/licenses.html
+++ b/licenses.html
@@ -5,7 +5,7 @@ class: license-types
 title: Licenses
 ---
 
-<p>Open source licenses grant permission to everyone to use, modify, and share licensed software for any purpose, subject to conditions preserving the provenance and openness of the software. The following licenses are arranged from one with the strongest of these conditions (GNU AGPLv3) to one with no conditions (Unlicense). Notice that the popular licenses featured on the <a href="/">home page</a> (GNU GPLv3, Apache License 2.0, and MIT License) fall within this spectrum.</p>
+<p>Open source licenses grant permission to everyone to use, modify, and share licensed software for any purpose, subject to conditions preserving the provenance and openness of the software. The following licenses are arranged from one with the strongest of these conditions (GNU AGPLv3) to one with no conditions (Unlicense). Notice that the popular licenses featured on the <a href="/">home page</a> (GNU GPLv3, and MIT License) fall within this spectrum.</p>
 <p style="font-size:small; margin-bottom: 40px">If you were looking for a reference table of all of the licenses on choosealicense.com, see the <a href="/appendix">appendix</a>.</p>
 
 {% include license-overview.html license-id="agpl-3.0" %}


### PR DESCRIPTION
Because the Apache 2.0 license has been removed from the home page, thus update licenses.html to reflect the change.