### PR TITLE
Remove unnecessary (c) from MIT license

### DIFF
--- a/_licenses/mit.txt
+++ b/_licenses/mit.txt
@@ -30,7 +30,7 @@ limitations:
 
 MIT License
 
-Copyright (c) [year] [fullname]
+Copyright [year] [fullname]
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
**Supersedes #735**

The copyright symbol (c) is unnecessary in the MIT license, also the Open Source Initiative does not use it in their copy: https://opensource.org/licenses/MIT