### PR TITLE
Meta tweak: Update license year to 2022

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
-Copyright (c) 2013-2021 GitHub, Inc. and contributors
+Copyright (c) 2013-2022 GitHub, Inc. and contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
We are actually not in 2021 anymore. Most projects changed the year in their license to 2022.