### PR TITLE
Add Ethical Source's Initiative in Contributor Docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,6 +20,7 @@ Choosealicense.com is intended to demystify license choices, not present or cata
 2. The license must be listed on one of the following approved lists of licenses:
    * [List of OSI approved licenses](https://opensource.org/licenses/alphabetical)
    * [GNU's list of free licenses](https://www.gnu.org/licenses/license-list.en.html) (*note: the license must be listed in one of the three "free" categories*)
+   * [The Ethical Source Movement](https://ethicalsource.dev/) 
    * [Open Definition's list of conformant licenses](https://opendefinition.org/licenses/) (non-code)
 3. The license must be used in at least *1,000* public repositories. This may be documented, for example, with a [GitHub code search](https://github.com/search?q=MIT+filename%3ALICENSE&type=Code).
 4. 3 notable projects using the license must be identified. These must have straightforward LICENSE files which serve as examples newcomers can follow and that could be detected by [licensee](https://github.com/licensee/licensee) if it knew about the license.


### PR DESCRIPTION
Hi, I am proposing a change in the Contributor documents:
I am currently requesting that you consider adding [Ethical Source](https://ethicalsource.dev) as one of the allowed initiatives in the contributor docs (keeping in mind still the other requirements such as 1000+ repos, identifier, etc.)
I feel like limiting the initiatives to OSI, OKF, and FSF may allow for centralization in regards to philosophy. 
In my opinion, OSI and OKF are heavily against ethical statements in open sources licenses even if it doesn't prevent massive redistribution or is a non-binding/non-constricting statement that doesn't discriminate against endeavors. This is problematic given that open source licenses that are pro-ethical and allow for entirely free redistribution may otherwise get shutdown.
I feel since people have the ability to chose a license, **also the name of this repo**, it may be a good idea to include it as one of the acceptable initiatives. Most Ethical licenses are also non-constraining in regards to free redistribution of the software. In most cases, non-discriminatory ethical statements don't prohibit any usage of the software unless it was going to likely violate some form of human rights or international law to begin with. If one disagrees with said ethical statement, they can always chose a different license. 

Anyways, I strongly urge GitHub to consider allowing Ethical Source compliant licenses in your template repository if they meet usage requirements. It would help open source tremendously. 