### PR TITLE
rm source metadata, defer to SPDX record

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 2.4
+  TargetRubyVersion: 2.5
   Exclude:
     - _site/**/*
     - vendor/**/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ script: "./script/cibuild"
 #environment
 language: ruby
 rvm:
-  - 2.4.2
+  - 2.5.1
 
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,10 @@ addons:
     packages:
     - libcurl4-openssl-dev
 
+before_install:
+  - gem update --system
+  - gem install bundler
+
 branches:
   only:
     - gh-pages

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,7 @@ addons:
     - libcurl4-openssl-dev
 
 before_install:
-  - gem update --system
-  - gem install bundler
+  - gem install bundler --version 1.16.2
 
 branches:
   only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,6 @@ addons:
     packages:
     - libcurl4-openssl-dev
 
-before_install:
-  - gem install bundler --version 1.16.2
-
 branches:
   only:
     - gh-pages

--- a/README.md
+++ b/README.md
@@ -35,7 +35,6 @@ Licenses sit in the `/_licenses` folder. Each license has YAML front matter desc
 
 * `title` - The license full name specified by https://spdx.org/licenses/
 * `spdx-id` - Short identifier specified by https://spdx.org/licenses/
-* `source` - The URL to the license source text
 * `description` - A human-readable description of the license
 * `how` - Instructions on how to implement the license
 * `using` - A list of 3 notable projects using the license with straightforward LICENSE files which serve as examples newcomers can follow and that can be detected by [licensee](https://github.com/benbalter/licensee) in the form of `project_name: license_file_url`

--- a/_data/meta.yml
+++ b/_data/meta.yml
@@ -9,10 +9,6 @@
   description: Short identifier specified by https://spdx.org/licenses/
   required: true
 
-- name: source
-  description: The URL to the license source text
-  required: true
-
 - name: description
   description: A human-readable description of the license
   required: true

--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -19,7 +19,7 @@
 
   {% if page.source %}
   <div class="source">
-    <a href="{{ page.source }}">
+    <a href="https://spdx.org/licenses/{{ page.spdx-id }}.html">
       <span class="license-sprite"></span>
       Source
     </a>

--- a/_licenses/afl-3.0.txt
+++ b/_licenses/afl-3.0.txt
@@ -1,7 +1,6 @@
 ---
 title: Academic Free License v3.0
 spdx-id: AFL-3.0
-source: https://opensource.org/licenses/afl-3.0
 
 description: The Academic Free License is a variant of the Open Software License that does not require that the source code of derivative works be disclosed. It contains explicit copyright and patent grants and reserves trademark rights in the author.
 

--- a/_licenses/agpl-3.0.txt
+++ b/_licenses/agpl-3.0.txt
@@ -3,7 +3,6 @@ title: GNU Affero General Public License v3.0
 spdx-id: AGPL-3.0
 nickname: GNU AGPLv3
 redirect_from: /licenses/agpl/
-source: https://www.gnu.org/licenses/agpl-3.0.txt
 hidden: false
 
 description: Permissions of this strongest copyleft license are conditioned on making available complete source code of licensed works and modifications, which include larger works using a licensed work, under the same license. Copyright and license notices must be preserved. Contributors provide an express grant of patent rights. When a modified version is used to provide a service over a network, the complete source code of the modified version must be made available.

--- a/_licenses/apache-2.0.txt
+++ b/_licenses/apache-2.0.txt
@@ -2,7 +2,6 @@
 title: Apache License 2.0
 spdx-id: Apache-2.0
 redirect_from: /licenses/apache/
-source: https://www.apache.org/licenses/LICENSE-2.0.html
 featured: true
 hidden: false
 

--- a/_licenses/artistic-2.0.txt
+++ b/_licenses/artistic-2.0.txt
@@ -2,7 +2,6 @@
 title: Artistic License 2.0
 spdx-id: Artistic-2.0
 redirect_from: /licenses/artistic/
-source: https://spdx.org/licenses/Artistic-2.0.html
 
 description: Heavily favored by the Perl community, the Artistic license requires that modified versions of the software do not prevent users from running the standard version.
 

--- a/_licenses/bsd-2-clause.txt
+++ b/_licenses/bsd-2-clause.txt
@@ -2,7 +2,6 @@
 title: BSD 2-Clause "Simplified" License
 spdx-id: BSD-2-Clause
 redirect_from: /licenses/bsd/
-source: https://opensource.org/licenses/BSD-2-Clause
 hidden: false
 
 description: A permissive license that comes in two variants, the <a href="/licenses/bsd-2-clause/">BSD 2-Clause</a> and <a href="/licenses/bsd-3-clause/">BSD 3-Clause</a>. Both have very minute differences to the MIT license.

--- a/_licenses/bsd-3-clause-clear.txt
+++ b/_licenses/bsd-3-clause-clear.txt
@@ -1,7 +1,6 @@
 ---
 title: BSD 3-Clause Clear License
 spdx-id: BSD-3-Clause-Clear
-source: https://spdx.org/licenses/BSD-3-Clause-Clear.html
 
 description: A variant of the <a href="/licenses/bsd-3-clause/">BSD 3-Clause License</a> that explicitly does not grant any patent rights.
 

--- a/_licenses/bsd-3-clause.txt
+++ b/_licenses/bsd-3-clause.txt
@@ -1,7 +1,6 @@
 ---
 title: BSD 3-Clause "New" or "Revised" License
 spdx-id: BSD-3-Clause
-source: https://opensource.org/licenses/BSD-3-Clause
 hidden: false
 
 description: A permissive license similar to the <a href="/licenses/bsd-2-clause/">BSD 2-Clause License</a>, but with a 3rd clause that prohibits others from using the name of the project or its contributors to promote derived products without written consent.

--- a/_licenses/bsl-1.0.txt
+++ b/_licenses/bsl-1.0.txt
@@ -1,7 +1,6 @@
 ---
 title: Boost Software License 1.0
 spdx-id: BSL-1.0
-source: https://opensource.org/licenses/BSL-1.0
 
 description: A simple permissive license only requiring preservation of copyright and license notices for source (and not binary) distribution. Licensed works, modifications, and larger works may be distributed under different terms and without source code.
 

--- a/_licenses/cc-by-4.0.txt
+++ b/_licenses/cc-by-4.0.txt
@@ -1,7 +1,6 @@
 ---
 title: Creative Commons Attribution 4.0 International
 spdx-id: CC-BY-4.0
-source: https://creativecommons.org/licenses/by/4.0/legalcode.txt
 
 description: Permits almost any use subject to providing credit and license notice. Frequently used for media assets and educational materials. The most common license for Open Access scientific publications. Not recommended for software.
 

--- a/_licenses/cc-by-sa-4.0.txt
+++ b/_licenses/cc-by-sa-4.0.txt
@@ -1,7 +1,6 @@
 ---
 title: Creative Commons Attribution Share Alike 4.0 International
 spdx-id: CC-BY-SA-4.0
-source: https://creativecommons.org/licenses/by-sa/4.0/legalcode.txt
 
 description: Similar to <a href='/licenses/cc-by-4.0/'>CC-BY-4.0</a> but requires derivatives be distributed under the same or a similar, <a href="https://creativecommons.org/compatiblelicenses/">compatible</a> license. Frequently used for media assets and educational materials. A previous version is the default license for Wikipedia and other Wikimedia projects. Not recommended for software.
 

--- a/_licenses/cc0-1.0.txt
+++ b/_licenses/cc0-1.0.txt
@@ -2,7 +2,6 @@
 title: Creative Commons Zero v1.0 Universal
 spdx-id: CC0-1.0
 redirect_from: /licenses/cc0/
-source: https://creativecommons.org/publicdomain/zero/1.0/
 
 description: The <a href="https://creativecommons.org/publicdomain/zero/1.0/">Creative Commons CC0 Public Domain Dedication</a> waives copyright interest in a work you've created and dedicates it to the world-wide public domain. Use CC0 to opt out of copyright entirely and ensure your work has the widest reach. As with the Unlicense and typical software licenses, CC0 disclaims warranties. CC0 is very similar to the Unlicense.
 

--- a/_licenses/ecl-2.0.txt
+++ b/_licenses/ecl-2.0.txt
@@ -1,7 +1,6 @@
 ---
 title: Educational Community License v2.0
 spdx-id: ECL-2.0
-source: https://opensource.org/licenses/ECL-2.0
 
 description: The Educational Community License version 2.0 ("ECL") consists of the Apache 2.0 license, modified to change the scope of the patent grant in section 3 to be specific to the needs of the education communities using this license.
 

--- a/_licenses/epl-1.0.txt
+++ b/_licenses/epl-1.0.txt
@@ -1,7 +1,6 @@
 ---
 title: Eclipse Public License 1.0
 spdx-id: EPL-1.0
-source: https://www.eclipse.org/legal/epl-v10.html
 
 description: This commercially-friendly copyleft license provides the ability to commercially license binaries; a modern royalty-free patent license grant; and the ability for linked works to use other licenses, including commercial ones.
 

--- a/_licenses/epl-2.0.txt
+++ b/_licenses/epl-2.0.txt
@@ -2,7 +2,6 @@
 title: Eclipse Public License 2.0
 spdx-id: EPL-2.0
 redirect_from: /licenses/eclipse/
-source: https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt
 hidden: false
 
 description: This commercially-friendly copyleft license provides the ability to commercially license binaries; a modern royalty-free patent license grant; and the ability for linked works to use other licenses, including commercial ones.

--- a/_licenses/eupl-1.1.txt
+++ b/_licenses/eupl-1.1.txt
@@ -2,7 +2,6 @@
 title: European Union Public License 1.1
 spdx-id: EUPL-1.1
 redirect_from: /licenses/eupl-v1.1/
-source: https://joinup.ec.europa.eu/page/eupl-text-11-12
 
 description: The “European Union Public Licence” (EUPL) is a copyleft free/open source software license created on the initiative of and approved by the European Commission in 22 official languages of the European Union.
 

--- a/_licenses/eupl-1.2.txt
+++ b/_licenses/eupl-1.2.txt
@@ -1,7 +1,6 @@
 ---
 title: European Union Public License 1.2
 spdx-id: EUPL-1.2
-source: https://eur-lex.europa.eu/legal-content/TXT/?uri=CELEX%3A32017D0863
 
 description: The European Union Public Licence (EUPL) is a copyleft free/open source software license created on the initiative of and approved by the European Commission in 22 official languages of the European Union.
 

--- a/_licenses/gpl-2.0.txt
+++ b/_licenses/gpl-2.0.txt
@@ -3,7 +3,6 @@ title: GNU General Public License v2.0
 spdx-id: GPL-2.0
 nickname: GNU GPLv2
 redirect_from: /licenses/gpl-v2/
-source: https://www.gnu.org/licenses/gpl-2.0.txt
 hidden: false
 
 description: The GNU GPL is the most widely used free software license and has a strong copyleft requirement. When distributing derived works, the source code of the work must be made available under the same license. There are multiple variants of the GNU GPL, each with different requirements.

--- a/_licenses/gpl-3.0.txt
+++ b/_licenses/gpl-3.0.txt
@@ -3,7 +3,6 @@ title: GNU General Public License v3.0
 spdx-id: GPL-3.0
 nickname: GNU GPLv3
 redirect_from: /licenses/gpl-v3/
-source: https://www.gnu.org/licenses/gpl-3.0.txt
 featured: true
 hidden: false
 

--- a/_licenses/isc.txt
+++ b/_licenses/isc.txt
@@ -1,7 +1,6 @@
 ---
 title: ISC License
 spdx-id: ISC
-source: https://opensource.org/licenses/isc-license
 
 description: A permissive license lets people do anything with your code with proper attribution and without warranty. The ISC license is functionally equivalent to the <a href="/licenses/bsd-2-clause/">BSD 2-Clause</a> and <a href="/licenses/mit/">MIT</a> licenses, removing some language that is no longer necessary.
 

--- a/_licenses/lgpl-2.1.txt
+++ b/_licenses/lgpl-2.1.txt
@@ -3,7 +3,6 @@ title: GNU Lesser General Public License v2.1
 spdx-id: LGPL-2.1
 nickname: GNU LGPLv2.1
 redirect_from: /licenses/lgpl-v2.1/
-source: https://www.gnu.org/licenses/lgpl-2.1.txt
 hidden: false
 
 description: Primarily used for software libraries, the GNU LGPL requires that derived works be licensed under the same license, but works that only link to it do not fall under this restriction. There are two commonly used versions of the GNU LGPL.

--- a/_licenses/lgpl-3.0.txt
+++ b/_licenses/lgpl-3.0.txt
@@ -3,7 +3,6 @@ title: GNU Lesser General Public License v3.0
 spdx-id: LGPL-3.0
 nickname: GNU LGPLv3
 redirect_from: /licenses/lgpl-v3/
-source: https://www.gnu.org/licenses/lgpl-3.0.txt
 hidden: false
 
 description: Permissions of this copyleft license are conditioned on making available complete source code of licensed works and modifications under the same license or the GNU GPLv3. Copyright and license notices must be preserved. Contributors provide an express grant of patent rights. However, a larger work using the licensed work through interfaces provided by the licensed work may be distributed under different terms and without source code for the larger work.

--- a/_licenses/lppl-1.3c.txt
+++ b/_licenses/lppl-1.3c.txt
@@ -1,7 +1,6 @@
 ---
 title: LaTeX Project Public License v1.3c
 spdx-id: LPPL-1.3c
-source: https://latex-project.org/lppl/lppl-1-3c.html
 
 description: The LaTeX Project Public License (LPPL) is the primary license under which the LaTeX kernel and the base LaTeX packages are distributed.
 

--- a/_licenses/mit.txt
+++ b/_licenses/mit.txt
@@ -1,7 +1,6 @@
 ---
 title: MIT License
 spdx-id: MIT
-source: https://opensource.org/licenses/MIT
 featured: true
 hidden: false
 

--- a/_licenses/mpl-2.0.txt
+++ b/_licenses/mpl-2.0.txt
@@ -2,7 +2,6 @@
 title: Mozilla Public License 2.0
 spdx-id: MPL-2.0
 redirect_from: /licenses/mozilla/
-source: https://www.mozilla.org/media/MPL/2.0/index.txt
 hidden: false
 
 description: Permissions of this weak copyleft license are conditioned on making available source code of licensed files and modifications of those files under the same license (or in certain cases, one of the GNU licenses). Copyright and license notices must be preserved. Contributors provide an express grant of patent rights. However, a larger work using the licensed work may be distributed under different terms and without source code for files added in the larger work.

--- a/_licenses/ms-pl.txt
+++ b/_licenses/ms-pl.txt
@@ -1,7 +1,6 @@
 ---
 title: Microsoft Public License
 spdx-id: MS-PL
-source: https://opensource.org/licenses/ms-pl
 
 description: An open source license with a patent grant.
 

--- a/_licenses/ms-rl.txt
+++ b/_licenses/ms-rl.txt
@@ -1,7 +1,6 @@
 ---
 title: Microsoft Reciprocal License
 spdx-id: MS-RL
-source: https://opensource.org/licenses/ms-rl
 
 description: An open source license with a patent grant similar to the <a href="/licenses/ms-pl/">Microsoft Public License</a>, with the additional condition that any source code for any derived file be provided under this license.
 

--- a/_licenses/ncsa.txt
+++ b/_licenses/ncsa.txt
@@ -2,7 +2,6 @@
 title: University of Illinois/NCSA Open Source License
 spdx-id: NCSA
 nickname: UIUC/NCSA
-source: https://opensource.org/licenses/NCSA
 
 description: The University of Illinois/NCSA Open Source License, or UIUC license, is a permissive free software license, based on the <a href="/licenses/mit/">MIT/X11 license</a>  and the <a href="/licenses/bsd-3-clause/">BSD 3-clause License</a>. Its conditions include requiring the preservation of copyright and license notices both in source and in binary distributions and the prohibition of using the names of the authors or the project organization to promote or endorse derived products.
 

--- a/_licenses/ofl-1.1.txt
+++ b/_licenses/ofl-1.1.txt
@@ -2,7 +2,6 @@
 title: SIL Open Font License 1.1
 spdx-id: OFL-1.1
 redirect_from: /licenses/ofl/
-source: http://scripts.sil.org/OFL_web
 
 description: The Open Font License (OFL) is maintained by SIL International. It attempts to be a compromise between the values of the free software and typeface design communities. It is used for almost all open source font projects, including those by Adobe, Google and Mozilla.
 

--- a/_licenses/osl-3.0.txt
+++ b/_licenses/osl-3.0.txt
@@ -1,7 +1,6 @@
 ---
 title: Open Software License 3.0
 spdx-id: OSL-3.0
-source: https://opensource.org/licenses/OSL-3.0
 
 description: OSL 3.0 is a copyleft license that does not require reciprocal licensing on linked works. It also provides an express grant of patent rights from contributors to users, with a termination clause triggered if a user files a patent infringement lawsuit.
 

--- a/_licenses/postgresql.txt
+++ b/_licenses/postgresql.txt
@@ -1,7 +1,6 @@
 ---
 title: PostgreSQL License
 spdx-id: PostgreSQL
-source: https://opensource.org/licenses/PostgreSQL
 
 description: A very short, BSD-style license, used specifically for PostgreSQL.  
 

--- a/_licenses/unlicense.txt
+++ b/_licenses/unlicense.txt
@@ -1,7 +1,6 @@
 ---
 title: The Unlicense
 spdx-id: Unlicense
-source: https://unlicense.org/UNLICENSE
 hidden: false
 
 description: A license with no conditions whatsoever which dedicates works to the public domain. Unlicensed works, modifications, and larger works may be distributed under different terms and without source code.

--- a/_licenses/upl-1.0.txt
+++ b/_licenses/upl-1.0.txt
@@ -1,7 +1,6 @@
 ---
 title: Universal Permissive License v1.0
 spdx-id: UPL-1.0
-source: https://oss.oracle.com/licenses/upl/
 
 description: A permissive, OSI and FSF approved, GPL compatible license, expressly allowing attribution with just a copyright notice and a short form link rather than the full text of the license.  Includes an express grant of patent rights.  Licensed works and modifications may be distributed under different terms and without source code, and the patent grant may also optionally be expanded to larger works to permit use as a contributor license agreement.
 

--- a/_licenses/wtfpl.txt
+++ b/_licenses/wtfpl.txt
@@ -1,7 +1,6 @@
 ---
 title: "Do What The F*ck You Want To Public License"
 spdx-id: WTFPL
-source: http://www.wtfpl.net/txt/copying/
 
 description: The easiest license out there. It gives the user permissions to do whatever they want with your code.
 

--- a/_licenses/zlib.txt
+++ b/_licenses/zlib.txt
@@ -1,7 +1,6 @@
 ---
 title: zlib License
 spdx-id: Zlib
-source: https://opensource.org/licenses/Zlib
 
 description: A short permissive license, compatible with GPL. Requires altered source versions to be documented as such.
 

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -3,7 +3,7 @@
 set -e
 
 echo "bundling installin'"
-gem install bundler
+gem install bundler --version 1.16.2
 bundle install
 
 echo


### PR DESCRIPTION
I think the SPDX page for each license is superior to identifying a single source URL for each license in this project, especially given that the single source URL is sometimes squirrelly or context-free (latter: text files) while the SPDX page contains the source and relevant other links.

What about consumers?

Licensee does expose license metadata, including source: https://github.com/benbalter/licensee/blob/0d87ecc0f59189a670597d001641abf775433362/docs/usage.md#license-ruby-api

It could manufacture source metadata, as [done in this PR](https://github.com/github/choosealicense.com/pull/601/files#diff-88116a8ad5517e8b9bfd0e9911642382R22).

The GitHub licenses API does not expose source metadata https://developer.github.com/v3/licenses/#response-1