### PR TITLE
Update GPL links to point to SPDX pages without deprecation warnings

### DIFF
--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -6,7 +6,7 @@
   <div class="repository-suggestion">
     <p>Make a pull request to suggest this license for a project that is <a href="/no-permission/">not licensed</a>. Please be polite: see if a license has already been suggested, try to suggest a license fitting for the project's <a href="/community/">community</a>, and keep your communication with project maintainers friendly.</p>
     <div class="input-wrapper">
-      <input type="text" data-license-id="{{ page.spdx-id }}" placeholder="Enter GitHub repository URL" id="repository-url" title="status" />
+      <input type="text" data-license-id="{{ page.spdx-id }}-only" placeholder="Enter GitHub repository URL" id="repository-url" title="status" />
       <div class="status-indicator"></div>
     </div>
   </div>

--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -34,7 +34,7 @@
   </div>
 
   <div class="source">
-    <a href="https://spdx.org/licenses/{{ page.spdx-id }}{% if xgpl %}-only{% endif %}.html">
+    <a href="https://spdx.org/licenses/{{ page.spdx-id }}{% if xgpl %}-or-later{% endif %}.html">
       <span class="license-sprite"></span>
       Source
     </a>

--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -6,7 +6,7 @@
   <div class="repository-suggestion">
     <p>Make a pull request to suggest this license for a project that is <a href="/no-permission/">not licensed</a>. Please be polite: see if a license has already been suggested, try to suggest a license fitting for the project's <a href="/community/">community</a>, and keep your communication with project maintainers friendly.</p>
     <div class="input-wrapper">
-      <input type="text" data-license-id="{{ page.spdx-id }}-only" placeholder="Enter GitHub repository URL" id="repository-url" title="status" />
+      <input type="text" data-license-id="{{ page.spdx-id }}" placeholder="Enter GitHub repository URL" id="repository-url" title="status" />
       <div class="status-indicator"></div>
     </div>
   </div>

--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -34,7 +34,7 @@
   </div>
 
   <div class="source">
-    <a href="https://spdx.org/licenses/{{ page.spdx-id }}.html">
+    <a href="https://spdx.org/licenses/{{ page.spdx-id }}{% if xgpl %}-only{% endif %}.html">
       <span class="license-sprite"></span>
       Source
     </a>


### PR DESCRIPTION
Resolves #729 