### PR TITLE
ISC examples: replace helix with starship

### DIFF
--- a/_licenses/isc.txt
+++ b/_licenses/isc.txt
@@ -7,7 +7,7 @@ description: A permissive license lets people do anything with your code with pr
 how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file. Replace [year] with the current year and [fullname] with the name (or names) of the copyright holders.
 
 using:
-  - Helix: https://github.com/tildeio/helix/blob/master/LICENSE
+  - Starship: https://github.com/starship/starship/blob/master/LICENSE
   - Node.js semver: https://github.com/npm/node-semver/blob/master/LICENSE
   - OpenStreetMap iD: https://github.com/openstreetmap/iD/blob/master/LICENSE.md
 


### PR DESCRIPTION
The starship project is [more active](https://github.com/starship/starship/pulse/monthly) than [helix is](https://github.com/tildeio/helix/pulse/monthly), and [more popular](https://github.com/starship/starship/stargazers) (despite being younger) [as well](https://github.com/tildeio/helix/stargazers), so it's a better example to showcase the license.