### PR TITLE
.NET Core > .NET

### DIFF
--- a/_licenses/mit.txt
+++ b/_licenses/mit.txt
@@ -10,7 +10,7 @@ how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of 
 
 using:
   Babel: https://github.com/babel/babel/blob/master/LICENSE
-  .NET Core: https://github.com/dotnet/runtime/blob/master/LICENSE.TXT
+  .NET: https://github.com/dotnet/runtime/blob/master/LICENSE.TXT
   Rails: https://github.com/rails/rails/blob/master/MIT-LICENSE
 
 permissions:

--- a/_licenses/mit.txt
+++ b/_licenses/mit.txt
@@ -10,7 +10,7 @@ how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of 
 
 using:
   Babel: https://github.com/babel/babel/blob/master/LICENSE
-  .NET: https://github.com/dotnet/runtime/blob/master/LICENSE.TXT
+  .NET: https://github.com/dotnet/runtime/blob/main/LICENSE.TXT
   Rails: https://github.com/rails/rails/blob/master/MIT-LICENSE
 
 permissions:


### PR DESCRIPTION
According to https://en.wikipedia.org/wiki/.NET, the .NET foundation dropped the "Core" from .NET's name. .NET Framework remains using it's current name.