### PR TITLE
Stop vendored material READMEs from rendering

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -34,6 +34,7 @@ exclude:
   - tests
   - assets/vendor/selectivizr/tests
   - assets/vendor/clipboard/test
+  - assets/vendor/*/README.*
 
 plugins:
   - jekyll-sitemap


### PR DESCRIPTION
And thus appearing in sitemap.xml.