### PR TITLE
[WIP] feat: click on a license rule to highlight his associated text ranges

### DIFF
--- a/_layouts/license.html
+++ b/_layouts/license.html
@@ -31,10 +31,19 @@
                         {% for rule_obj in rules %}
                           {% assign req = rule_obj.tag %}
                           {% if page[type] contains req %}
-                            <li class="{{ req }}">
+                            <li class="{{type}} {{ req }}">
                               <span class="license-sprite"></span>
                               {{ rule_obj.label }}
                             </li>
+                          {% else %}
+                            {% for rule in page[type] %}
+                              {% if rule.tag == req %}
+                                <li class="{{type}} {{ req }} annotated-rule" data-rule-ranges="{{ rule.ranges | join: "," }}">
+                                  <span class="license-sprite"></span>
+                                  {{ rule_obj.label }}
+                                </li>
+                              {% endif %}
+                            {% endfor %}
                           {% endif %}
                         {% endfor %}
                       </ul>

--- a/assets/css/application.scss
+++ b/assets/css/application.scss
@@ -240,6 +240,10 @@ strong {
   margin-bottom: 5px;
 }
 
+.license-rules li.annotated-rule {
+  cursor: pointer;
+}
+
 .license-rules li:hover {
   color: #444;
 }
@@ -430,6 +434,12 @@ strong {
   line-height: 1.3;
 }
 
+#license-text dfn {
+  font-style: inherit;
+}
+
+.license-rules li.conditions.active,
+dfn.conditions,
 .qtip-conditions {
   background-color: #d0ebf6;
   border-color: #149ad4;
@@ -441,6 +451,8 @@ strong {
   color: #fff;
 }
 
+.license-rules li.permissions.active,
+dfn.permissions,
 .qtip-fetching,
 .qtip-permissions {
   background-color: #d8f4d7;
@@ -454,6 +466,8 @@ strong {
   color: #fff;
 }
 
+.license-rules li.limitations.active,
+dfn.limitations,
 .qtip-error,
 .qtip-limitations {
   background-color: #f4d9d8;


### PR DESCRIPTION
This implements #441:

![license-annotation-demo](https://user-images.githubusercontent.com/25326257/47315902-3156ca80-d61c-11e8-9536-15d440da1fd3.gif)

For this to work, the ranges are defined inside the license file as arrays of `start-end` string positions, inside each rule, that can now be a object too. The purposed new data format does not break the old. **Example**: 
```
permissions:
  - tag: commercial-use
    ranges:
    - 249-393
    - 401-523
  - modifications
  - distribution
  - patent-use
  - private-use
```
In this example, only the `commercial-use` rule is annotated.
@mlinksva could you please review this implementation? This is not complete yet, as I need to deal with overlapping ranges and I think the UI need some adjustments, especially to indicate the presence of the annotated rules - any suggestion is welcome.

If this gets traction, I think we should make some tool, maybe inside the license page itself, to aid the creation of these annotated ranges of text.