### PR TITLE
Fix typo in non-software licenses page

### DIFF
--- a/non-software.md
+++ b/non-software.md
@@ -8,7 +8,7 @@ Open source software licenses can be also used for non-software works and are of
 
 ### Data, media, etc.
 
-[CC0-1.0](/licenses/cc0-1.0/), [CC-BY-4.0](/licenses/cc-by-4.0/), and [CC-BY-SA-4.0](/licenses/cc-by-sa-4.0/) are [open](https://opendefinition.org) licenses used for non-software material ranging from datasets to videos. Note that Creative Commons does [not recommond its licenses be used for software](https://creativecommons.org/faq/#can-i-apply-a-creative-commons-license-to-software) or hardware.
+[CC0-1.0](/licenses/cc0-1.0/), [CC-BY-4.0](/licenses/cc-by-4.0/), and [CC-BY-SA-4.0](/licenses/cc-by-sa-4.0/) are [open](https://opendefinition.org) licenses used for non-software material ranging from datasets to videos. Note that Creative Commons does [not recommend its licenses be used for software](https://creativecommons.org/faq/#can-i-apply-a-creative-commons-license-to-software) or hardware.
 
 ### Documentation
 


### PR DESCRIPTION
Corrects `recommond` to `recommend`