### PR TITLE
Make rules with -- eg same-license--file appear lighter in appendix table

### DIFF
--- a/appendix.md
+++ b/appendix.md
@@ -42,7 +42,12 @@ If you're here to choose a license, **[start from the home page](/)** to see a f
         {% for r in license[t] %}
           {% if r contains req %}
             <td class="license-{{ t }}" style="text-align:center">
-              <span class="{{ r }}">
+              {% if r contains "--" %}
+                {% assign lite = " lite" %}
+              {% else %}
+                {% assign lite = "" %}
+              {% endif %}
+              <span class="{{ r | append: lite }}">
                 <span class="license-sprite {{ r }}"></span>
               </span>
             </td>

--- a/assets/css/application.scss
+++ b/assets/css/application.scss
@@ -254,6 +254,7 @@ strong {
 .license-limitations span { background-position: -16px 0; width: 12px; height: 12px; }
 .license-permissions span { background-position: -28px 0; width: 12px; height: 12px; }
 .license-conditions span  { background-position: -40px 0; width: 12px; height: 12px; }
+.lite span { opacity: 0.5; }
 
 .license-rules-sidebar li {
   float: none;


### PR DESCRIPTION
Not needed elsewhere eg license view because actual rule is spelled out and no distinction with other licenses with non-attenuated versions of the rules is useful for eyeballing.

Some visual cue other than .5 opacity might be more useful, eg smaller or not filled in circle, but this is easy first cut given current sprite setup.

Here's what it looks like
![image](https://user-images.githubusercontent.com/40415/70023587-ced53b00-154c-11ea-82bc-d31252b80c4d.png)

(Boost in the license and copyright notice column, LGPL* in the same license column.)

Compare with live version of https://choosealicense.com/appendix/