### PR TITLE
Make the { } on home page more visible

### DIFF
--- a/assets/css/application.scss
+++ b/assets/css/application.scss
@@ -93,7 +93,7 @@ strong {
 }
 
 .home h2 span {
-  color: #f1f1f1;
+  color: #bfbfbf;
   font-size: 70px;
   padding: 0 5px;
   position: relative;


### PR DESCRIPTION
Currently, the { } on the home page surrounding the h2 titles are barely visible. I have changed the colour to something that increases the contrast and makes them more visible.