### PR TITLE
Throttle concurrency of html link checker

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -16,6 +16,7 @@ task :test do
                               check_html: true,
                               validation: { ignore_script_embeds: true },
                               url_swap: { %r{https://choosealicense.com} => '' },
+                              hydra: { max_concurrency: 10 },
                               check_img_http: true).run
 end
 


### PR DESCRIPTION
spdx.org obtains 503 if too many connections opened, it seems eg https://travis-ci.org/github/choosealicense.com/builds/439831256

Problem goes away locally when html-proofer/typhoeus/hydra default changed from 200 to 10.