### PR TITLE
Replace font-size absolute units with relative units

### DIFF
--- a/assets/css/application.scss
+++ b/assets/css/application.scss
@@ -7,7 +7,7 @@
 body {
   background: #fafafa;
   color: #5c5855;
-  font: 14px/1.4 "Helvetica Neue", Helvetica, Arial, sans-serif;
+  font: 0.875rem/1.4 "Helvetica Neue", Helvetica, Arial, sans-serif;
 }
 
 @media (prefers-color-scheme: dark) {
@@ -68,7 +68,7 @@ h1, h2, h3, h5 {
 }
 
 h1 {
-  font-size: 35px;
+  font-size: 2.1875rem;
   margin-bottom: 25px;
 }
 
@@ -78,19 +78,19 @@ h1 {
 
 h2 {
   opacity: 0.8;
-  font-size: 24px;
+  font-size: 1.5rem;
   margin-top: 24px;
   margin-bottom: 10px;
 }
 
 h3 {
-  font-size: 15px;
+  font-size: 0.9375rem;
   margin-top: 20px;
   margin-bottom: 10px;
 }
 
 h5 {
-  font-size: 14px;
+  font-size: 0.875rem;
   margin-bottom: 15px;
 }
 
@@ -120,12 +120,12 @@ strong {
 }
 
 .home h1 {
-  font-size: 60px;
+  font-size: 3.75rem;
 }
 
 .home h2 {
   color: #687072;
-  font-size: 27px;
+  font-size: 1.6875rem;
   line-height: 70px;
   margin-bottom: 45px;
   vertical-align: middle;
@@ -134,7 +134,7 @@ strong {
 
 .home h2 span {
   color: rgba(127,127,127,10%);
-  font-size: 70px;
+  font-size: 4.375rem;
   padding: 0 5px;
   position: relative;
   top: 10px;
@@ -160,7 +160,7 @@ strong {
 }
 
 .triptych h3 {
-  font-size: 22px;
+  font-size: 1.375rem;
   margin: 0 auto 20px auto;
   width: 220px;
 }
@@ -218,7 +218,7 @@ strong {
 }
 
 .license-overview-name {
-  font-size: 28px;
+  font-size: 1.75rem;
   margin-top: 5px;
 }
 
@@ -228,7 +228,7 @@ strong {
 
 .license-rules {
   border-bottom: solid 1px #ddd;
-  font-size: 13px;
+  font-size: 0.8125rem;
   line-height: 1.3;
   margin-bottom: 12px;
   width: 100%;
@@ -240,7 +240,7 @@ strong {
 }
 
 .license-rules th {
-  font-size: 15px;
+  font-size: 0.9375rem;
   padding: 5px 10px 5px 0;
   vertical-align: bottom;
 }
@@ -259,11 +259,11 @@ strong {
 }
 
 .license-rules .name a {
-  font-size: 28px;
+  font-size: 1.75rem;
 }
 
 .license-rules .name small a {
-  font-size: 16px;
+  font-size: 1rem;
 }
 
 .license-rules td {
@@ -302,14 +302,14 @@ strong {
 }
 
 .license-body {
-  font-size: 15px;
+  font-size: 0.9375rem;
   float: left;
   width: 700px;
 }
 
 .license-body pre {
   font-family: Consolas, Monaco, Courier, monospace;
-  font-size: 14px;
+  font-size: 0.875rem;
   background-color: #fff;
   border: 1px solid #eee;
   -webkit-border-radius: 3px;
@@ -327,7 +327,7 @@ strong {
 .sidebar {
   float: right;
   width: 220px;
-  font-size: 12px;
+  font-size: 0.75rem;
 }
 
 .sidebar a.button {
@@ -398,7 +398,7 @@ strong {
   background-image: -o-linear-gradient(#eee, #ddd);
   background-image: linear-gradient(#eee, #ddd);
   display: inline-block;
-  font-size: 12px;
+  font-size: 0.75rem;
   font-weight: normal;
   padding: 5px 10px;
   text-align: center;
@@ -423,7 +423,7 @@ strong {
   margin-top: 30px;
   padding-top: 20px;
   color: #555;
-  font-size: 12px;
+  font-size: 0.75rem;
   text-align: left;
   line-height: 1.5;
 }
@@ -467,7 +467,7 @@ strong {
 .qtip-limitations,
 .qtip-fetching,
 .qtip-error {
-  font-size: 12px;
+  font-size: 0.75rem;
   line-height: 1.3;
 }
 


### PR DESCRIPTION
## Summary
I noticed #904 and thought I would attempt to resolve it. I believe I translated all `font-size` CSS properties from `px` to `rem`, in the `application.css` file. 

If your browser is at the default font settings you should see no change in font size, and the site will look identical. If you modify your browser's font size you will now see the site's font size scale accordingly.

- Resolves #904 

### REM
Web browsers calculate REM from the root element size. By default, modern web browsers use  `16px = 1rem`. Therefore I performed `px/16 = rem`. 

Rem is a relative unit meaning it is adjustable by the browser or by modifying the root element in CSS. As an example, if a user changes their browser's default font size then rem will increase/decrease accordingly. Therefore this change improves user accessibility.

*[Mozzila Documentation on CSS values and units.](https://developer.mozilla.org/en-US/docs/Learn/CSS/Building_blocks/Values_and_units)*
*[WC3/WAI - Draft Tutorial](https://www.w3.org/WAI/tutorials/page-structure/styling/)*