### PR TITLE
Fix misplaced blank line in cc-by-sa-4.0

### DIFF
--- a/_licenses/cc-by-sa-4.0.txt
+++ b/_licenses/cc-by-sa-4.0.txt
@@ -335,8 +335,8 @@ apply to Your use of the Licensed Material:
      contents in a database in which You have Sui Generis Database
      Rights, then the database in which You have Sui Generis Database
      Rights (but not its individual contents) is Adapted Material,
-
      including for purposes of Section 3(b); and
+
   c. You must comply with the conditions in Section 3(a) if You Share
      all or a substantial portion of the contents of the database.
 


### PR DESCRIPTION
There is no special formatting of [these line(s) in the SPDX XML file](https://github.com/spdx/license-list-XML/blob/f9911cd7e819569734efc89f96197735fd0a8dc3/src/CC-BY-SA-4.0.xml#L339-L340) in the [spdx/license-list-XML](https://github.com/spdx/license-list-XML) repository.