### PR TITLE
Lowercase npm

### DIFF
--- a/community.md
+++ b/community.md
@@ -16,7 +16,7 @@ Some communities have strong preferences for particular licenses. If you want to
 * [Apache](https://www.apache.org/licenses/) requires [Apache License 2.0](/licenses/apache-2.0/)
 * [Cloud Native Computing Foundation](https://github.com/cncf/toc/blob/master/process/project_proposals.adoc) dictates [Apache License 2.0](/licenses/apache-2.0/) by default
 * [GNU](https://www.gnu.org/licenses/license-recommendations.html) recommends [GNU GPLv3](/licenses/gpl-3.0/) for most programs
-* [NPM packages](https://libraries.io/search?platforms=NPM) overwhelmingly use the [MIT](/licenses/mit/) or the very similar [ISC](/licenses/isc) licenses
+* [npm packages](https://libraries.io/search?platforms=npm) overwhelmingly use the [MIT](/licenses/mit/) or the very similar [ISC](/licenses/isc) licenses
 * [OpenBSD](https://www.openbsd.org/policy.html) prefers the [ISC License](/licenses/isc/)
 * [Rust](https://rust-lang.github.io/api-guidelines/necessities.html#crate-and-its-dependencies-have-a-permissive-license-c-permissive) crates are overwhelmingly licensed under both [MIT](/licenses/mit/) and [Apache License 2.0](/licenses/apache-2.0/)
 * [WordPress](https://wordpress.org/about/license/) plugins and themes must be [GNU GPLv2](/licenses/gpl-2.0/) (or later)


### PR DESCRIPTION
npm should never be capitalized: https://github.com/npm/cli#is-it-npm-or-npm-or-npm