### PR TITLE
license(apache-2.0): add mention of placeholders in the "how" part

### DIFF
--- a/_licenses/apache-2.0.txt
+++ b/_licenses/apache-2.0.txt
@@ -7,7 +7,7 @@ hidden: false
 
 description: A permissive license whose main conditions require preservation of copyright and license notices. Contributors provide an express grant of patent rights. Licensed works, modifications, and larger works may be distributed under different terms and without source code.
 
-how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file.
+how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file. Replace [yyyy] with the current year and [name of copyright owner] with the name (or names) of the copyright holders.
 
 note: The Apache Foundation recommends taking the additional step of adding a boilerplate notice to the header of each source file. You can find the notice in the appendix at the very end of the license text.
 


### PR DESCRIPTION
Currently, the MIT license _"How to apply this license"_ sidebar mentions the placeholders in the example license file to replace (`[year]` and `[fullname]`):

<https://github.com/github/choosealicense.com/blob/d91f364d2ce30201d712dd065437339a70cca9f1/_licenses/mit.txt#L9>

The Apache License 2.0 also has such placeholders (`[yyyy]` and `[name of copyright owner]`), but **features no mention of them in the "How to" part**.

Given the fact as these placeholders are at the end of the file (compared to MIT where it's the second line), and [the amount of Apache 2.0 LICENSE files with such a placeholder still in them on GitHub](https://github.com/search?q=%22%5Bname+of+copyright+owner%5D%22)), one might argue that this is even more relevant to mention it for the Apache License 2.0 than it is for the MIT one.

This PR adds a mention of these placeholders in the _"How to apply this license"_, inspired and aligned by what's being done with the MIT license 🙂
