### PR TITLE
Add the BSD-4-Clause license

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,7 @@ end
 
 group :test do
   gem 'html-proofer', '~> 3.0'
-  gem 'licensee'
+  gem 'licensee', git: 'https://github.com/licensee/licensee.git', branch: 'master'
   gem 'rake'
   gem 'rspec'
   gem 'rubocop'

--- a/_licenses/bsd-4-clause.txt
+++ b/_licenses/bsd-4-clause.txt
@@ -1,0 +1,62 @@
+---
+title: BSD 4-Clause "Original" or "Old" License
+spdx-id: BSD-4-Clause
+hidden: true
+
+description: A permissive license similar to the <a href="/licenses/bsd-3-clause/">BSD 3-Clause License</a>, but with a 4th clause (known as the "advertising clause") that requires an acknowledgment of the original source in all advertising material.
+
+how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file. Replace [year] with the current year and [fullname] with the name (or names) of the copyright holders. Replace [project] with the project organization, if any, that sponsors this work.
+
+using:
+  - Yosemite Blockchain: https://github.com/YosemiteLabs/yosemite-public-blockchain/blob/master/LICENSE
+  - querybuilder: https://github.com/pwolfgang/querybuilder/blob/master/LICENSE
+  - PMSPAUR-public: https://github.com/ArthurGodet/PMSPAUR-public/blob/88b6d0fd172950a7e5e1cc595d180565cfaa5462/LICENSE
+
+permissions:
+  - commercial-use
+  - modifications
+  - distribution
+  - private-use
+
+conditions:
+  - include-copyright
+
+limitations:
+  - liability
+  - warranty
+
+---
+
+BSD 4-Clause License
+
+Copyright (c) [year], [fullname]
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. All advertising materials mentioning features or use of this software must
+   display the following acknowledgement:
+     This product includes software developed by [project].
+
+4. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY COPYRIGHT HOLDER "AS IS" AND ANY EXPRESS OR
+IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+EVENT SHALL COPYRIGHT HOLDER BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/_licenses/bsd-4-clause.txt
+++ b/_licenses/bsd-4-clause.txt
@@ -10,7 +10,7 @@ how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of 
 using:
   - Yosemite Blockchain: https://github.com/YosemiteLabs/yosemite-public-blockchain/blob/master/LICENSE
   - querybuilder: https://github.com/pwolfgang/querybuilder/blob/master/LICENSE
-  - PMSPAUR-public: https://github.com/ArthurGodet/PMSPAUR-public/blob/88b6d0fd172950a7e5e1cc595d180565cfaa5462/LICENSE
+  - PMSPAUR-public: https://github.com/ArthurGodet/PMSPAUR-public/blob/master/LICENSE
 
 permissions:
   - commercial-use


### PR DESCRIPTION
This adds the BSD-4-clause license type.

1. SPDX Identifier: https://spdx.org/licenses/BSD-4-Clause.html
2. GNU's list of free licenses: https://www.gnu.org/licenses/license-list.en.html#OriginalBSD and FSF approved
3. Over 1000 projects: https://github.com/search?q=BSD+4-Clause+filename%3ALICENSE&type=Code
4. Yosemite Blockchain, mono/mcs/jay and LibreSSl use the BSD-4-clause license

This is based on the previous work of: https://github.com/github/choosealicense.com/pull/511

It appears that the matches fails to match any licenses as the BSD
licenses end up being different for every project. If this is merged we
can then work on updating projects to the the SPDX wording which should
fix the problem.

Signed-off-by: Alistair Francis <alistair@alistair23.me>