### PR TITLE
Fix the license text in the BSD 4-Clause License

### DIFF
--- a/_licenses/bsd-4-clause.txt
+++ b/_licenses/bsd-4-clause.txt
@@ -43,7 +43,7 @@ modification, are permitted provided that the following conditions are met:
 
 3. All advertising materials mentioning features or use of this software must
    display the following acknowledgement:
-     This product includes software developed by [project].
+     This product includes software developed by [fullname].
 
 4. Neither the name of the copyright holder nor the names of its
    contributors may be used to endorse or promote products derived from


### PR DESCRIPTION
In the 3rd clause it says:
```
3. All advertising materials mentioning features or use of this software must
   display the following acknowledgement:
     This product includes software developed by [project].
```
Instead of the project name, it should say the name of the creator, so it should say [name] or [fullname] instead of [project].