### PR TITLE
Restore title in text of 0BSD license (now present in SPDX)

### DIFF
--- a/_licenses/0bsd.txt
+++ b/_licenses/0bsd.txt
@@ -25,6 +25,8 @@ limitations:
 
 ---
 
+BSD Zero Clause License
+
 Copyright (c) [year] [fullname]
 
 Permission to use, copy, modify, and/or distribute this software for any


### PR DESCRIPTION
This reverts commit bab9f14fa93405fead73948946c8ca9c2b62c1c5 from PR #643.

Fixes #837.