### PR TITLE
Make sidebar info bits directly linkable

### DIFF
--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -11,12 +11,12 @@
   </div>
 
   <div class="how-to-apply">
-    <h3>How to apply this license</h3>
+    <h3 id="how-to-apply">How to apply this license</h3>
     <p>
       {{ page.how | markdownify | remove: '<p>' | remove: '</p>' }}
     </p>
     <div class="note">
-    <h4>Optional steps</h4>
+    <h4 id="optional-steps">Optional steps</h4>
     {% if page.note %}
     <p>
       {{ page.note | markdownify | remove: '<p>' | remove: '</p>' }}
@@ -24,9 +24,9 @@
     {% endif %}
     {% assign xgpl = false %}
     {% if page.spdx-id contains 'GPL' %}{% assign xgpl = true %}{% endif %}
-    <p>Add <strong><code>{{ page.spdx-id }}{% if xgpl %}-or-later{% endif %}</code></strong>{% if xgpl %} (or <strong><code>{{ page.spdx-id }}-only</code></strong> to disallow future versions){% endif %} to your project's package description, if applicable (e.g., <a href="https://docs.npmjs.com/files/package.json#license">Node.js</a>, <a href="https://guides.rubygems.org/specification-reference/#license=">Ruby</a>, and <a href="https://doc.rust-lang.org/cargo/reference/manifest.html#package-metadata">Rust</a>). This will ensure the license is displayed in package directories.</p>
+    <p id="package-metadata">Add <strong><code>{{ page.spdx-id }}{% if xgpl %}-or-later{% endif %}</code></strong>{% if xgpl %} (or <strong><code>{{ page.spdx-id }}-only</code></strong> to disallow future versions){% endif %} to your project's package description, if applicable (e.g., <a href="https://docs.npmjs.com/files/package.json#license">Node.js</a>, <a href="https://guides.rubygems.org/specification-reference/#license=">Ruby</a>, and <a href="https://doc.rust-lang.org/cargo/reference/manifest.html#package-metadata">Rust</a>). This will ensure the license is displayed in package directories.</p>
     {% if page.spdx-id contains 'GPL-2' %}
-    <p>If you would like your project to adopt the GPL-3.0's cure provision, add the <a href="https://github.com/gplcc/gplcc/blob/master/Project/COMMITMENT">text</a> of the <a href="https://gplcc.github.io/gplcc/">GPL Cooperation Commitment</a> to a file named <code>COMMITMENT</code> in the same directory as your {{ page.spdx-id }} license file.</p>
+    <p id="gplcc">If you would like your project to adopt the GPL-3.0's cure provision, add the <a href="https://github.com/gplcc/gplcc/blob/master/Project/COMMITMENT">text</a> of the <a href="https://gplcc.github.io/gplcc/">GPL Cooperation Commitment</a> to a file named <code>COMMITMENT</code> in the same directory as your {{ page.spdx-id }} license file.</p>
     {% endif %}
     </div>
   </div>


### PR DESCRIPTION
Sometimes I want to direct people to a specific bit of instruction/info in the sidebar of a license and have that be highlighted. Needs `id`s for that, this adds them.