### PR TITLE
Remove unnecessary (c) symbol from licenses

### DIFF
--- a/_licenses/0bsd.txt
+++ b/_licenses/0bsd.txt
@@ -25,7 +25,7 @@ limitations:
 
 ---
 
-Copyright (c) [year] [fullname]
+Copyright [year] [fullname]
 
 Permission to use, copy, modify, and/or distribute this software for any
 purpose with or without fee is hereby granted.

--- a/_licenses/bsd-2-clause.txt
+++ b/_licenses/bsd-2-clause.txt
@@ -30,7 +30,7 @@ limitations:
 
 BSD 2-Clause License
 
-Copyright (c) [year], [fullname]
+Copyright [year], [fullname]
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/_licenses/bsd-3-clause-clear.txt
+++ b/_licenses/bsd-3-clause-clear.txt
@@ -27,7 +27,7 @@ limitations:
 
 The Clear BSD License
 
-Copyright (c) [year] [fullname]
+Copyright [year] [fullname]
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/_licenses/bsd-3-clause.txt
+++ b/_licenses/bsd-3-clause.txt
@@ -29,7 +29,7 @@ limitations:
 
 BSD 3-Clause License
 
-Copyright (c) [year], [fullname]
+Copyright [year], [fullname]
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/_licenses/bsd-4-clause.txt
+++ b/_licenses/bsd-4-clause.txt
@@ -28,7 +28,7 @@ limitations:
 
 BSD 4-Clause License
 
-Copyright (c) [year], [fullname]
+Copyright [year], [fullname]
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/_licenses/isc.txt
+++ b/_licenses/isc.txt
@@ -28,7 +28,7 @@ limitations:
 
 ISC License
 
-Copyright (c) [year], [fullname]
+Copyright [year], [fullname]
 
 Permission to use, copy, modify, and/or distribute this software for any
 purpose with or without fee is hereby granted, provided that the above

--- a/_licenses/mit.txt
+++ b/_licenses/mit.txt
@@ -30,7 +30,7 @@ limitations:
 
 MIT License
 
-Copyright (c) [year] [fullname]
+Copyright [year] [fullname]
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/_licenses/ncsa.txt
+++ b/_licenses/ncsa.txt
@@ -29,7 +29,7 @@ limitations:
 
 University of Illinois/NCSA Open Source License
 
-Copyright (c) [year] [fullname]. All rights reserved.
+Copyright [year] [fullname]. All rights reserved.
 
 Developed by: [project]
               [fullname]

--- a/_licenses/ofl-1.1.txt
+++ b/_licenses/ofl-1.1.txt
@@ -30,7 +30,7 @@ limitations:
 
 ---
 
-Copyright (c) [year] [fullname] ([email])
+Copyright [year] [fullname] ([email])
 
 This Font Software is licensed under the SIL Open Font License, Version 1.1.
 This license is copied below, and is also available with a FAQ at:

--- a/_licenses/postgresql.txt
+++ b/_licenses/postgresql.txt
@@ -28,7 +28,7 @@ limitations:
 
 PostgreSQL License
 
-Copyright (c) [year], [fullname]
+Copyright [year], [fullname]
 
 Permission to use, copy, modify, and distribute this software and its
 documentation for any purpose, without fee, and without a written agreement is

--- a/_licenses/upl-1.0.txt
+++ b/_licenses/upl-1.0.txt
@@ -29,7 +29,7 @@ limitations:
 
 ---
 
-Copyright (c) [year] [fullname]
+Copyright [year] [fullname]
 
 The Universal Permissive License (UPL), Version 1.0
 


### PR DESCRIPTION
**Supersedes #735**

The symbol (c) is redundant when compbined with the word "Copyright"