### PR TITLE
chore: remove git.io

### DIFF
--- a/spec/license_spec.rb
+++ b/spec/license_spec.rb
@@ -28,7 +28,7 @@ describe 'licenses' do
 
       context 'industry approval' do
         it 'should be approved by OSI or FSF or OD' do
-          expect(approved_licenses).to include(spdx_lcase), 'See https://github.com/github/choosealicense.com/blob/master/CONTRIBUTING.md#adding-new-licenses.'
+          expect(approved_licenses).to include(spdx_lcase), 'See https://github.com/github/choosealicense.com/blob/gh-pages/CONTRIBUTING.md#adding-new-licenses.'
         end
       end
 

--- a/spec/license_spec.rb
+++ b/spec/license_spec.rb
@@ -28,7 +28,7 @@ describe 'licenses' do
 
       context 'industry approval' do
         it 'should be approved by OSI or FSF or OD' do
-          expect(approved_licenses).to include(spdx_lcase), 'See https://git.io/vzCTV.'
+          expect(approved_licenses).to include(spdx_lcase), 'See https://github.com/github/choosealicense.com/blob/master/CONTRIBUTING.md#adding-new-licenses.'
         end
       end
 


### PR DESCRIPTION
All links on git.io will stop redirecting after April 29, 2022.

- https://github.blog/changelog/2022-04-25-git-io-deprecation/