### PR TITLE
Add cern ohl v2

### DIFF
--- a/_licenses/cern-ohl-p-2.0.txt
+++ b/_licenses/cern-ohl-p-2.0.txt
@@ -3,7 +3,7 @@ title: CERN Open Hardware Licence Version 2 - Permissive
 spdx-id: CERN-OHL-P-2.0
 nickname: CERN OHL v2 Permissive
 
-description: A permissive license for hardware designs,  with conditions only requiring preservation of notices. Contributors provide an express grant of patent rights. Licensed works, modifications, and larger works may be distributed under different terms and without sources.
+description: A permissive license for hardware designs, with conditions only requiring preservation of notices. Contributors provide an express grant of patent rights. Licensed works, modifications, and larger works may be distributed under different terms and without sources.
 
 how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file.
 

--- a/_licenses/cern-ohl-p-2.0.txt
+++ b/_licenses/cern-ohl-p-2.0.txt
@@ -7,7 +7,7 @@ description: The CERN OHL was drafted with hardware in mind.  On top of licensin
 
 how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file.
 
-note: CERN recommends adding the following information in the source files: copyright and license notice, a disclaimer of warranties and a source location. You can also include the source location in a part of the design which will be visible in the end product. See the <a href="https://ohwr.org/project/cernohl/wikis/uploads/8a6b5d01f71c207c49493e4d114d61e6/cern_ohl_p_v2_howto.pdf">User's Guide</a> for example notices and further explanation.
+note: CERN <a href="https://ohwr.org/project/cernohl/wikis/uploads/8a6b5d01f71c207c49493e4d114d61e6/cern_ohl_p_v2_howto.pdf">recommends</a> adding the following information in the source files: copyright and license notice, a disclaimer of warranties and a source location. You can also include the source location in a part of the design which will be visible in the end product.
 
 using:
   tedium: https://github.com/jboone/tedium/blob/master/LICENSE-CERN-OHL-P-v2

--- a/_licenses/cern-ohl-p-2.0.txt
+++ b/_licenses/cern-ohl-p-2.0.txt
@@ -7,7 +7,7 @@ description: The CERN OHL was drafted with hardware in mind.  On top of licensin
 
 how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file.
 
-note: CERN recommends adding a license header and copyright notice to the README and source files.  CERN provides a <a href="https://ohwr.org/project/cernohl/wikis/uploads/8a6b5d01f71c207c49493e4d114d61e6/cern_ohl_p_v2_howto.pdf">User's Guide</a> containing a recommended license header.
+note: CERN recommends adding the following information in the source files: copyright and license notice, a disclaimer of warranties and a source location. You can also include the source location in a part of the design which will be visible in the end product. See the <a href="https://ohwr.org/project/cernohl/wikis/uploads/8a6b5d01f71c207c49493e4d114d61e6/cern_ohl_p_v2_howto.pdf">User's Guide</a> for example notices and further explanation.
 
 using:
   tedium: https://github.com/jboone/tedium/blob/master/LICENSE-CERN-OHL-P-v2

--- a/_licenses/cern-ohl-p-2.0.txt
+++ b/_licenses/cern-ohl-p-2.0.txt
@@ -3,7 +3,7 @@ title: CERN Open Hardware Licence Version 2 - Permissive
 spdx-id: CERN-OHL-P-2.0
 nickname: CERN OHL v2 Permissive
 
-description: The CERN OHL was drafted with hardware in mind.  On top of licensing copyright like software and documentation licenses, it also licenses patents.  This “Permissive” variant allows people to take your code, relicense it and use it without any obligation to distribute the sources when they ship a product; however, it does have an attribution requirement.
+description: A permissive license for hardware designs,  with conditions only requiring preservation of notices. Contributors provide an express grant of patent rights. Licensed works, modifications, and larger works may be distributed under different terms and without sources.
 
 how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file.
 

--- a/_licenses/cern-ohl-p-2.0.txt
+++ b/_licenses/cern-ohl-p-2.0.txt
@@ -13,7 +13,7 @@ note:
 using:
   tedium: https://github.com/jboone/tedium/blob/master/LICENSE-CERN-OHL-P-v2
   LEDEAF: https://github.com/adamgreig/ledeaf/blob/master/LICENSE_CERN_OHL_P_v2.txt
-  Open source controller board for ventilators: https://github.com/CV19CO/open_controller_for_ventilator/master/LICENSE
+  Open source controller board for ventilators: https://github.com/CV19CO/open_controller_for_ventilator/blob/master/LICENSE
 
 permissions:
   - commercial-use

--- a/_licenses/cern-ohl-p-2.0.txt
+++ b/_licenses/cern-ohl-p-2.0.txt
@@ -1,0 +1,216 @@
+---
+title: CERN Open Hardware Licence Version 2 - Permissive
+spdx-id: CERN-OHL-P-2.0
+nickname: CERN OHL v2 Permissive
+
+description: The CERN OHL was drafted with hardware in mind.  On top of licensing copyright like software and documentation licenses, it also licenses patents.  This “Permissive” variant allows people to take your code, relicense it and use it without any obligation to distribute the sources when they ship a product; it does have an attribution requirement.
+
+how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file.
+
+note: CERN recommends adding a license header and copyright notice to the README and source files.  CERN provides a <a href="https://ohwr.org/project/cernohl/wikis/uploads/8a6b5d01f71c207c49493e4d114d61e6/cern_ohl_p_v2_howto.pdf">User's Guide</a> containing a recommended license header.
+
+using:
+  Castor & Pollux: https://github.com/wntrblm/Castor_and_Pollux/blob/main/hardware/mainboard/LICENSE
+  LEDEAF: https://github.com/adamgreig/ledeaf/blob/master/LICENSE_CERN_OHL_P_v2.txt
+  ProtoCentral ECG Breakout: https://github.com/Protocentral/protocentral_max86150_ecg_ppg/blob/master/LICENSE.md#hardware
+
+permissions:
+  - commercial-use
+  - modifications
+  - distribution
+  - private-use
+  - patent-use
+
+conditions:
+  - include-copyright
+  - document-changes
+
+limitations:
+  - liability
+  - warranty
+
+---
+CERN Open Hardware Licence Version 2 - Permissive
+
+
+Preamble
+
+CERN has developed this licence to promote collaboration among hardware
+designers and to provide a legal tool which supports the freedom to use,
+study, modify, share and distribute hardware designs and products based on
+those designs. Version 2 of the CERN Open Hardware Licence comes in three
+variants: this licence, CERN-OHL-P (permissive); and two reciprocal licences:
+CERN-OHL-W (weakly reciprocal) and CERN-OHL-S (strongly reciprocal).
+
+The CERN-OHL-P is copyright CERN 2020. Anyone is welcome to use it, in
+unmodified form only.
+
+Use of this Licence does not imply any endorsement by CERN of any Licensor or
+their designs nor does it imply any involvement by CERN in their development.
+
+
+1 Definitions
+
+  1.1 'Licence' means this CERN-OHL-P.
+
+  1.2 'Source' means information such as design materials or digital code
+      which can be applied to Make or test a Product or to prepare a Product
+      for use, Conveyance or sale, regardless of its medium or how it is
+      expressed. It may include Notices.
+
+  1.3 'Covered Source' means Source that is explicitly made available under
+      this Licence.
+
+  1.4 'Product' means any device, component, work or physical object, whether
+      in finished or intermediate form, arising from the use, application or
+      processing of Covered Source.
+
+  1.5 'Make' means to create or configure something, whether by manufacture,
+      assembly, compiling, loading or applying Covered Source or another Product
+      or otherwise.
+
+  1.6 'Notice' means copyright, acknowledgement and trademark notices,
+      references to the location of any Notices, modification notices
+      (subsection 3.3(b)) and all notices that refer to this Licence and to
+      the disclaimer of warranties that are included in the Covered Source.
+
+  1.7 'Licensee' or 'You' means any person exercising rights under this
+      Licence.
+
+  1.8 'Licensor' means a person who creates Source or modifies Covered Source
+      and subsequently Conveys the resulting Covered Source under the terms
+      and conditions of this Licence. A person may be a Licensee and a
+      Licensor at the same time.
+
+  1.9 'Convey' means to communicate to the public or distribute.
+
+
+2 Applicability
+
+  2.1 This Licence governs the use, copying, modification, Conveying of
+      Covered Source and Products, and the Making of Products. By exercising
+      any right granted under this Licence, You irrevocably accept these terms
+      and conditions.
+
+  2.2 This Licence is granted by the Licensor directly to You, and shall apply
+      worldwide and without limitation in time.
+
+  2.3 You shall not attempt to restrict by contract or otherwise the rights
+      granted under this Licence to other Licensees.
+
+  2.4 This Licence is not intended to restrict fair use, fair dealing, or any
+      other similar right.
+
+
+3 Copying, Modifying and Conveying Covered Source
+
+  3.1 You may copy and Convey verbatim copies of Covered Source, in any
+      medium, provided You retain all Notices.
+
+  3.2 You may modify Covered Source, other than Notices.
+
+      You may only delete Notices if they are no longer applicable to the
+      corresponding Covered Source as modified by You and You may add
+      additional Notices applicable to Your modifications.
+
+  3.3 You may Convey modified Covered Source (with the effect that You shall
+      also become a Licensor) provided that You:
+
+       a) retain Notices as required in subsection 3.2; and
+
+       b) add a Notice to the modified Covered Source stating that You have
+          modified it, with the date and brief description of how You have
+          modified it.
+
+  3.4 You may Convey Covered Source or modified Covered Source under licence
+      terms which differ from the terms of this Licence provided that You:
+
+       a) comply at all times with subsection 3.3; and
+
+       b) provide a copy of this Licence to anyone to whom You Convey Covered
+          Source or modified Covered Source.
+
+
+4 Making and Conveying Products
+
+You may Make Products, and/or Convey them, provided that You ensure that the
+recipient of the Product has access to any Notices applicable to the Product.
+
+
+5 DISCLAIMER AND LIABILITY
+
+  5.1 DISCLAIMER OF WARRANTY -- The Covered Source and any Products are
+      provided 'as is' and any express or implied warranties, including, but
+      not limited to, implied warranties of merchantability, of satisfactory
+      quality, non-infringement of third party rights, and fitness for a
+      particular purpose or use are disclaimed in respect of any Source or
+      Product to the maximum extent permitted by law. The Licensor makes no
+      representation that any Source or Product does not or will not infringe
+      any patent, copyright, trade secret or other proprietary right. The
+      entire risk as to the use, quality, and performance of any Source or
+      Product shall be with You and not the Licensor. This disclaimer of
+      warranty is an essential part of this Licence and a condition for the
+      grant of any rights granted under this Licence.
+
+  5.2 EXCLUSION AND LIMITATION OF LIABILITY -- The Licensor shall, to the
+      maximum extent permitted by law, have no liability for direct, indirect,
+      special, incidental, consequential, exemplary, punitive or other damages
+      of any character including, without limitation, procurement of
+      substitute goods or services, loss of use, data or profits, or business
+      interruption, however caused and on any theory of contract, warranty,
+      tort (including negligence), product liability or otherwise, arising in
+      any way in relation to the Covered Source, modified Covered Source
+      and/or the Making or Conveyance of a Product, even if advised of the
+      possibility of such damages, and You shall hold the Licensor(s) free and
+      harmless from any liability, costs, damages, fees and expenses,
+      including claims by third parties, in relation to such use.
+
+
+6 Patents
+
+  6.1 Subject to the terms and conditions of this Licence, each Licensor
+      hereby grants to You a perpetual, worldwide, non-exclusive, no-charge,
+      royalty-free, irrevocable (except as stated in this section 6, or where
+      terminated by the Licensor for cause) patent licence to Make, have Made,
+      use, offer to sell, sell, import, and otherwise transfer the Covered
+      Source and Products, where such licence applies only to those patent
+      claims licensable by such Licensor that are necessarily infringed by
+      exercising rights under the Covered Source as Conveyed by that Licensor.
+
+  6.2 If You institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Covered
+      Source or a Product constitutes direct or contributory patent
+      infringement, or You seek any declaration that a patent licensed to You
+      under this Licence is invalid or unenforceable then any rights granted
+      to You under this Licence shall terminate as of the date such process is
+      initiated.
+
+
+7 General
+
+  7.1 If any provisions of this Licence are or subsequently become invalid or
+      unenforceable for any reason, the remaining provisions shall remain
+      effective.
+
+  7.2 You shall not use any of the name (including acronyms and
+      abbreviations), image, or logo by which the Licensor or CERN is known,
+      except where needed to comply with section 3, or where the use is
+      otherwise allowed by law. Any such permitted use shall be factual and
+      shall not be made so as to suggest any kind of endorsement or
+      implication of involvement by the Licensor or its personnel.
+
+  7.3 CERN may publish updated versions and variants of this Licence which it
+      considers to be in the spirit of this version, but may differ in detail
+      to address new problems or concerns. New versions will be published with
+      a unique version number and a variant identifier specifying the variant.
+      If the Licensor has specified that a given variant applies to the
+      Covered Source without specifying a version, You may treat that Covered
+      Source as being released under any version of the CERN-OHL with that
+      variant. If no variant is specified, the Covered Source shall be treated
+      as being released under CERN-OHL-S. The Licensor may also specify that
+      the Covered Source is subject to a specific version of the CERN-OHL or
+      any later version in which case You may apply this or any later version
+      of CERN-OHL with the same variant identifier published by CERN.
+
+  7.4 This Licence shall not be enforceable except by a Licensor acting as
+      such, and third party beneficiary rights are specifically excluded.

--- a/_licenses/cern-ohl-p-2.0.txt
+++ b/_licenses/cern-ohl-p-2.0.txt
@@ -3,11 +3,12 @@ title: CERN Open Hardware Licence Version 2 - Permissive
 spdx-id: CERN-OHL-P-2.0
 nickname: CERN OHL v2 Permissive
 
-description: The CERN OHL was drafted with hardware in mind.  On top of licensing copyright like software and documentation licenses, it also licenses patents.  This “Permissive” variant allows people to take your code, relicense it and use it without any obligation to distribute the sources when they ship a product; it does have an attribution requirement.
+description: The CERN OHL was drafted with hardware in mind.  On top of licensing copyright like software and documentation licenses, it also licenses patents.  This “Permissive” variant allows people to take your code, relicense it and use it without any obligation to distribute the sources when they ship a product; however, it does have an attribution requirement.
 
 how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file.
 
-note: CERN <a href="https://ohwr.org/project/cernohl/wikis/uploads/8a6b5d01f71c207c49493e4d114d61e6/cern_ohl_p_v2_howto.pdf">recommends</a> adding the following information in the source files: copyright and license notice, a disclaimer of warranties and a source location. You can also include the source location in a part of the design which will be visible in the end product.
+note:
+    CERN <a href="https://ohwr.org/project/cernohl/wikis/uploads/8a6b5d01f71c207c49493e4d114d61e6/cern_ohl_p_v2_howto.pdf">recommends</a> adding the following information in the source files: copyright and license notice, a disclaimer of warranties and a source location. You can also include the source location in a part of the design which will be visible in the end product.
 
 using:
   tedium: https://github.com/jboone/tedium/blob/master/LICENSE-CERN-OHL-P-v2

--- a/_licenses/cern-ohl-p-2.0.txt
+++ b/_licenses/cern-ohl-p-2.0.txt
@@ -66,8 +66,8 @@ their designs nor does it imply any involvement by CERN in their development.
       processing of Covered Source.
 
   1.5 'Make' means to create or configure something, whether by manufacture,
-      assembly, compiling, loading or applying Covered Source or another Product
-      or otherwise.
+      assembly, compiling, loading or applying Covered Source or another
+      Product or otherwise.
 
   1.6 'Notice' means copyright, acknowledgement and trademark notices,
       references to the location of any Notices, modification notices

--- a/_licenses/cern-ohl-p-2.0.txt
+++ b/_licenses/cern-ohl-p-2.0.txt
@@ -10,9 +10,9 @@ how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of 
 note: CERN recommends adding a license header and copyright notice to the README and source files.  CERN provides a <a href="https://ohwr.org/project/cernohl/wikis/uploads/8a6b5d01f71c207c49493e4d114d61e6/cern_ohl_p_v2_howto.pdf">User's Guide</a> containing a recommended license header.
 
 using:
-  Castor & Pollux: https://github.com/wntrblm/Castor_and_Pollux/blob/main/hardware/mainboard/LICENSE
+  tedium: https://github.com/jboone/tedium/blob/master/LICENSE-CERN-OHL-P-v2
   LEDEAF: https://github.com/adamgreig/ledeaf/blob/master/LICENSE_CERN_OHL_P_v2.txt
-  ProtoCentral ECG Breakout: https://github.com/Protocentral/protocentral_max86150_ecg_ppg/blob/master/LICENSE.md#hardware
+  Open source controller board for ventilators: https://github.com/CV19CO/open_controller_for_ventilator/master/LICENSE
 
 permissions:
   - commercial-use

--- a/_licenses/cern-ohl-s-2.0.txt
+++ b/_licenses/cern-ohl-s-2.0.txt
@@ -13,7 +13,7 @@ note:
 using:
   USB Armory: https://github.com/f-secure-foundry/usbarmory/blob/master/hardware/mark-two/LICENSE
   waffling60: https://github.com/4pplet/waffling60/blob/master/LICENCE.md
-  Passport Electronics https://github.com/Foundation-Devices/passport-electronics/blob/master/LICENSE.txt
+  Passport Electronics: https://github.com/Foundation-Devices/passport-electronics/blob/master/LICENSE.txt
 
 permissions:
   - commercial-use

--- a/_licenses/cern-ohl-s-2.0.txt
+++ b/_licenses/cern-ohl-s-2.0.txt
@@ -12,7 +12,7 @@ note: CERN recommends adding a license header and copyright notice to the README
 using:
   USB Armory: https://github.com/f-secure-foundry/usbarmory/blob/master/hardware/mark-two/LICENSE
   waffling60: https://github.com/4pplet/waffling60/blob/master/LICENCE.md
-  Duet 3 Mainboard 6HC: https://github.com/Duet3D/Duet3-Mainboard-6HC/blob/master/LICENSE
+  plt-docs PLT Demo Board: https://github.com/bcdevices/plt-docs/blob/main/PLT-DEMOv2/LICENSE
 
 permissions:
   - commercial-use

--- a/_licenses/cern-ohl-s-2.0.txt
+++ b/_licenses/cern-ohl-s-2.0.txt
@@ -3,7 +3,7 @@ title: CERN Open Hardware Licence Version 2 - Strongly Reciprocal
 spdx-id: CERN-OHL-S-2.0
 nickname: CERN OHL v2 Strongly Reciprocal
 
-description: The CERN OHL was drafted with hardware in mind.  On top of licensing copyright like software and documentation licenses, it also licenses patents.  This “Strongly Reciprocal” variant applies virally, and if a CERN-OHL-S-2.0 file is used in a project then the full project must be released under the CERN-OHL-S-2.0 (or a compatible license).
+description: The CERN OHL was drafted with hardware in mind.  On top of licensing copyright like software and documentation licenses, it also licenses patents.  This “Strongly Reciprocal” variant applies to a complete design, and if a CERN-OHL-S-2.0 file is used in a project then the full project must be released under the CERN-OHL-S-2.0 (or a compatible license).
 
 how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file.
 

--- a/_licenses/cern-ohl-s-2.0.txt
+++ b/_licenses/cern-ohl-s-2.0.txt
@@ -12,7 +12,7 @@ note: CERN <a href="https://ohwr.org/project/cernohl/wikis/uploads/cf37727497ca2
 using:
   USB Armory: https://github.com/f-secure-foundry/usbarmory/blob/master/hardware/mark-two/LICENSE
   waffling60: https://github.com/4pplet/waffling60/blob/master/LICENCE.md
-  plt-docs PLT Demo Board: https://github.com/bcdevices/plt-docs/blob/main/PLT-DEMOv2/LICENSE
+  Passport Electronics https://github.com/Foundation-Devices/passport-electronics/blob/master/LICENSE.txt
 
 permissions:
   - commercial-use

--- a/_licenses/cern-ohl-s-2.0.txt
+++ b/_licenses/cern-ohl-s-2.0.txt
@@ -7,7 +7,7 @@ description: The CERN OHL was drafted with hardware in mind.  On top of licensin
 
 how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file.
 
-note: CERN recommends adding a license header and copyright notice to the README and source files.  CERN provides a <a href="https://ohwr.org/project/cernohl/wikis/uploads/cf37727497ca2b5295a7ab83a40fcf5a/cern_ohl_s_v2_user_guide.pdf">User's Guide</a> containing a recommended license header.
+note: CERN recommends adding the following information in the source files: copyright and license notice, a disclaimer of warranties and a source location. You can also include the source location in a part of the design which will be visible in the end product. See the <a href="https://ohwr.org/project/cernohl/wikis/uploads/cf37727497ca2b5295a7ab83a40fcf5a/cern_ohl_s_v2_user_guide.pdf">User's Guide</a> for example notices and further explanation.
 
 using:
   USB Armory: https://github.com/f-secure-foundry/usbarmory/blob/master/hardware/mark-two/LICENSE

--- a/_licenses/cern-ohl-s-2.0.txt
+++ b/_licenses/cern-ohl-s-2.0.txt
@@ -7,7 +7,7 @@ description: The CERN OHL was drafted with hardware in mind.  On top of licensin
 
 how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file.
 
-note: CERN recommends adding the following information in the source files: copyright and license notice, a disclaimer of warranties and a source location. You can also include the source location in a part of the design which will be visible in the end product. See the <a href="https://ohwr.org/project/cernohl/wikis/uploads/cf37727497ca2b5295a7ab83a40fcf5a/cern_ohl_s_v2_user_guide.pdf">User's Guide</a> for example notices and further explanation.
+note: CERN <a href="https://ohwr.org/project/cernohl/wikis/uploads/cf37727497ca2b5295a7ab83a40fcf5a/cern_ohl_s_v2_user_guide.pdf">recommends</a> adding the following information in the source files: copyright and license notice, a disclaimer of warranties and a source location. You can also include the source location in a part of the design which will be visible in the end product.
 
 using:
   USB Armory: https://github.com/f-secure-foundry/usbarmory/blob/master/hardware/mark-two/LICENSE

--- a/_licenses/cern-ohl-s-2.0.txt
+++ b/_licenses/cern-ohl-s-2.0.txt
@@ -3,11 +3,12 @@ title: CERN Open Hardware Licence Version 2 - Strongly Reciprocal
 spdx-id: CERN-OHL-S-2.0
 nickname: CERN OHL v2 Strongly Reciprocal
 
-description: The CERN OHL was drafted with hardware in mind.  On top of licensing copyright like software and documentation licenses, it also licenses patents.  This “Strongly Reciprocal” variant applies to a complete design, and if a CERN-OHL-S-2.0 file is used in a project then the full project must be released under the CERN-OHL-S-2.0 (or a compatible license).
+description: The CERN OHL was drafted with hardware in mind.  On top of licensing copyright like software and documentation licenses, it also licenses patents.  This “Strongly Reciprocal” variant applies to a complete design, so if a CERN-OHL-S-2.0 file is used in a project then the full project must be released under the CERN-OHL-S-2.0 (or a compatible license).
 
 how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file.
 
-note: CERN <a href="https://ohwr.org/project/cernohl/wikis/uploads/cf37727497ca2b5295a7ab83a40fcf5a/cern_ohl_s_v2_user_guide.pdf">recommends</a> adding the following information in the source files: copyright and license notice, a disclaimer of warranties and a source location. You can also include the source location in a part of the design which will be visible in the end product.
+note:
+    CERN <a href="https://ohwr.org/project/cernohl/wikis/uploads/cf37727497ca2b5295a7ab83a40fcf5a/cern_ohl_s_v2_user_guide.pdf">recommends</a> adding the following information in the source files: copyright and license notice, a disclaimer of warranties and a source location. You can also include the source location in a part of the design which will be visible in the end product.
 
 using:
   USB Armory: https://github.com/f-secure-foundry/usbarmory/blob/master/hardware/mark-two/LICENSE

--- a/_licenses/cern-ohl-s-2.0.txt
+++ b/_licenses/cern-ohl-s-2.0.txt
@@ -3,7 +3,7 @@ title: CERN Open Hardware Licence Version 2 - Strongly Reciprocal
 spdx-id: CERN-OHL-S-2.0
 nickname: CERN OHL v2 Strongly Reciprocal
 
-description: The CERN OHL was drafted with hardware in mind.  On top of licensing copyright like software and documentation licenses, it also licenses patents.  This “Strongly Reciprocal” variant applies to a complete design, so if a CERN-OHL-S-2.0 file is used in a project then the full project must be released under the CERN-OHL-S-2.0 (or a compatible license).
+description: Permissions of this strongly reciprocal license for hardware designs are conditioned on making available complete sources of licensed works and modifications, which include larger works using a licensed work, under the same license. Notices must be preserved. Contributors provide an express grant of patent rights.
 
 how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file.
 

--- a/_licenses/cern-ohl-s-2.0.txt
+++ b/_licenses/cern-ohl-s-2.0.txt
@@ -1,0 +1,299 @@
+---
+title: CERN Open Hardware Licence Version 2 - Strongly Reciprocal
+spdx-id: CERN-OHL-S-2.0
+nickname: CERN OHL v2 Strongly Reciprocal
+
+description: The CERN OHL was drafted with hardware in mind.  On top of licensing copyright like software and documentation licenses, it also licenses patents.  This “Strongly Reciprocal” variant applies virally, and if a CERN-OHL-S-2.0 file is used in a project then the full project must be released under the CERN-OHL-S-2.0 (or a compatible license).
+
+how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file.
+
+note: CERN recommends adding a license header and copyright notice to the README and source files.  CERN provides a <a href="https://ohwr.org/project/cernohl/wikis/uploads/cf37727497ca2b5295a7ab83a40fcf5a/cern_ohl_s_v2_user_guide.pdf">User's Guide</a> containing a recommended license header.
+
+using:
+  USB Armory: https://github.com/f-secure-foundry/usbarmory/blob/master/hardware/mark-two/LICENSE
+  waffling60: https://github.com/4pplet/waffling60/blob/master/LICENCE.md
+  Duet 3 Mainboard 6HC: https://github.com/Duet3D/Duet3-Mainboard-6HC/blob/master/LICENSE
+
+permissions:
+  - commercial-use
+  - modifications
+  - distribution
+  - private-use
+  - patent-use
+
+conditions:
+  - include-copyright
+  - document-changes
+  - disclose-source
+  - same-license
+
+limitations:
+  - liability
+  - warranty
+
+---
+CERN Open Hardware Licence Version 2 - Strongly Reciprocal
+
+
+Preamble
+
+CERN has developed this licence to promote collaboration among hardware
+designers and to provide a legal tool which supports the freedom to use,
+study, modify, share and distribute hardware designs and products based on
+those designs. Version 2 of the CERN Open Hardware Licence comes in three
+variants: CERN-OHL-P (permissive); and two reciprocal licences: CERN-OHL-W
+(weakly reciprocal) and this licence, CERN-OHL-S (strongly reciprocal).
+
+The CERN-OHL-S is copyright CERN 2020. Anyone is welcome to use it, in
+unmodified form only.
+
+Use of this Licence does not imply any endorsement by CERN of any Licensor or
+their designs nor does it imply any involvement by CERN in their development.
+
+
+1 Definitions
+
+  1.1 'Licence' means this CERN-OHL-S.
+
+  1.2 'Compatible Licence' means
+
+       a) any earlier version of the CERN Open Hardware licence, or
+
+       b) any version of the CERN-OHL-S, or
+
+       c) any licence which permits You to treat the Source to which it
+          applies as licensed under CERN-OHL-S provided that on Conveyance of
+          any such Source, or any associated Product You treat the Source in
+          question as being licensed under CERN-OHL-S.
+
+  1.3 'Source' means information such as design materials or digital code
+      which can be applied to Make or test a Product or to prepare a Product
+      for use, Conveyance or sale, regardless of its medium or how it is
+      expressed. It may include Notices.
+
+  1.4 'Covered Source' means Source that is explicitly made available under
+      this Licence.
+
+  1.5 'Product' means any device, component, work or physical object, whether
+      in finished or intermediate form, arising from the use, application or
+      processing of Covered Source.
+
+  1.6 'Make' means to create or configure something, whether by manufacture,
+      assembly, compiling, loading or applying Covered Source or another
+      Product or otherwise.
+
+  1.7 'Available Component' means any part, sub-assembly, library or code
+      which:
+
+       a) is licensed to You as Complete Source under a Compatible Licence; or
+
+       b) is available, at the time a Product or the Source containing it is
+          first Conveyed, to You and any other prospective licensees
+
+            i) as a physical part with sufficient rights and information
+               (including any configuration and programming files and
+               information about its characteristics and interfaces) to enable
+               it either to be Made itself, or to be sourced and used to Make
+               the Product; or
+           ii) as part of the normal distribution of a tool used to design or
+               Make the Product.
+
+  1.8 'Complete Source' means the set of all Source necessary to Make a
+      Product, in the preferred form for making modifications, including
+      necessary installation and interfacing information both for the Product,
+      and for any included Available Components.  If the format is
+      proprietary, it must also be made available in a format (if the
+      proprietary tool can create it) which is viewable with a tool available
+      to potential licensees and licensed under a licence approved by the Free
+      Software Foundation or the Open Source Initiative. Complete Source need
+      not include the Source of any Available Component, provided that You
+      include in the Complete Source sufficient information to enable a
+      recipient to Make or source and use the Available Component to Make the
+      Product.
+
+  1.9 'Source Location' means a location where a Licensor has placed Covered
+      Source, and which that Licensor reasonably believes will remain easily
+      accessible for at least three years for anyone to obtain a digital copy.
+
+ 1.10 'Notice' means copyright, acknowledgement and trademark notices, Source
+      Location references, modification notices (subsection 3.3(b)) and all
+      notices that refer to this Licence and to the disclaimer of warranties
+      that are included in the Covered Source.
+
+ 1.11 'Licensee' or 'You' means any person exercising rights under this
+      Licence.
+
+ 1.12 'Licensor' means a natural or legal person who creates or modifies
+      Covered Source. A person may be a Licensee and a Licensor at the same
+      time.
+
+ 1.13 'Convey' means to communicate to the public or distribute.
+
+
+2 Applicability
+
+  2.1 This Licence governs the use, copying, modification, Conveying of
+      Covered Source and Products, and the Making of Products. By exercising
+      any right granted under this Licence, You irrevocably accept these terms
+      and conditions.
+
+  2.2 This Licence is granted by the Licensor directly to You, and shall apply
+      worldwide and without limitation in time.
+
+  2.3 You shall not attempt to restrict by contract or otherwise the rights
+      granted under this Licence to other Licensees.
+
+  2.4 This Licence is not intended to restrict fair use, fair dealing, or any
+      other similar right.
+
+
+3 Copying, Modifying and Conveying Covered Source
+
+  3.1 You may copy and Convey verbatim copies of Covered Source, in any
+      medium, provided You retain all Notices.
+
+  3.2 You may modify Covered Source, other than Notices, provided that You
+      irrevocably undertake to make that modified Covered Source available
+      from a Source Location should You Convey a Product in circumstances
+      where the recipient does not otherwise receive a copy of the modified
+      Covered Source. In each case subsection 3.3 shall apply.
+
+      You may only delete Notices if they are no longer applicable to the
+      corresponding Covered Source as modified by You and You may add
+      additional Notices applicable to Your modifications.  Including Covered
+      Source in a larger work is modifying the Covered Source, and the larger
+      work becomes modified Covered Source.
+
+  3.3 You may Convey modified Covered Source (with the effect that You shall
+      also become a Licensor) provided that You:
+
+       a) retain Notices as required in subsection 3.2;
+
+       b) add a Notice to the modified Covered Source stating that You have
+          modified it, with the date and brief description of how You have
+          modified it;
+
+       c) add a Source Location Notice for the modified Covered Source if You
+          Convey in circumstances where the recipient does not otherwise
+          receive a copy of the modified Covered Source; and
+
+       d) license the modified Covered Source under the terms and conditions
+          of this Licence (or, as set out in subsection 8.3, a later version,
+          if permitted by the licence of the original Covered Source). Such
+          modified Covered Source must be licensed as a whole, but excluding
+          Available Components contained in it, which remain licensed under
+          their own applicable licences.
+
+
+4 Making and Conveying Products
+
+You may Make Products, and/or Convey them, provided that You either provide
+each recipient with a copy of the Complete Source or ensure that each
+recipient is notified of the Source Location of the Complete Source. That
+Complete Source is Covered Source, and You must accordingly satisfy Your
+obligations set out in subsection 3.3. If specified in a Notice, the Product
+must visibly and securely display the Source Location on it or its packaging
+or documentation in the manner specified in that Notice.
+
+
+5 Research and Development
+
+You may Convey Covered Source, modified Covered Source or Products to a legal
+entity carrying out development, testing or quality assurance work on Your
+behalf provided that the work is performed on terms which prevent the entity
+from both using the Source or Products for its own internal purposes and
+Conveying the Source or Products or any modifications to them to any person
+other than You. Any modifications made by the entity shall be deemed to be
+made by You pursuant to subsection 3.2.
+
+
+6 DISCLAIMER AND LIABILITY
+
+  6.1 DISCLAIMER OF WARRANTY -- The Covered Source and any Products are
+      provided 'as is' and any express or implied warranties, including, but
+      not limited to, implied warranties of merchantability, of satisfactory
+      quality, non-infringement of third party rights, and fitness for a
+      particular purpose or use are disclaimed in respect of any Source or
+      Product to the maximum extent permitted by law. The Licensor makes no
+      representation that any Source or Product does not or will not infringe
+      any patent, copyright, trade secret or other proprietary right. The
+      entire risk as to the use, quality, and performance of any Source or
+      Product shall be with You and not the Licensor. This disclaimer of
+      warranty is an essential part of this Licence and a condition for the
+      grant of any rights granted under this Licence.
+
+  6.2 EXCLUSION AND LIMITATION OF LIABILITY -- The Licensor shall, to the
+      maximum extent permitted by law, have no liability for direct, indirect,
+      special, incidental, consequential, exemplary, punitive or other damages
+      of any character including, without limitation, procurement of
+      substitute goods or services, loss of use, data or profits, or business
+      interruption, however caused and on any theory of contract, warranty,
+      tort (including negligence), product liability or otherwise, arising in
+      any way in relation to the Covered Source, modified Covered Source
+      and/or the Making or Conveyance of a Product, even if advised of the
+      possibility of such damages, and You shall hold the Licensor(s) free and
+      harmless from any liability, costs, damages, fees and expenses,
+      including claims by third parties, in relation to such use.
+
+
+7 Patents
+
+  7.1 Subject to the terms and conditions of this Licence, each Licensor
+      hereby grants to You a perpetual, worldwide, non-exclusive, no-charge,
+      royalty-free, irrevocable (except as stated in subsections 7.2 and 8.4)
+      patent licence to Make, have Made, use, offer to sell, sell, import, and
+      otherwise transfer the Covered Source and Products, where such licence
+      applies only to those patent claims licensable by such Licensor that are
+      necessarily infringed by exercising rights under the Covered Source as
+      Conveyed by that Licensor.
+
+  7.2 If You institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Covered
+      Source or a Product constitutes direct or contributory patent
+      infringement, or You seek any declaration that a patent licensed to You
+      under this Licence is invalid or unenforceable then any rights granted
+      to You under this Licence shall terminate as of the date such process is
+      initiated.
+
+
+8 General
+
+  8.1 If any provisions of this Licence are or subsequently become invalid or
+      unenforceable for any reason, the remaining provisions shall remain
+      effective.
+
+  8.2 You shall not use any of the name (including acronyms and
+      abbreviations), image, or logo by which the Licensor or CERN is known,
+      except where needed to comply with section 3, or where the use is
+      otherwise allowed by law. Any such permitted use shall be factual and
+      shall not be made so as to suggest any kind of endorsement or
+      implication of involvement by the Licensor or its personnel.
+
+  8.3 CERN may publish updated versions and variants of this Licence which it
+      considers to be in the spirit of this version, but may differ in detail
+      to address new problems or concerns. New versions will be published with
+      a unique version number and a variant identifier specifying the variant.
+      If the Licensor has specified that a given variant applies to the
+      Covered Source without specifying a version, You may treat that Covered
+      Source as being released under any version of the CERN-OHL with that
+      variant. If no variant is specified, the Covered Source shall be treated
+      as being released under CERN-OHL-S. The Licensor may also specify that
+      the Covered Source is subject to a specific version of the CERN-OHL or
+      any later version in which case You may apply this or any later version
+      of CERN-OHL with the same variant identifier published by CERN.
+
+  8.4 This Licence shall terminate with immediate effect if You fail to comply
+      with any of its terms and conditions.
+
+  8.5 However, if You cease all breaches of this Licence, then Your Licence
+      from any Licensor is reinstated unless such Licensor has terminated this
+      Licence by giving You, while You remain in breach, a notice specifying
+      the breach and requiring You to cure it within 30 days, and You have
+      failed to come into compliance in all material respects by the end of
+      the 30 day period. Should You repeat the breach after receipt of a cure
+      notice and subsequent reinstatement, this Licence will terminate
+      immediately and permanently. Section 6 shall continue to apply after any
+      termination.
+
+  8.6 This Licence shall not be enforceable except by a Licensor acting as
+      such, and third party beneficiary rights are specifically excluded.

--- a/_licenses/cern-ohl-w-2.0.txt
+++ b/_licenses/cern-ohl-w-2.0.txt
@@ -7,7 +7,7 @@ description: The CERN OHL was drafted with hardware in mind.  On top of licensin
 
 how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file.
 
-note: CERN recommends adding a license header and copyright notice to the README and source files.  CERN provides a <a href="https://ohwr.org/project/cernohl/wikis/uploads/c2e5e9d297949b5c2d324a6cbf6adda0/cern_ohl_w_v2_howto.pdf">User's Guide</a> containing a recommended license header.
+note: CERN recommends adding the following information in the source files: copyright and license notice, a disclaimer of warranties and a source location. You can also include the source location in a part of the design which will be visible in the end product. See the <a href="https://ohwr.org/project/cernohl/wikis/uploads/c2e5e9d297949b5c2d324a6cbf6adda0/cern_ohl_w_v2_howto.pdf">User's Guide</a> for example notices and further explanation.
 
 using:
   Simple PCIe FMC carrier: https://ohwr.org/project/spec/blob/master/LICENSES/CERN-OHL-W-2.0.txt

--- a/_licenses/cern-ohl-w-2.0.txt
+++ b/_licenses/cern-ohl-w-2.0.txt
@@ -3,7 +3,7 @@ title: CERN Open Hardware Licence Version 2 - Weakly Reciprocal
 spdx-id: CERN-OHL-W-2.0
 nickname: CERN OHL v2 Weakly Reciprocal
 
-description: The CERN OHL was drafted with hardware in mind.  On top of licensing copyright like software and documentation licenses, it also licenses patents.  This “Weakly Reciprocal” variant applies to individual designs but does not spread to the entire project it is included in.
+description: Permissions of this weakly-reciprocal license are conditioned on making available complete sources of licensed works and modifications under the same license. Notices must be preserved. Contributors provide an express grant of patent rights. However, a larger work using the licensed work through interfaces provided by the licensed work may be distributed under different terms and without sources for the larger work.
 
 how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file.
 

--- a/_licenses/cern-ohl-w-2.0.txt
+++ b/_licenses/cern-ohl-w-2.0.txt
@@ -7,7 +7,8 @@ description: The CERN OHL was drafted with hardware in mind.  On top of licensin
 
 how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file.
 
-note: CERN <a href="https://ohwr.org/project/cernohl/wikis/uploads/c2e5e9d297949b5c2d324a6cbf6adda0/cern_ohl_w_v2_howto.pdf">recommends</a> adding the following information in the source files: copyright and license notice, a disclaimer of warranties and a source location. You can also include the source location in a part of the design which will be visible in the end product.
+note:
+    CERN <a href="https://ohwr.org/project/cernohl/wikis/uploads/c2e5e9d297949b5c2d324a6cbf6adda0/cern_ohl_w_v2_howto.pdf">recommends</a> adding the following information in the source files: copyright and license notice, a disclaimer of warranties and a source location. You can also include the source location in a part of the design which will be visible in the end product.
 
 using:
   Simple PCIe FMC carrier: https://ohwr.org/project/spec/blob/master/LICENSES/CERN-OHL-W-2.0.txt

--- a/_licenses/cern-ohl-w-2.0.txt
+++ b/_licenses/cern-ohl-w-2.0.txt
@@ -1,0 +1,321 @@
+---
+title: CERN Open Hardware Licence Version 2 - Weakly Reciprocal
+spdx-id: CERN-OHL-W-2.0
+nickname: CERN OHL v2 Weakly Reciprocal
+
+description: The CERN OHL was drafted with hardware in mind.  On top of licensing copyright like software and documentation licenses, it also licenses patents.  This “Weakly Reciprocal” variant applies to individual designs but does not spread to the entire project it is included in.
+
+how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file.
+
+note: CERN recommends adding a license header and copyright notice to the README and source files.  CERN provides a <a href="https://ohwr.org/project/cernohl/wikis/uploads/c2e5e9d297949b5c2d324a6cbf6adda0/cern_ohl_w_v2_howto.pdf">User's Guide</a> containing a recommended license header.
+
+using:
+  Simple PCIe FMC carrier: https://ohwr.org/project/spec/blob/master/LICENSES/CERN-OHL-W-2.0.txt
+  GProcessor8Bits: https://github.com/JonathSpirit/GP8B/blob/master/LICENSE
+  FPGA Cores: https://github.com/suoto/fpga_cores/blob/master/LICENSE
+
+permissions:
+  - commercial-use
+  - modifications
+  - distribution
+  - private-use
+  - patent-use
+
+conditions:
+  - include-copyright
+  - document-changes
+  - disclose-source
+  - same-license--file
+
+limitations:
+  - liability
+  - warranty
+
+---
+CERN Open Hardware Licence Version 2 - Weakly Reciprocal
+
+
+Preamble
+
+CERN has developed this licence to promote collaboration among hardware
+designers and to provide a legal tool which supports the freedom to use,
+study, modify, share and distribute hardware designs and products based on
+those designs. Version 2 of the CERN Open Hardware Licence comes in three
+variants: CERN-OHL-P (permissive); and two reciprocal licences: this licence,
+CERN-OHL-W (weakly reciprocal) and CERN-OHL-S (strongly reciprocal).
+
+The CERN-OHL-W is copyright CERN 2020. Anyone is welcome to use it, in
+unmodified form only.
+
+Use of this Licence does not imply any endorsement by CERN of any Licensor or
+their designs nor does it imply any involvement by CERN in their development.
+
+
+1 Definitions
+
+  1.1 'Licence' means this CERN-OHL-W.
+
+  1.2 'Compatible Licence' means
+
+       a) any earlier version of the CERN Open Hardware licence, or
+
+       b) any version of the CERN-OHL-S or the CERN-OHL-W, or
+
+       c) any licence which permits You to treat the Source to which it
+          applies as licensed under CERN-OHL-S or CERN-OHL-W provided that on
+          Conveyance of any such Source, or any associated Product You treat
+          the Source in question as being licensed under CERN-OHL-S or
+          CERN-OHL-W as appropriate.
+
+  1.3 'Source' means information such as design materials or digital code
+      which can be applied to Make or test a Product or to prepare a Product
+      for use, Conveyance or sale, regardless of its medium or how it is
+      expressed. It may include Notices.
+
+  1.4 'Covered Source' means Source that is explicitly made available under
+      this Licence.
+
+  1.5 'Product' means any device, component, work or physical object, whether
+      in finished or intermediate form, arising from the use, application or
+      processing of Covered Source.
+
+  1.6 'Make' means to create or configure something, whether by manufacture,
+      assembly, compiling, loading or applying Covered Source or another
+      Product or otherwise.
+
+  1.7 'Available Component' means any part, sub-assembly, library or code
+      which:
+
+       a) is licensed to You as Complete Source under a Compatible Licence; or
+
+       b) is available, at the time a Product or the Source containing it is
+          first Conveyed, to You and any other prospective licensees
+
+           i) with sufficient rights and information (including any
+              configuration and programming files and information about its
+              characteristics and interfaces) to enable it either to be Made
+              itself, or to be sourced and used to Make the Product; or
+          ii) as part of the normal distribution of a tool used to design or
+              Make the Product.
+
+  1.8 'External Material' means anything (including Source) which:
+
+       a) is only combined with Covered Source in such a way that it
+          interfaces with the Covered Source using a documented interface
+          which is described in the Covered Source; and
+
+       b) is not a derivative of or contains Covered Source, or, if it is, it
+          is solely to the extent necessary to facilitate such interfacing.
+
+  1.9 'Complete Source' means the set of all Source necessary to Make a
+      Product, in the preferred form for making modifications, including
+      necessary installation and interfacing information both for the Product,
+      and for any included Available Components.  If the format is
+      proprietary, it must also be made available in a format (if the
+      proprietary tool can create it) which is viewable with a tool available
+      to potential licensees and licensed under a licence approved by the Free
+      Software Foundation or the Open Source Initiative. Complete Source need
+      not include the Source of any Available Component, provided that You
+      include in the Complete Source sufficient information to enable a
+      recipient to Make or source and use the Available Component to Make the
+      Product.
+
+ 1.10 'Source Location' means a location where a Licensor has placed Covered
+      Source, and which that Licensor reasonably believes will remain easily
+      accessible for at least three years for anyone to obtain a digital copy.
+
+ 1.11 'Notice' means copyright, acknowledgement and trademark notices, Source
+      Location references, modification notices (subsection 3.3(b)) and all
+      notices that refer to this Licence and to the disclaimer of warranties
+      that are included in the Covered Source.
+
+ 1.12 'Licensee' or 'You' means any person exercising rights under this
+      Licence.
+
+ 1.13 'Licensor' means a natural or legal person who creates or modifies
+      Covered Source. A person may be a Licensee and a Licensor at the same
+      time.
+
+ 1.14 'Convey' means to communicate to the public or distribute.
+
+
+2 Applicability
+
+  2.1 This Licence governs the use, copying, modification, Conveying of
+      Covered Source and Products, and the Making of Products. By exercising
+      any right granted under this Licence, You irrevocably accept these terms
+      and conditions.
+
+  2.2 This Licence is granted by the Licensor directly to You, and shall apply
+      worldwide and without limitation in time.
+
+  2.3 You shall not attempt to restrict by contract or otherwise the rights
+      granted under this Licence to other Licensees.
+
+  2.4 This Licence is not intended to restrict fair use, fair dealing, or any
+      other similar right.
+
+
+3 Copying, Modifying and Conveying Covered Source
+
+  3.1 You may copy and Convey verbatim copies of Covered Source, in any
+      medium, provided You retain all Notices.
+
+  3.2 You may modify Covered Source, other than Notices, provided that You
+      irrevocably undertake to make that modified Covered Source available
+      from a Source Location should You Convey a Product in circumstances
+      where the recipient does not otherwise receive a copy of the modified
+      Covered Source. In each case subsection 3.3 shall apply.
+
+      You may only delete Notices if they are no longer applicable to the
+      corresponding Covered Source as modified by You and You may add
+      additional Notices applicable to Your modifications.
+
+  3.3 You may Convey modified Covered Source (with the effect that You shall
+      also become a Licensor) provided that You:
+
+       a) retain Notices as required in subsection 3.2;
+
+       b) add a Notice to the modified Covered Source stating that You have
+          modified it, with the date and brief description of how You have
+          modified it;
+
+       c) add a Source Location Notice for the modified Covered Source if You
+          Convey in circumstances where the recipient does not otherwise
+          receive a copy of the modified Covered Source; and
+
+       d) license the modified Covered Source under the terms and conditions
+          of this Licence (or, as set out in subsection 8.3, a later version,
+          if permitted by the licence of the original Covered Source). Such
+          modified Covered Source must be licensed as a whole, but excluding
+          Available Components contained in it or External Material to which
+          it is interfaced, which remain licensed under their own applicable
+          licences.
+
+
+4 Making and Conveying Products
+
+  4.1 You may Make Products, and/or Convey them, provided that You either
+      provide each recipient with a copy of the Complete Source or ensure that
+      each recipient is notified of the Source Location of the Complete
+      Source. That Complete Source includes Covered Source and You must
+      accordingly satisfy Your obligations set out in subsection 3.3. If
+      specified in a Notice, the Product must visibly and securely display the
+      Source Location on it or its packaging or documentation in the manner
+      specified in that Notice.
+
+  4.2 Where You Convey a Product which incorporates External Material, the
+      Complete Source for that Product which You are required to provide under
+      subsection 4.1 need not include any Source for the External Material.
+
+  4.3 You may license Products under terms of Your choice, provided that such
+      terms do not restrict or attempt to restrict any recipients' rights
+      under this Licence to the Covered Source.
+
+
+5 Research and Development
+
+You may Convey Covered Source, modified Covered Source or Products to a legal
+entity carrying out development, testing or quality assurance work on Your
+behalf provided that the work is performed on terms which prevent the entity
+from both using the Source or Products for its own internal purposes and
+Conveying the Source or Products or any modifications to them to any person
+other than You. Any modifications made by the entity shall be deemed to be
+made by You pursuant to subsection 3.2.
+
+
+6 DISCLAIMER AND LIABILITY
+
+  6.1 DISCLAIMER OF WARRANTY -- The Covered Source and any Products are
+      provided 'as is' and any express or implied warranties, including, but
+      not limited to, implied warranties of merchantability, of satisfactory
+      quality, non-infringement of third party rights, and fitness for a
+      particular purpose or use are disclaimed in respect of any Source or
+      Product to the maximum extent permitted by law. The Licensor makes no
+      representation that any Source or Product does not or will not infringe
+      any patent, copyright, trade secret or other proprietary right. The
+      entire risk as to the use, quality, and performance of any Source or
+      Product shall be with You and not the Licensor. This disclaimer of
+      warranty is an essential part of this Licence and a condition for the
+      grant of any rights granted under this Licence.
+
+  6.2 EXCLUSION AND LIMITATION OF LIABILITY -- The Licensor shall, to the
+      maximum extent permitted by law, have no liability for direct, indirect,
+      special, incidental, consequential, exemplary, punitive or other damages
+      of any character including, without limitation, procurement of
+      substitute goods or services, loss of use, data or profits, or business
+      interruption, however caused and on any theory of contract, warranty,
+      tort (including negligence), product liability or otherwise, arising in
+      any way in relation to the Covered Source, modified Covered Source
+      and/or the Making or Conveyance of a Product, even if advised of the
+      possibility of such damages, and You shall hold the Licensor(s) free and
+      harmless from any liability, costs, damages, fees and expenses,
+      including claims by third parties, in relation to such use.
+
+
+7 Patents
+
+  7.1 Subject to the terms and conditions of this Licence, each Licensor
+      hereby grants to You a perpetual, worldwide, non-exclusive, no-charge,
+      royalty-free, irrevocable (except as stated in subsections 7.2 and 8.4)
+      patent licence to Make, have Made, use, offer to sell, sell, import, and
+      otherwise transfer the Covered Source and Products, where such licence
+      applies only to those patent claims licensable by such Licensor that are
+      necessarily infringed by exercising rights under the Covered Source as
+      Conveyed by that Licensor.
+
+  7.2 If You institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Covered
+      Source or a Product constitutes direct or contributory patent
+      infringement, or You seek any declaration that a patent licensed to You
+      under this Licence is invalid or unenforceable then any rights granted
+      to You under this Licence shall terminate as of the date such process is
+      initiated.
+
+
+8 General
+
+  8.1 If any provisions of this Licence are or subsequently become invalid or
+      unenforceable for any reason, the remaining provisions shall remain
+      effective.
+
+  8.2 You shall not use any of the name (including acronyms and
+      abbreviations), image, or logo by which the Licensor or CERN is known,
+      except where needed to comply with section 3, or where the use is
+      otherwise allowed by law. Any such permitted use shall be factual and
+      shall not be made so as to suggest any kind of endorsement or
+      implication of involvement by the Licensor or its personnel.
+
+  8.3 CERN may publish updated versions and variants of this Licence which it
+      considers to be in the spirit of this version, but may differ in detail
+      to address new problems or concerns. New versions will be published with
+      a unique version number and a variant identifier specifying the variant.
+      If the Licensor has specified that a given variant applies to the
+      Covered Source without specifying a version, You may treat that Covered
+      Source as being released under any version of the CERN-OHL with that
+      variant. If no variant is specified, the Covered Source shall be treated
+      as being released under CERN-OHL-S. The Licensor may also specify that
+      the Covered Source is subject to a specific version of the CERN-OHL or
+      any later version in which case You may apply this or any later version
+      of CERN-OHL with the same variant identifier published by CERN.
+
+      You may treat Covered Source licensed under CERN-OHL-W as licensed under
+      CERN-OHL-S if and only if all Available Components referenced in the
+      Covered Source comply with the corresponding definition of Available
+      Component for CERN-OHL-S.
+
+  8.4 This Licence shall terminate with immediate effect if You fail to comply
+      with any of its terms and conditions.
+
+  8.5 However, if You cease all breaches of this Licence, then Your Licence
+      from any Licensor is reinstated unless such Licensor has terminated this
+      Licence by giving You, while You remain in breach, a notice specifying
+      the breach and requiring You to cure it within 30 days, and You have
+      failed to come into compliance in all material respects by the end of
+      the 30 day period. Should You repeat the breach after receipt of a cure
+      notice and subsequent reinstatement, this Licence will terminate
+      immediately and permanently. Section 6 shall continue to apply after any
+      termination.
+
+  8.6 This Licence shall not be enforceable except by a Licensor acting as
+       such, and third party beneficiary rights are specifically excluded.

--- a/_licenses/cern-ohl-w-2.0.txt
+++ b/_licenses/cern-ohl-w-2.0.txt
@@ -26,7 +26,7 @@ conditions:
   - include-copyright
   - document-changes
   - disclose-source
-  - same-license--file
+  - same-license--library
 
 limitations:
   - liability

--- a/_licenses/cern-ohl-w-2.0.txt
+++ b/_licenses/cern-ohl-w-2.0.txt
@@ -7,7 +7,7 @@ description: The CERN OHL was drafted with hardware in mind.  On top of licensin
 
 how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file.
 
-note: CERN recommends adding the following information in the source files: copyright and license notice, a disclaimer of warranties and a source location. You can also include the source location in a part of the design which will be visible in the end product. See the <a href="https://ohwr.org/project/cernohl/wikis/uploads/c2e5e9d297949b5c2d324a6cbf6adda0/cern_ohl_w_v2_howto.pdf">User's Guide</a> for example notices and further explanation.
+note: CERN <a href="https://ohwr.org/project/cernohl/wikis/uploads/c2e5e9d297949b5c2d324a6cbf6adda0/cern_ohl_w_v2_howto.pdf">recommends</a> adding the following information in the source files: copyright and license notice, a disclaimer of warranties and a source location. You can also include the source location in a part of the design which will be visible in the end product.
 
 using:
   Simple PCIe FMC carrier: https://ohwr.org/project/spec/blob/master/LICENSES/CERN-OHL-W-2.0.txt

--- a/non-software.md
+++ b/non-software.md
@@ -20,9 +20,9 @@ The [SIL Open Font License 1.1](/licenses/ofl-1.1/) keeps fonts open, allowing t
 
 ### Hardware
 
-There are the CERN Open Hardware family of licenses: [CERN-OHL-P-2.0](/licenses/cern-ohl-p-2.0/) (Permissive, [MIT](/licenses/mit/)-like), [CERN-OHL-W-2.0](/licenses/cern-ohl-w-2.0/) (Weakly reciprocal, [MPL](/licenses/mpl-2.0/)-like), and [cern-ohl-s-2.0](/licenses/cern-ohl-s-2.0/) (Strongly reciprocal, [GPL](/licenses/gpl-3.0/)-like).  The CERN OHL family is also applicable to HDL source code and programmable hardware such as FPGA bitstreams.
+There are the CERN Open Hardware family of licenses: [CERN-OHL-P-2.0](/licenses/cern-ohl-p-2.0/), the permissive variant ([MIT](/licenses/mit/)-like); [CERN-OHL-W-2.0](/licenses/cern-ohl-w-2.0/), the “weakly reciprocal” variant ([MPL](/licenses/mpl-2.0/)-like), and [CERN-OHL-S-2.0](/licenses/cern-ohl-s-2.0/), the “strongly reciprocal” variant ([GPL](/licenses/gpl-3.0/)-like).  The CERN OHL family is also applicable to HDL source code and synthesized bitstreams as would be used in FPGAs.
 
-[CC-BY-4.0](/licenses/cc-by-4.0/) and [CC-BY-SA-4.0](/licenses/cc-by-sa-4.0/) are also commonly used for hardware; however they do not grant patent rights which restricts usage of patent-encumbered hardware licensed under them.
+[CC-BY-4.0](/licenses/cc-by-4.0/) and [CC-BY-SA-4.0](/licenses/cc-by-sa-4.0/) are also commonly used for hardware; however they do not grant patent rights which can restrict usage of patent-encumbered hardware licensed under them and Creative Commons does not recommend them for hardware.
 
 If your hardware has accompanying software then be sure to specify a license for the software portion as well as the hardware portion.
 

--- a/non-software.md
+++ b/non-software.md
@@ -18,6 +18,14 @@ Any open source software license or open license for media (see [above](#data-me
 
 The [SIL Open Font License 1.1](/licenses/ofl-1.1/) keeps fonts open, allowing them to be freely used in other works.
 
+### Hardware
+
+There are the CERN Open Hardware family of licenses: [CERN-OHL-P-2.0](/licenses/cern-ohl-p-2.0/) (Permissive, [MIT](/licenses/mit/)-like), [CERN-OHL-W-2.0](/licenses/cern-ohl-w-2.0/) (Weakly reciprocal, [MPL](/licenses/mpl-2.0/)-like), and [cern-ohl-s-2.0](/licenses/cern-ohl-s-2.0/) (Strongly reciprocal, [GPL](/licenses/gpl-3.0/)-like).  The CERN OHL family is also applicable to HDL source code and programmable hardware such as FPGA bitstreams.
+
+[CC-BY-4.0](/licenses/cc-by-4.0/) and [CC-BY-SA-4.0](/licenses/cc-by-sa-4.0/) are also commonly used for hardware; however they do not grant patent rights which restricts usage of patent-encumbered hardware licensed under them.
+
+If your hardware has accompanying software then be sure to specify a license for the software portion as well as the hardware portion.
+
 ### Mixed projects
 
 If your project contains a mix of software and other material, you can include multiple licenses, as long as you are explicit about which license applies to each part of the project. See [the license notice for this site](https://github.com/github/choosealicense.com#license) as an example.

--- a/non-software.md
+++ b/non-software.md
@@ -4,11 +4,11 @@ layout: default
 permalink: /non-software/
 ---
 
-Open source software licenses can be also used for non-software works and are often the best choice, especially when the works in question can be edited and versioned as source (e.g., [open source hardware](https://www.oshwa.org/definition/) designs). [Choose an open source license here.](/licenses/)
+Open source software licenses can be also used for non-software works and are often the best choice, especially when the works in question can be edited and versioned as source. [Choose an open source license](/).
 
 ### Data, media, etc.
 
-[CC0-1.0](/licenses/cc0-1.0/), [CC-BY-4.0](/licenses/cc-by-4.0/), and [CC-BY-SA-4.0](/licenses/cc-by-sa-4.0/) are [open](https://opendefinition.org) licenses used for non-software material ranging from datasets to videos. Note that CC-BY-4.0 and CC-BY-SA-4.0 should [not be used for software](https://creativecommons.org/faq/#can-i-apply-a-creative-commons-license-to-software).
+[CC0-1.0](/licenses/cc0-1.0/), [CC-BY-4.0](/licenses/cc-by-4.0/), and [CC-BY-SA-4.0](/licenses/cc-by-sa-4.0/) are [open](https://opendefinition.org) licenses used for non-software material ranging from datasets to videos. Note that Creative Commons does [not recommond its licenses be used for software](https://creativecommons.org/faq/#can-i-apply-a-creative-commons-license-to-software) or hardware.
 
 ### Documentation
 
@@ -20,12 +20,8 @@ The [SIL Open Font License 1.1](/licenses/ofl-1.1/) keeps fonts open, allowing t
 
 ### Hardware
 
-There are the CERN Open Hardware family of licenses: [CERN-OHL-P-2.0](/licenses/cern-ohl-p-2.0/), the permissive variant ([MIT](/licenses/mit/)-like); [CERN-OHL-W-2.0](/licenses/cern-ohl-w-2.0/), the “weakly reciprocal” variant ([MPL](/licenses/mpl-2.0/)-like), and [CERN-OHL-S-2.0](/licenses/cern-ohl-s-2.0/), the “strongly reciprocal” variant ([GPL](/licenses/gpl-3.0/)-like).  The CERN OHL family is also applicable to HDL source code and synthesized bitstreams as would be used in FPGAs.
-
-[CC-BY-4.0](/licenses/cc-by-4.0/) and [CC-BY-SA-4.0](/licenses/cc-by-sa-4.0/) are also commonly used for hardware; however they do not grant patent rights which can restrict usage of patent-encumbered hardware licensed under them and Creative Commons does not recommend them for hardware.
-
-If your hardware has accompanying software then be sure to specify a license for the software portion as well as the hardware portion.
+Designs for [open source hardware](https://www.oshwa.org/definition/) ranging from furniture to [FGPAs](https://www.oshwa.org/best-practices-for-sharing-fpga-designs-2/) are covered by CERN Open Hardware licenses: [CERN-OHL-P-2.0](/licenses/cern-ohl-p-2.0/) (permissive), [CERN-OHL-W-2.0](/licenses/cern-ohl-w-2.0/) (weakly reciprocal), and [CERN-OHL-S-2.0](/licenses/cern-ohl-s-2.0/) (strongly reciprocal).
 
 ### Mixed projects
 
-If your project contains a mix of software and other material, you can include multiple licenses, as long as you are explicit about which license applies to each part of the project. See [the license notice for this site](https://github.com/github/choosealicense.com#license) as an example.
+If your project contains a mix of different types of material, you can include multiple licenses, as long as you are explicit about which license applies to each part of the project. See [the license notice for this site](https://github.com/github/choosealicense.com#license) as an example.

--- a/spec/license_meta_spec.rb
+++ b/spec/license_meta_spec.rb
@@ -53,6 +53,8 @@ describe 'license meta' do
               example_url.gsub!(%r{/tree/}, '/plain/')
             elsif example_url.start_with?('https://bitbucket.org/')
               example_url.gsub!(%r{/src/}, '/raw/')
+            elsif example_url.start_with?('https://ohwr.org/')
+              example_url.gsub!(%r{/blob/}, '/raw/')
             end
 
             it "is a #{slug} license" do


### PR DESCRIPTION
This PR contains all the commits from #854 adding the CERN-OHL v2 family of licenses. (See also the discussion in issue/fixes #853)

This remains a draft whilst we check and tweak the "how" field

## Requirements

### 1. The license must have [an SPDX identifier](https://spdx.org/licenses/). If your license isn't registered with SPDX, please [request that it be added](https://spdx.org/spdx-license-list/request-new-license).

* [CERN-OHL-P-2.0](https://spdx.org/licenses/CERN-OHL-P-2.0.html)
* [CERN-OHL-S-2.0](https://spdx.org/licenses/CERN-OHL-S-2.0.html)
* [CERN-OHL-W-2.0](https://spdx.org/licenses/CERN-OHL-W-2.0.html)

### 2. The license must be listed on one of the following approved lists of licenses:

* [CERN-OHL-P-2.0](https://opensource.org/CERN-OHL-P)
* [CERN-OHL-S-2.0](https://opensource.org/CERN-OHL-S)
* [CERN-OHL-W-2.0](https://opensource.org/CERN-OHL-W)

### 3. The license must be used in at least 1,000 public repositories. This may be documented, for example, with a [GitHub code search](https://github.com/search?q=MIT+filename%3ALICENSE&type=Code).

As noted in #853,  there are a considerable number of projects using the CERN-OHL family of licenses.

This requirement appears to be to show the license is notable enough for inclusion. As the Open Hardware community is still settling on how best to share hardware, this increases the number of platforms that need to be searched. We provide the following further considerations:

1.  The CERN OHL family is recommended by the [Open Source Hardware Association](https://www.oshwa.org/)
2.  The CERN OHL family is recommended by journals such as [HardwareX](https://www.elsevier.com/journals/hardwarex/2468-0672/guide-for-authors) and [Journal of Open Hardware](https://openhardware.metajnl.com/about/submissions/)
3.  Inclusion of CERN OHL as the first OSI approved hardware specific licenses was deemed newsworthy by [a major tech news website](https://www.theregister.com/2021/01/29/cern_ohl_approved/)

### 4. 3 notable projects using the license must be identified. These must have straightforward LICENSE files which serve as examples newcomers can follow and that could be detected by [licensee](https://github.com/licensee/licensee) if it knew about the license.

As discussed in #854 this PR updates the projects.
