### PR TITLE
Gitignored cname

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ assets/vendor/qtip2/basic
 /tmp
 Gemfile.lock
 .jekyll-metadata
+CNAME


### PR DESCRIPTION
Makes 100% sure it won’t change unless needed. 