### PR TITLE
Make css and js load correctly if site rendered in a subdirectory

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -16,9 +16,9 @@
     </div> <!-- /container -->
 
     {% if page.collection == "licenses" or page.class == "license-types" %}
-    <script src="/assets/vendor/jquery/jquery.min.js"></script>
-    <script src="/assets/vendor/qtip2/jquery.qtip.min.js"></script>
-    <script src="/assets/vendor/clipboard/dist/clipboard.min.js"></script>
+    <script src="{{ 'assets/vendor/jquery/jquery.min.js' | relative_url }}"></script>
+    <script src="{{ 'assets/vendor/qtip2/jquery.qtip.min.js' | relative_url }}"></script>
+    <script src="{{ 'assets/vendor/clipboard/dist/clipboard.min.js' | relative_url }}"></script>
     <script>
       window.annotations = {{ site.data.rules | jsonify }};
       {% if page.collection == "licenses" %}
@@ -32,7 +32,7 @@
       ];
       {% endif %}
     </script>
-    <script src="/assets/js/app.js"></script>
+    <script src="{{ 'assets/js/app.js' | relative_url }}"></script>
     {% endif %}
   </body>
 </html>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -5,8 +5,8 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Chivo:900">
-    <link rel="stylesheet" href="/assets/css/application.css?v={{ site.github.build_revision }}">
-    <link rel="shortcut icon" href="/favicon.ico" type="image/x-icon">
+    <link rel="stylesheet" href="{{ 'assets/css/application.css' | relative_url }}?v={{ site.github.build_revision }}">
+    <link rel="shortcut icon" href="{{ 'favicon.ico' | relative_url }}" type="image/x-icon">
     <!--[if lt IE 9]>
     <script src="/assets/vendor/html5shiv/dist/html5shiv.js"></script>
     <script src="/assets/vendor/selectivizr/selectivizr.js"></script>

--- a/assets/css/application.scss
+++ b/assets/css/application.scss
@@ -1,8 +1,8 @@
 ---
 ---
 
-@import "/assets/vendor/normalize-css/normalize.css";
-@import "/assets/vendor/qtip2/jquery.qtip.min.css";
+@import "../vendor/normalize-css/normalize.css";
+@import "../vendor/qtip2/jquery.qtip.min.css";
 
 body {
   background: #fafafa;


### PR DESCRIPTION
To make showing changes from {user}.github.io/choosealicense.com possible, as suggested by @waldyrious in https://github.com/github/choosealicense.com/pull/833#issuecomment-860777503

Example: https://mlinksva.github.io/choosealicense.com/

Note links within the site will still break in this scenario, would need relative_url sprinkled in all internal links to avoid. Non-goal for now.