### PR TITLE
Standardize structure of first sentence of usage instructions

### DIFF
--- a/_licenses/artistic-2.0.txt
+++ b/_licenses/artistic-2.0.txt
@@ -5,7 +5,7 @@ redirect_from: /licenses/artistic/
 
 description: Heavily favored by the Perl community, the Artistic license requires that modified versions of the software do not prevent users from running the standard version.
 
-how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code, and copy the text of the license into the file. Do not replace the copyright notice (year, author), which refers to the license itself, not the licensed project.
+how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file. Do not replace the copyright notice (year, author), which refers to the license itself, not the licensed project.
 
 using:
 

--- a/_licenses/cc0-1.0.txt
+++ b/_licenses/cc0-1.0.txt
@@ -6,7 +6,7 @@ hidden: false
 
 description: The <a href="https://creativecommons.org/publicdomain/zero/1.0/">Creative Commons CC0 Public Domain Dedication</a> waives copyright interest in a work you've created and dedicates it to the world-wide public domain. Use CC0 to opt out of copyright entirely and ensure your work has the widest reach. As with the Unlicense and typical software licenses, CC0 disclaims warranties. CC0 is very similar to the Unlicense.
 
-how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the CC0 into the file.
+how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file.
 
 note: Creative Commons recommends taking the additional step of adding a boilerplate notice to the top of each file. The boilerplate can be <a href="https://wiki.creativecommons.org/wiki/CC0_FAQ#May_I_apply_CC0_to_computer_software.3F_If_so.2C_is_there_a_recommended_implementation.3F">found on their website</a>.
 

--- a/_licenses/gpl-3.0.txt
+++ b/_licenses/gpl-3.0.txt
@@ -8,7 +8,7 @@ hidden: false
 
 description: Permissions of this strong copyleft license are conditioned on making available complete source code of licensed works and modifications, which include larger works using a licensed work, under the same license. Copyright and license notices must be preserved. Contributors provide an express grant of patent rights.
 
-how: Create a text file in the root of your source code, typically named COPYING (a GNU convention). Then copy the text of the license into that file.
+how: Create a text file (typically named COPYING, as per GNU conventions) in the root of your source code and copy the text of the license into the file.
 
 note: The Free Software Foundation recommends taking the additional step of adding a boilerplate notice to the top of each file. The boilerplate can be found at the end of the license.
 

--- a/_licenses/lppl-1.3c.txt
+++ b/_licenses/lppl-1.3c.txt
@@ -4,7 +4,7 @@ spdx-id: LPPL-1.3c
 
 description: The LaTeX Project Public License (LPPL) is the primary license under which the LaTeX kernel and the base LaTeX packages are distributed.
 
-how: To use this license, place in each of the components of your work both an explicit copyright notice including your name and the year the work was authored and/or last substantially modified. Include also a statement that the distribution and/or modification of that component is constrained by the conditions in this license.
+how: Place in each of the components of your work both an explicit copyright notice including your name, and the year the work was authored and/or last substantially modified. Include also a statement that the distribution and/or modification of that component is constrained by the conditions in this license.
 
 note: An example boilerplate and more information about how to use the license can be found at the end of the license.
 

--- a/_licenses/ofl-1.1.txt
+++ b/_licenses/ofl-1.1.txt
@@ -5,7 +5,7 @@ redirect_from: /licenses/ofl/
 
 description: The Open Font License (OFL) is maintained by SIL International. It attempts to be a compromise between the values of the free software and typeface design communities. It is used for almost all open source font projects, including those by Adobe, Google and Mozilla.
 
-how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your font source and copy the text of the license into the file. Replace [year] with the current year and [fullname] ([email]) with the name and contact email address of each copyright holder. You may take the additional step of appending a Reserved Font Name notice. This option requires anyone making modifications to change the font's name, and is not ideal for web fonts (which all users will modify by changing formats and subsetting for their own needs.)
+how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your font's source code and copy the text of the license into the file. Replace [year] with the current year and [fullname] ([email]) with the name and contact email address of each copyright holder. You may take the additional step of appending a Reserved Font Name notice. This option requires anyone making modifications to change the font's name, and is not ideal for web fonts (which all users will modify by changing formats and subsetting for their own needs.)
 
 note: This license doesn't require source provision, but recommends it. All files derived from OFL files must remain licensed under the OFL.
 

--- a/_licenses/postgresql.txt
+++ b/_licenses/postgresql.txt
@@ -4,7 +4,7 @@ spdx-id: PostgreSQL
 
 description: A very short, BSD-style license, used specifically for PostgreSQL.
 
-how: To use it, say that it is The PostgreSQL License, and then substitute the copyright year and name of the copyright holder into the body of the license. Then put the license into a prominent file ("COPYRIGHT", "LICENSE" or "COPYING" are common names for this file) in your software distribution.
+how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file. Replace [year] with the current year and [fullname] with the name (or names) of the copyright holders.
 
 using:
   - pgBadger: https://github.com/darold/pgbadger/blob/master/LICENSE

--- a/_licenses/upl-1.0.txt
+++ b/_licenses/upl-1.0.txt
@@ -4,7 +4,7 @@ spdx-id: UPL-1.0
 
 description: A permissive, OSI and FSF approved, GPL compatible license, expressly allowing attribution with just a copyright notice and a short form link rather than the full text of the license.  Includes an express grant of patent rights.  Licensed works and modifications may be distributed under different terms and without source code, and the patent grant may also optionally be expanded to larger works to permit use as a contributor license agreement.
 
-how: Insert the license or a link to it along with a copyright notice into your source file(s), and/or create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license and your copyright notice into the file.
+how: Insert the license or a link to it along with a copyright notice into your source file(s), and/or create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file, replacing [year] with the current year and [fullname] with the name (or names) of the copyright holders.
 
 note: It is recommended to add a link to the license and copyright notice at the top of each source file, example text can be found at https://oss.oracle.com/licenses/upl/.
 


### PR DESCRIPTION
@mlinksva while working on the changes discussed [here](https://github.com/github/choosealicense.com/pull/583#issuecomment-575892253), I realized that the usage instructions followed a very regular pattern, with a few exceptions, so I decided to make them consistent where the meaning is unchanged. That said, I have some questions:

- Is the different in usage instructions for the EUPL 1.2 relative to the EUPL 1.1 deliberate? The latter uses the common template, but the second has different (and IMO less clear) instructions.
- Can CC0 be described as a "license", or should be "license disclaimer" as is done for the Unlicense? Conversely, if merely "license" is acceptable, can we drop "disclaimer" from the Unlicense usage text?
- Can the usage instructions for GPLv3 recommend the same typical license filenames as the others? GPLv2 seems to allow that, but since GPLv3 mentions GNU conventions, I wonder if it shouldn't apply for GPLv2 (and the other GNU-created licenses) as well.
- Are the changes made to the PostgreSQL license's usage instructions acceptable? They are a little deeper than the others in this PR, but the original and changed texts seem reasonably equivalent to me.
- Is any additional standardization of this sentence possible? Or are the remaining differences intentional and legally significant?