### PR TITLE
Change phrasing of no-license text.

### DIFF
--- a/index.html
+++ b/index.html
@@ -72,7 +72,7 @@ permalink: /
   <li>
     <h3>I don’t want to choose a license.</h3>
     <p>
-      <a href="no-permission/">You don’t have to</a>.
+      <a href="no-permission/">Here’s what happens if you don’t</a>.
     </p>
   </li>
 </ul>


### PR DESCRIPTION
Someone asked me for advice on picking an open source license, so I pointed them to choosealicense.com. They read all of the options on the page, got down to “You don’t have to” and said “oh good, I won’t bother then” and closed the tab. This rather missed the point (they really did want users to be able to use their program), so here’s a PR that clarifies the wording to make it clearer that there are consequences to this decision.