### PR TITLE
Update link to .NET Core license file

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ require 'json'
 require 'open-uri'
 versions = JSON.parse(open('https://pages.github.com/versions.json').read)
 
+gem 'faraday', '< 1.0'
 gem 'github-pages', versions['github-pages']
 
 group :development do

--- a/_licenses/mit.txt
+++ b/_licenses/mit.txt
@@ -10,7 +10,7 @@ how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of 
 
 using:
   - Babel: https://github.com/babel/babel/blob/master/LICENSE
-  - .NET Core: https://github.com/dotnet/corefx/blob/master/LICENSE.TXT
+  - .NET Core: https://github.com/dotnet/runtime/blob/master/LICENSE.TXT
   - Rails: https://github.com/rails/rails/blob/master/MIT-LICENSE
 
 permissions:


### PR DESCRIPTION
It appears the .NET Core repos were consolidated at some point so the current link is no longer valid.
More info: https://github.com/dotnet/announcements/issues/119