### PR TITLE
Make repository use requirement for adding a license slightly more generic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ script: "./script/cibuild"
 #environment
 language: ruby
 rvm:
-  - 2.5.3
+  - 2.5.8
 
 addons:
   apt:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ Choosealicense.com is intended to demystify license choices, not present or cata
    * [GNU's list of free licenses](https://www.gnu.org/licenses/license-list.en.html) (*note: the license must be listed in one of the three "free" categories*)
    * [Open Definition's list of conformant licenses](https://opendefinition.org/licenses/) (non-code)
 3. The license must be used in at least *1,000* public repositories. This may be documented, for example, with a [GitHub code search](https://github.com/search?q=MIT+filename%3ALICENSE&type=Code).
-4. 3 notable projects using the license must be identified. These must have straightforward LICENSE files which serve as examples newcomers can follow and that could be detected by [licensee](https://github.com/benbalter/licensee) if it knew about the license.
+4. 3 notable projects using the license must be identified. These must have straightforward LICENSE files which serve as examples newcomers can follow and that could be detected by [licensee](https://github.com/licensee/licensee) if it knew about the license.
 
 If your proposed license meets the above criteria, here's a few other things to keep in mind as you propose the license's addition:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,7 @@ Choosealicense.com is intended to demystify license choices, not present or cata
    * [List of OSI approved licenses](https://opensource.org/licenses/alphabetical)
    * [GNU's list of free licenses](https://www.gnu.org/licenses/license-list.en.html) (*note: the license must be listed in one of the three "free" categories*)
    * [Open Definition's list of conformant licenses](https://opendefinition.org/licenses/) (non-code)
-3. A [GitHub code search](https://github.com/search?q=MIT+filename%3ALICENSE&type=Code) must reveal at least *1,000* public repositories using the license.
+3. The license must be used in at least *1,000* public repositories. This may be documented, for example, with a [GitHub code search](https://github.com/search?q=MIT+filename%3ALICENSE&type=Code).
 4. 3 notable projects using the license must be identified. These must have straightforward LICENSE files which serve as examples newcomers can follow and that could be detected by [licensee](https://github.com/benbalter/licensee) if it knew about the license.
 
 If your proposed license meets the above criteria, here's a few other things to keep in mind as you propose the license's addition:

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://travis-ci.org/github/choosealicense.com.svg?branch=gh-pages)](https://travis-ci.org/github/choosealicense.com)
 
-We catalog [select](CONTRIBUTING.md#adding-a-license) open source licenses with a [Jekyll collection](https://jekyllrb.com/docs/collections/) (in `_licenses`). The catalog is used to render [ChooseALicense.com](https://choosealicense.com) and is regularly vendored into [Licensee](https://github.com/benbalter/licensee), which GitHub uses to provide a [license chooser and license detection](https://help.github.com/articles/adding-a-license-to-a-repository/), a [licenses API](https://developer.github.com/v3/licenses/), and to [display license descriptions and metadata](https://github.com/blog/2335-open-source-license-descriptions-and-metadata).
+We catalog [select](CONTRIBUTING.md#adding-a-license) open source licenses with a [Jekyll collection](https://jekyllrb.com/docs/collections/) (in `_licenses`). The catalog is used to render [ChooseALicense.com](https://choosealicense.com) and is regularly vendored into [Licensee](https://github.com/licensee/licensee), which GitHub uses to provide a [license chooser and license detection](https://help.github.com/articles/adding-a-license-to-a-repository/), a [licenses API](https://developer.github.com/v3/licenses/), and to [display license descriptions and metadata](https://github.com/blog/2335-open-source-license-descriptions-and-metadata).
 
 ## Goals
 
@@ -37,7 +37,7 @@ Licenses sit in the `/_licenses` folder. Each license has YAML front matter desc
 * `spdx-id` - Short identifier specified by https://spdx.org/licenses/
 * `description` - A human-readable description of the license
 * `how` - Instructions on how to implement the license
-* `using` - A list of 3 notable projects using the license with straightforward LICENSE files which serve as examples newcomers can follow and that can be detected by [licensee](https://github.com/benbalter/licensee) in the form of `project_name: license_file_url`
+* `using` - A list of 3 notable projects using the license with straightforward LICENSE files which serve as examples newcomers can follow and that can be detected by [licensee](https://github.com/licensee/licensee) in the form of `project_name: license_file_url`
 * `permissions` - Bulleted list of permission rules
 * `conditions` - Bulleted list of condition rules
 * `limitations` - Bulleted list of limitation rules

--- a/_data/meta.yml
+++ b/_data/meta.yml
@@ -30,7 +30,7 @@
   required: true
 
 - name: using
-  description: 'A list of 3 notable projects using the license with straightforward LICENSE files which serve as examples newcomers can follow and that can be detected by [licensee](https://github.com/benbalter/licensee) in the form of `project_name: license_file_url`'
+  description: 'A list of 3 notable projects using the license with straightforward LICENSE files which serve as examples newcomers can follow and that can be detected by [licensee](https://github.com/licensee/licensee) in the form of `project_name: license_file_url`'
   required: true
 
 # Optional fields

--- a/_licenses/cc0-1.0.txt
+++ b/_licenses/cc0-1.0.txt
@@ -11,7 +11,7 @@ how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of 
 note: Creative Commons recommends taking the additional step of adding a boilerplate notice to the top of each file. The boilerplate can be <a href="https://wiki.creativecommons.org/wiki/CC0_FAQ#May_I_apply_CC0_to_computer_software.3F_If_so.2C_is_there_a_recommended_implementation.3F">found on their website</a>.
 
 using:
-  - Awesome: https://github.com/sindresorhus/awesome/blob/master/license
+  - Awesome: https://github.com/sindresorhus/awesome/blob/main/license
   - Shields.io: https://github.com/badges/shields/blob/master/LICENSE
   - psdash: https://github.com/Jahaja/psdash/blob/master/LICENSE
 

--- a/_licenses/epl-1.0.txt
+++ b/_licenses/epl-1.0.txt
@@ -8,7 +8,7 @@ how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of 
 
 using:
   - Eclipse hawkBit: https://github.com/eclipse/hawkbit/blob/master/LICENSE
-  - JUnit: https://github.com/junit-team/junit4/blob/master/LICENSE-junit.txt
+  - JUnit: https://github.com/junit-team/junit4/blob/main/LICENSE-junit.txt
   - Quil: https://github.com/quil/quil/blob/master/LICENSE
 
 permissions:

--- a/_licenses/mpl-2.0.txt
+++ b/_licenses/mpl-2.0.txt
@@ -12,7 +12,7 @@ note: The Mozilla Foundation recommends taking the additional step of adding a b
 
 using:
   - Servo: https://github.com/servo/servo/blob/master/LICENSE
-  - Syncthing: https://github.com/syncthing/syncthing/blob/master/LICENSE
+  - Syncthing: https://github.com/syncthing/syncthing/blob/main/LICENSE
   - TimelineJS3: https://github.com/NUKnightLab/TimelineJS3/blob/master/LICENSE
 
 permissions:

--- a/_licenses/ncsa.txt
+++ b/_licenses/ncsa.txt
@@ -8,9 +8,9 @@ description: The University of Illinois/NCSA Open Source License, or UIUC licens
 how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file. Replace [year] with the current year and [fullname] with the name (or names) of the copyright holders. Replace [project] with the project organization, if any, that sponsors this work.
 
 using:
- - LLDB: https://github.com/llvm-mirror/lldb/blob/master/LICENSE.TXT
  - ROCR-Runtime: https://github.com/RadeonOpenCompute/ROCR-Runtime/blob/master/LICENSE.txt
  - RLTK: https://github.com/chriswailes/RLTK/blob/master/LICENSE
+ - ToaruOS: https://github.com/klange/toaruos/blob/master/LICENSE
 
 permissions:
   - commercial-use

--- a/spec/license_meta_spec.rb
+++ b/spec/license_meta_spec.rb
@@ -58,7 +58,7 @@ describe 'license meta' do
             end
 
             it "is a #{slug} license" do
-              skip 'NCSA and PostgreSQL licenses hard to detect' if %(ncsa postgresql).include?(slug)
+              skip 'hard to detect licenses' if %(ncsa postgresql vim).include?(slug) && detected.key == 'other'
               expect(detected.key).to eq(slug)
             end
           end


### PR DESCRIPTION
Conceivably there could be substantial evidence in public repositories outside GitHub, move GitHub search to eg. Fixes #739