### PR TITLE
Add vim.txt

### DIFF
--- a/_licenses/vim.txt
+++ b/_licenses/vim.txt
@@ -1,0 +1,114 @@
+---
+title: VIM LICENSE
+spdx-id: Vim
+featured: false
+hidden: false
+
+description: There are no restrictions on using or distributing an unmodified copy of the software. Parts of the software may also be distributed, but the license text must always be included. For modified versions a few restrictions apply. The license is GPL compatible, you may compile the software with GPL libraries and distribute it.
+
+how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file. Replace [project] with the project name.
+
+using:
+  - Vim https://github.com/vim/vim/blob/master/LICENSE
+  - Pathogen https://github.com/tpope/vim-pathogen/blob/master/LICENSE
+  - vim-license-gen: https://github.com/othree/vim-license/blob/master/LICENSE
+
+permissions:
+  - commercial-use
+  - modifications
+  - distribution
+  - private-use
+
+conditions:
+  - include-copyright
+  - document-changes
+  - disclose-source
+  - same-license
+
+limitations:
+  - liability
+
+---
+
+VIM LICENSE
+
+I)  There are no restrictions on distributing unmodified copies of [project]
+    except that they must include this license text.  You can also distribute
+    unmodified parts of [project], likewise unrestricted except that they must
+    include this license text.  You are also allowed to include executables
+    that you made from the unmodified [project] sources, plus your own usage
+    examples and Vim scripts.
+
+II) It is allowed to distribute a modified (or extended) version of [project],
+    including executables and/or source code, when the following four
+    conditions are met:
+    1) This license text must be included unmodified.
+    2) The modified [project] must be distributed in one of the following five
+       ways:
+       a) If you make changes to [project] yourself, you must clearly describe
+          in the distribution how to contact you.  When the maintainer asks
+          you (in any way) for a copy of the modified [project] you
+          distributed, you must make your changes, including source code,
+          available to the maintainer without fee.  The maintainer reserves
+          the right to include your changes in the official version of
+          [project].  What the maintainer will do with your changes and under
+          what license they will be distributed is negotiable.  If there has
+          been no negotiation then this license, or a later version, also
+          applies to your changes. The current maintainer is Bram Moolenaar
+          <Bram@vim.org>.  If this changes it will be announced in appropriate
+          places (most likely vim.sf.net, www.vim.org and/or comp.editors).
+          When it is completely impossible to contact the maintainer, the
+          obligation to send him your changes ceases.  Once the maintainer has
+          confirmed that he has received your changes they will not have to be
+          sent again.
+       b) If you have received a modified [project] that was distributed as
+          mentioned under a) you are allowed to further distribute it
+          unmodified, as mentioned at I).  If you make additional changes the
+          text under a) applies to those changes.
+       c) Provide all the changes, including source code, with every copy of
+          the modified [project] you distribute.  This may be done in the form
+          of a context diff.  You can choose what license to use for new code
+          you add.  The changes and their license must not restrict others
+          from making their own changes to the official version of [project].
+       d) When you have a modified [project] which includes changes as
+          mentioned under c), you can distribute it without the source code
+          for the changes if the following three conditions are met:
+          - The license that applies to the changes permits you to distribute
+            the changes to the Vim maintainer without fee or restriction, and
+            permits the Vim maintainer to include the changes in the official
+            version of [project] without fee or restriction.
+          - You keep the changes for at least three years after last
+            distributing the corresponding modified [project].  When the
+            maintainer or someone who you distributed the modified [project]
+            to asks you (in any way) for the changes within this period, you
+            must make them available to him.
+          - You clearly describe in the distribution how to contact you.  This
+            contact information must remain valid for at least three years
+            after last distributing the corresponding modified [project], or
+            as long as possible.
+       e) When the GNU General Public License (GPL) applies to the changes,
+          you can distribute the modified [project] under the GNU GPL version
+          2 or any later version.
+    3) A message must be added, at least in the output of the ":version"
+       command and in the intro screen, such that the user of the modified
+       [project] is able to see that it was modified.  When distributing as
+       mentioned under 2)e) adding the message is only required for as far as
+       this does not conflict with the license used for the changes.
+    4) The contact information as required under 2)a) and 2)d) must not be
+       removed or changed, except that the person himself can make
+       corrections.
+
+III) If you distribute a modified version of [project], you are encouraged to
+     use the Vim license for your changes and make them available to the
+     maintainer, including the source code.  The preferred way to do this is
+     by e-mail or by uploading the files to a server and e-mailing the URL. If
+     the number of changes is small (e.g., a modified Makefile) e-mailing a
+     context diff will do.  The e-mail address to be used is
+     <maintainer@vim.org>
+
+IV)  It is not allowed to remove this license from the distribution of the
+     [project] sources, parts of it or from a modified version.  You may use
+     this license for previous [project] releases instead of the license that
+     they came with, at your option.
+
+

--- a/_licenses/vim.txt
+++ b/_licenses/vim.txt
@@ -23,8 +23,7 @@ conditions:
   - disclose-source
   - same-license
 
-limitations:
-  - liability
+limitations: []
 
 ---
 

--- a/_licenses/vim.txt
+++ b/_licenses/vim.txt
@@ -1,8 +1,6 @@
 ---
-title: VIM LICENSE
+title: Vim License
 spdx-id: Vim
-featured: false
-hidden: false
 
 description: There are no restrictions on using or distributing an unmodified copy of the software. Parts of the software may also be distributed, but the license text must always be included. For modified versions a few restrictions apply. The license is GPL compatible, you may compile the software with GPL libraries and distribute it.
 

--- a/_licenses/vim.txt
+++ b/_licenses/vim.txt
@@ -9,8 +9,8 @@ description: There are no restrictions on using or distributing an unmodified co
 how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file. Replace [project] with the project name.
 
 using:
-  - Vim https://github.com/vim/vim/blob/master/LICENSE
-  - Pathogen https://github.com/tpope/vim-pathogen/blob/master/LICENSE
+  - Vim: https://github.com/vim/vim/blob/master/LICENSE
+  - Pathogen: https://github.com/tpope/vim-pathogen/blob/master/LICENSE
   - vim-license-gen: https://github.com/othree/vim-license/blob/master/LICENSE
 
 permissions:


### PR DESCRIPTION
Hi

I am sending this PR to add Vim license.

Requirements:

1. SPDX identifier: `Vim` https://spdx.org/licenses/Vim.html
2. List in GNU's list of free licenses: https://www.gnu.org/licenses/license-list.en.html#Vim
3. At least 1,000 public repositories using the license
    * https://github.com/search?q=user%3Avim-scripts+%22VIM+LICENSE+applies%22&type=Code
   * https://github.com/search?q=user%3Avim-scripts+%22license+vim+license%22&type=Code
   * https://github.com/search?q=user%3Avim-scripts+%22same+as+vim%22&type=Code
   * https://github.com/search?q=%22VIM+LICENSE%22+filename%3ALICENSE&type=Code
4. Notable project listed in the `_licenses/vim.txt` file

I have tested this text file with licensee 9.13.0 using the notable projects I listed. Confirmed it work as expected.

<img width="939" alt="" src="https://user-images.githubusercontent.com/16474/72820213-87943c80-3ca9-11ea-91da-500a56a061b6.png">

If there is anything I missed please kindly remind me. Thank you.
