### PR TITLE
make the text visible on yellow :target background

### DIFF
--- a/assets/css/application.scss
+++ b/assets/css/application.scss
@@ -108,6 +108,7 @@ strong {
 
 :target {
   background-color: yellow;
+  color: #444 !important;
 }
 
 .container {


### PR DESCRIPTION
The white text was not visible on the yellow `:target` background so I made it darker.
(this is only a problem with dark mode)