### PR TITLE
Add Mulan PSL v2 as nickname for MulanPSL-2.0

### DIFF
--- a/_licenses/mulanpsl-2.0.txt
+++ b/_licenses/mulanpsl-2.0.txt
@@ -1,6 +1,7 @@
 ---
 title: Mulan Permissive Software License, Version 2
 spdx-id: MulanPSL-2.0
+nickname: Mulan PSL v2
 
 description: A permissive license similar to the <a href="/licenses/apache-2.0/">Apache License</a>, but explicitly states that it does not grant trademark rights. Mulan Permissive Software License is the first open source license in both Chinese and English approved by OSI.
 


### PR DESCRIPTION
`Mulan PSL v2` is used in the license text, and sometimes in project README files. This PR adds an optional `nickname:` field, the same as `GPLv3` is specified as a nickname for `GPL-3.0`.

@TheInterestingSoul I noticed this after merging your #818 PR. It's optional, let me know what you think.