### PR TITLE
Include Rust in community.md

### DIFF
--- a/community.md
+++ b/community.md
@@ -19,5 +19,6 @@ Some communities have strong preferences for particular licenses. If you want to
 * [NPM packages](https://libraries.io/search?platforms=NPM) overwhelmingly use the [MIT](/licenses/mit/) or the very similar [ISC](/licenses/isc) licenses
 * [OpenBSD](https://www.openbsd.org/policy.html) prefers the [ISC License](/licenses/isc/)
 * [WordPress](https://wordpress.org/about/license/) plugins and themes must be [GNU GPLv2](/licenses/gpl-2.0/) (or later)
+* [Rust](https://www.rust-lang.org/) [Crates](https://crates.io/) overwhelmingly uses a dual  [MIT](/licenses/mit/)/[Apache License 2.0](/licenses/apache-2.0/).
 
 Communities come in all shapes and sizes, and more than one might be pertinent (e.g., [your company](https://opensource.guide/legal/#what-does-my-companys-legal-team-need-to-know)). The examples above are *very* well established. If the community you see your project as a part of doesn't have set-in-stone licensing traditions, or you don't see your project as part of any particular community, that's just fine: [make your own choice of an open source license](/).

--- a/community.md
+++ b/community.md
@@ -19,6 +19,6 @@ Some communities have strong preferences for particular licenses. If you want to
 * [NPM packages](https://libraries.io/search?platforms=NPM) overwhelmingly use the [MIT](/licenses/mit/) or the very similar [ISC](/licenses/isc) licenses
 * [OpenBSD](https://www.openbsd.org/policy.html) prefers the [ISC License](/licenses/isc/)
 * [WordPress](https://wordpress.org/about/license/) plugins and themes must be [GNU GPLv2](/licenses/gpl-2.0/) (or later)
-* [Rust](https://www.rust-lang.org/) [Crates](https://crates.io/) overwhelmingly uses a dual  [MIT](/licenses/mit/)/[Apache License 2.0](/licenses/apache-2.0/).
+* [Rust](https://rust-lang-nursery.github.io/api-guidelines/necessities.html#crate-and-its-dependencies-have-a-permissive-license-c-permissive) crates are overwhelmingly licensed under both [MIT](/licenses/mit/) and [Apache License 2.0](/licenses/apache-2.0/).
 
 Communities come in all shapes and sizes, and more than one might be pertinent (e.g., [your company](https://opensource.guide/legal/#what-does-my-companys-legal-team-need-to-know)). The examples above are *very* well established. If the community you see your project as a part of doesn't have set-in-stone licensing traditions, or you don't see your project as part of any particular community, that's just fine: [make your own choice of an open source license](/).

--- a/community.md
+++ b/community.md
@@ -18,7 +18,7 @@ Some communities have strong preferences for particular licenses. If you want to
 * [GNU](https://www.gnu.org/licenses/license-recommendations.html) recommends [GNU GPLv3](/licenses/gpl-3.0/) for most programs
 * [NPM packages](https://libraries.io/search?platforms=NPM) overwhelmingly use the [MIT](/licenses/mit/) or the very similar [ISC](/licenses/isc) licenses
 * [OpenBSD](https://www.openbsd.org/policy.html) prefers the [ISC License](/licenses/isc/)
-* [WordPress](https://wordpress.org/about/license/) plugins and themes must be [GNU GPLv2](/licenses/gpl-2.0/) (or later)
 * [Rust](https://rust-lang-nursery.github.io/api-guidelines/necessities.html#crate-and-its-dependencies-have-a-permissive-license-c-permissive) crates are overwhelmingly licensed under both [MIT](/licenses/mit/) and [Apache License 2.0](/licenses/apache-2.0/)
+* [WordPress](https://wordpress.org/about/license/) plugins and themes must be [GNU GPLv2](/licenses/gpl-2.0/) (or later)
 
 Communities come in all shapes and sizes, and more than one might be pertinent (e.g., [your company](https://opensource.guide/legal/#what-does-my-companys-legal-team-need-to-know)). The examples above are *very* well established. If the community you see your project as a part of doesn't have set-in-stone licensing traditions, or you don't see your project as part of any particular community, that's just fine: [make your own choice of an open source license](/).

--- a/community.md
+++ b/community.md
@@ -19,6 +19,6 @@ Some communities have strong preferences for particular licenses. If you want to
 * [NPM packages](https://libraries.io/search?platforms=NPM) overwhelmingly use the [MIT](/licenses/mit/) or the very similar [ISC](/licenses/isc) licenses
 * [OpenBSD](https://www.openbsd.org/policy.html) prefers the [ISC License](/licenses/isc/)
 * [WordPress](https://wordpress.org/about/license/) plugins and themes must be [GNU GPLv2](/licenses/gpl-2.0/) (or later)
-* [Rust](https://rust-lang-nursery.github.io/api-guidelines/necessities.html#crate-and-its-dependencies-have-a-permissive-license-c-permissive) crates are overwhelmingly licensed under both [MIT](/licenses/mit/) and [Apache License 2.0](/licenses/apache-2.0/).
+* [Rust](https://rust-lang-nursery.github.io/api-guidelines/necessities.html#crate-and-its-dependencies-have-a-permissive-license-c-permissive) crates are overwhelmingly licensed under both [MIT](/licenses/mit/) and [Apache License 2.0](/licenses/apache-2.0/)
 
 Communities come in all shapes and sizes, and more than one might be pertinent (e.g., [your company](https://opensource.guide/legal/#what-does-my-companys-legal-team-need-to-know)). The examples above are *very* well established. If the community you see your project as a part of doesn't have set-in-stone licensing traditions, or you don't see your project as part of any particular community, that's just fine: [make your own choice of an open source license](/).


### PR DESCRIPTION
It's growing, and there are more and more people that are going to be using it. It's probably a good idea to let people know that most rusticians use the dual MIT/Apache-2.0 licence.

> The Apache license includes important protection against patent aggression, but it is not compatible with the GPL, version 2. To avoid problems using Rust with GPL2, it is alternately MIT licensed.
<https://doc.rust-lang.org/1.4.0/complement-project-faq.html#why-dual-mit/asl2-license?>