### PR TITLE
Improve Language Comprehension

### DIFF
--- a/non-software.md
+++ b/non-software.md
@@ -16,7 +16,7 @@ Any open source software license or open license for media (see [above](#data-me
 
 ### Fonts
 
-The [SIL Open Font License 1.1](/licenses/ofl-1.1/) keeps fonts open but allows them to be freely used in other works.
+The [SIL Open Font License 1.1](/licenses/ofl-1.1/) keeps fonts open and allows those to be freely used in other works.
 
 ### Mixed Projects
 


### PR DESCRIPTION
These changes help non-English speakers to read along.

Changing "but" to "and" suggests a correct continual pathos whilst adding clarity.
"But" is used to suggest a hard shift in mindset. It was misused.

Changing "them" to "those" clarified that the sentence is about fonts and not about people setting the license.
"Them" is used as shorthand for humans. It will confuse the reader.