### PR TITLE
BSD-2/3-Clause numbered list, uses

### DIFF
--- a/_licenses/bsd-2-clause.txt
+++ b/_licenses/bsd-2-clause.txt
@@ -10,6 +10,9 @@ description: A permissive license that comes in two variants, the <a href="/lice
 how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file. Replace [year] with the current year and [fullname] with the name (or names) of the copyright holders.
 
 using:
+  - go-redis: https://github.com/go-redis/redis/blob/master/LICENSE
+  - Homebrew: https://github.com/Homebrew/brew/blob/master/LICENSE.txt
+  - Pony: https://github.com/ponylang/ponyc/blob/master/LICENSE
 
 permissions:
   - commercial-use
@@ -34,12 +37,12 @@ All rights reserved.
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:
 
-* Redistributions of source code must retain the above copyright notice, this
-  list of conditions and the following disclaimer.
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
 
-* Redistributions in binary form must reproduce the above copyright notice,
-  this list of conditions and the following disclaimer in the documentation
-  and/or other materials provided with the distribution.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
 
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
 AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE

--- a/_licenses/bsd-3-clause.txt
+++ b/_licenses/bsd-3-clause.txt
@@ -10,7 +10,7 @@ how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of 
 using:
   - d3: https://github.com/d3/d3/blob/master/LICENSE
   - LevelDB: https://github.com/google/leveldb/blob/master/LICENSE
-  - Scala: https://github.com/scala/scala/blob/2.13.x/LICENSE
+  - Quill: https://github.com/quilljs/quill/blob/develop/LICENSE
 
 permissions:
   - commercial-use

--- a/_licenses/bsd-3-clause.txt
+++ b/_licenses/bsd-3-clause.txt
@@ -9,6 +9,9 @@ description: A permissive license similar to the <a href="/licenses/bsd-2-clause
 how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file. Replace [year] with the current year and [fullname] with the name (or names) of the copyright holders. Replace [project] with the project organization, if any, that sponsors this work.
 
 using:
+  - d3: https://github.com/d3/d3/blob/master/LICENSE
+  - LevelDB: https://github.com/google/leveldb/blob/master/LICENSE
+  - Scala: https://github.com/scala/scala/blob/2.13.x/LICENSE
 
 permissions:
   - commercial-use
@@ -33,16 +36,16 @@ All rights reserved.
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:
 
-* Redistributions of source code must retain the above copyright notice, this
-  list of conditions and the following disclaimer.
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
 
-* Redistributions in binary form must reproduce the above copyright notice,
-  this list of conditions and the following disclaimer in the documentation
-  and/or other materials provided with the distribution.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
 
-* Neither the name of the copyright holder nor the names of its
-  contributors may be used to endorse or promote products derived from
-  this software without specific prior written permission.
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
 
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
 AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE

--- a/spec/license_meta_spec.rb
+++ b/spec/license_meta_spec.rb
@@ -26,8 +26,6 @@ describe 'license meta' do
           'afl-3.0',
           'agpl-3.0',
           'artistic-2.0',
-          'bsd-2-clause',
-          'bsd-3-clause',
           'bsd-3-clause-clear',
           'bsl-1.0',
           'cc0-1.0',


### PR DESCRIPTION
SPDX and OSI have numbered lists for these licenses: one small change to bring license texts into line with SPDX https://github.com/github/choosealicense.com/pull/489

Tests do not pass for bsd-3-clause examples because licensee does not (yet) normalize bulleted/numbered lists, noticed at https://github.com/benbalter/licensee/issues/323#issuecomment-414081486

Don't intend to merge until tests pass.