### PR TITLE
Allow bundle updae and tests to be run under ruby 3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,8 +3,8 @@
 source 'https://rubygems.org'
 
 require 'json'
-require 'open-uri'
-versions = JSON.parse(open('https://pages.github.com/versions.json').read)
+require 'net/http'
+versions = JSON.parse(Net::HTTP.get(URI('https://pages.github.com/versions.json')))
 
 gem 'github-pages', versions['github-pages']
 

--- a/spec/ci_ruby_version_spec.rb
+++ b/spec/ci_ruby_version_spec.rb
@@ -6,7 +6,7 @@ require 'spec_helper'
 require 'yaml'
 
 describe 'ruby version' do
-  pages_versions = JSON.parse(open('https://pages.github.com/versions.json').read)
+  pages_versions = JSON.parse(URI.open('https://pages.github.com/versions.json').read)
   pages_ruby_version = pages_versions['ruby']
 
   ci_config_file = '.github/workflows/test.yml'


### PR DESCRIPTION
Fixes #820 

The obvious fix woud've been to use `URI.open` in `Gemfile` as well as in the test, but I get 

> There was an error parsing `Gemfile`: private method `open' called for Bundler::URI:Module. Bundler cannot continue.

Rather than figure it out, switched to a lower level API that for this use case is still very simple.