### PR TITLE
Update language count, add link for EUPL 1.2

### DIFF
--- a/_licenses/eupl-1.2.txt
+++ b/_licenses/eupl-1.2.txt
@@ -2,7 +2,7 @@
 title: European Union Public License 1.2
 spdx-id: EUPL-1.2
 
-description: The European Union Public Licence (EUPL) is a copyleft free/open source software license created on the initiative of and approved by the European Commission in 22 official languages of the European Union.
+description: The European Union Public Licence (EUPL) is a copyleft free/open source software license created on the initiative of and approved by the European Commission in <a href="https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12">23 official languages</a> of the European Union.
 
 how: Indicate “Licensed under the EUPL” following the copyright notice of your source code, for example in a README file or directly in a source code file as a comment.
 


### PR DESCRIPTION
I noticed this license is available in 23 languages now (could not check for EUPL v1.1). As it's a multi-lingual license a link to where users can find a version of this in other languages seems useful.