### PR TITLE
Making the OSL-3.0 and AFL-3.0 formatting consistent with each other.

### DIFF
--- a/_licenses/afl-3.0.txt
+++ b/_licenses/afl-3.0.txt
@@ -33,27 +33,27 @@ authorship (the "Original Work") whose owner (the "Licensor") has placed the
 following licensing notice adjacent to the copyright notice for the Original
 Work:
 
-     Licensed under the Academic Free License version 3.0
+  Licensed under the Academic Free License version 3.0
 
 1) Grant of Copyright License. Licensor grants You a worldwide, royalty-free,
 non-exclusive, sublicensable license, for the duration of the copyright, to do
 the following:
 
-     a) to reproduce the Original Work in copies, either alone or as part of a
-     collective work;
+  a) to reproduce the Original Work in copies, either alone or as part of a
+  collective work;
 
-     b) to translate, adapt, alter, transform, modify, or arrange the Original
-     Work, thereby creating derivative works ("Derivative Works") based upon
-     the Original Work;
+  b) to translate, adapt, alter, transform, modify, or arrange the Original
+  Work, thereby creating derivative works ("Derivative Works") based upon the
+  Original Work;
 
-     c) to distribute or communicate copies of the Original Work and
-     Derivative Works to the public, under any license of your choice that
-     does not contradict the terms and conditions, including Licensor's
-     reserved rights and remedies, in this Academic Free License;
+  c) to distribute or communicate copies of the Original Work and Derivative
+  Works to the public, under any license of your choice that does not
+  contradict the terms and conditions, including Licensor's reserved rights
+  and remedies, in this Academic Free License;
 
-     d) to perform the Original Work publicly; and
+  d) to perform the Original Work publicly; and
 
-     e) to display the Original Work publicly.
+  e) to display the Original Work publicly.
 
 2) Grant of Patent License. Licensor grants You a worldwide, royalty-free,
 non-exclusive, sublicensable license, under patent claims owned or controlled

--- a/_licenses/osl-3.0.txt
+++ b/_licenses/osl-3.0.txt
@@ -41,7 +41,7 @@ authorship (the "Original Work") whose owner (the "Licensor") has placed the
 following licensing notice adjacent to the copyright notice for the Original
 Work:
 
-Licensed under the Open Software License version 3.0
+  Licensed under the Open Software License version 3.0
 
 1) Grant of Copyright License. Licensor grants You a worldwide, royalty-free,
 non-exclusive, sublicensable license, for the duration of the copyright, to do


### PR DESCRIPTION
Greetings:

This is my first pull request to a public repository, so I must apologize in advance if I have misread any directions on the matter or missed them outright.

I would like to propose these formatting changes to the `OSL-3.0` and `AFL-3.0` licenses. As the two are directly related, I wanted to make the formatting between them completely consistent. Line wrapping is at 78 characters so as to not cause a horizontal scrollbar to appear when viewing through the Web site.

I would like to solicit any feedback on the matter.