### PR TITLE
Fix typo in UPL-1.0.

### DIFF
--- a/_licenses/upl-1.0.txt
+++ b/_licenses/upl-1.0.txt
@@ -34,7 +34,7 @@ Copyright (c) [year] [fullname]
 The Universal Permissive License (UPL), Version 1.0
 
 Subject to the condition set forth below, permission is hereby granted to any
-person obtaining a copy of this software, associate documentation and/or data
+person obtaining a copy of this software, associated documentation and/or data
 (collectively the "Software"), free of charge and under any and all copyright
 rights in the Software, and any and all patent rights owned or freely
 licensable by each licensor hereunder covering either (i) the unmodified


### PR DESCRIPTION
This adds the missing "d" from the word "associated".

Signed-off-by: Avi Miller <avi.miller@oracle.com>