### PR TITLE
Show BSL-1.0 between MIT and Unlicense in license spectrum

### DIFF
--- a/_licenses/bsl-1.0.txt
+++ b/_licenses/bsl-1.0.txt
@@ -1,6 +1,7 @@
 ---
 title: Boost Software License 1.0
 spdx-id: BSL-1.0
+hidden: false
 
 description: A simple permissive license only requiring preservation of copyright and license notices for source (and not binary) distribution. Licensed works, modifications, and larger works may be distributed under different terms and without source code.
 

--- a/licenses.html
+++ b/licenses.html
@@ -14,6 +14,7 @@ title: Licenses
 {% include license-overview.html license-id="mpl-2.0" %}
 {% include license-overview.html license-id="apache-2.0" %}
 {% include license-overview.html license-id="mit" %}
+{% include license-overview.html license-id="bsl-1.0" %}
 {% include license-overview.html license-id="unlicense" %}
 
 The above licenses represent the entire spectrum of open source licenses, from highly protective to unconditional. One of these should work for most new open source projects. Many other open source licenses exist, including older versions of and close substitutes for some of the above. See the resources listed on our <a href="/about/">about page</a> if you'd like to read more.

--- a/spec/license_shown_spec.rb
+++ b/spec/license_shown_spec.rb
@@ -10,6 +10,7 @@ describe 'shown licenses' do
     apache-2.0
     bsd-2-clause
     bsd-3-clause
+    bsl-1.0
     cc0-1.0
     epl-2.0
     gpl-2.0
@@ -21,7 +22,7 @@ describe 'shown licenses' do
   ].freeze
 
   it 'has the expected number of shown licenses' do
-    expect(shown_licenses.count).to eql(12)
+    expect(shown_licenses.count).to eql(13)
     expect(SHOWN_LICENSES.count).to eql(shown_licenses.count)
   end
 


### PR DESCRIPTION
Upon reflection I'm convinced enough BSL-1.0 represents a useful and underrepresented space in licensing spectrum that it makes sense to unhide and present accordingly, thus this PR. Fixes #694 