### PR TITLE
Update Apache  Original ©️ copyright holders 2.0 txt

### DIFF
--- a/_licenses/apache-2.0.txt
+++ b/_licenses/apache-2.0.txt
@@ -222,7 +222,7 @@ limitations:
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright [1999] [Zanic Klaus,Jenpervin,Theo Pervin]
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
This update is based on true fact. The Apache License Copyright ©️ holders 1999. Written by Ted L. Pervin also the creator of the GNU and MIT license. "Author" was made hidden by "Alter" alias names to protect the "Creator". Due to secrecy of Developer rights. If any questions regarding written proof please contact me. 

Nicklaus (Zanic Klaus) Ziems
Jennifer (Jenper) Pervin
301 Shelly Lane
La Crosse Wisconsin, 54603
1-(747)-477-4066