### PR TITLE
add gplcc note to gpl-2.0 and lgpl-2.1 sidebars

### DIFF
--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -15,14 +15,20 @@
     <p>
       {{ page.how | markdownify | remove: '<p>' | remove: '</p>' }}
     </p>
+    <div class="note">
+    <h4>Optional steps</h4>
     {% if page.note %}
-    <p class="note">
-      <strong>Note: </strong> {{ page.note | markdownify | remove: '<p>' | remove: '</p>' }}
+    <p>
+      {{ page.note | markdownify | remove: '<p>' | remove: '</p>' }}
     </p>
     {% endif %}
     {% assign xgpl = false %}
     {% if page.spdx-id contains 'GPL' %}{% assign xgpl = true %}{% endif %}
-    <p class="note"><strong>Optional: </strong> Add <strong><code>{{ page.spdx-id }}{% if xgpl %}-or-later{% endif %}</code></strong>{% if xgpl %} (or <strong><code>{{ page.spdx-id }}-only</code></strong> to disallow future versions){% endif %} to your project's package description, if applicable (e.g., <a href="https://docs.npmjs.com/files/package.json#license">Node.js</a>, <a href="https://guides.rubygems.org/specification-reference/#license=">Ruby</a>, and <a href="https://doc.rust-lang.org/cargo/reference/manifest.html#package-metadata">Rust</a>). This will ensure the license is displayed in package directories.</p>
+    <p>Add <strong><code>{{ page.spdx-id }}{% if xgpl %}-or-later{% endif %}</code></strong>{% if xgpl %} (or <strong><code>{{ page.spdx-id }}-only</code></strong> to disallow future versions){% endif %} to your project's package description, if applicable (e.g., <a href="https://docs.npmjs.com/files/package.json#license">Node.js</a>, <a href="https://guides.rubygems.org/specification-reference/#license=">Ruby</a>, and <a href="https://doc.rust-lang.org/cargo/reference/manifest.html#package-metadata">Rust</a>). This will ensure the license is displayed in package directories.</p>
+    {% if page.spdx-id contains 'GPL-2' %}
+    <p>If you would like your project to adopt the GPL-3.0's cure provision, add the <a href="https://github.com/gplcc/gplcc/blob/master/Project/COMMITMENT">text</a> of the <a href="https://gplcc.github.io/gplcc/">GPL Cooperation Commitment</a> to a file named <code>COMMITMENT</code> in the same directory as your {{ page.spdx-id }} license file.</p>
+    {% endif %}
+    </div>
   </div>
 
   <div class="source">


### PR DESCRIPTION
Somewhat obscure, but that's [changing](https://www.redhat.com/en/blog/gpl-cooperation-commitment-and-red-hat-projects), and GPLv2/LGPL2.1 aren't linked anywhere on the site besides the appendix...someone finding them might want to know about this uncontroversial and not situation specific additional permission.