### PR TITLE
add network-use-disclose to CeCILL v2

### DIFF
--- a/_licenses/cecill-2.1.txt
+++ b/_licenses/cecill-2.1.txt
@@ -20,6 +20,7 @@ permissions:
 
 conditions:
   - include-copyright
+  - network-use-disclose
   - disclose-source
   - same-license
 


### PR DESCRIPTION
> Le droit de distribution comporte notamment le droit de diffuser, de transmettre et de communiquer le Logiciel au public **sur tout support et par tout moyen** ainsi que le droit de mettre sur le marché à titre onéreux ou gratuit, un ou des exemplaires du Logiciel par tout procédé.
- CeCILL, section 5.3

> In particular, the right of distribution includes the right to publish, transmit and communicate the Software to the general public on **any or all medium, and by any or all means**, and the right to market, either in consideration of a fee, or free of charge, one or more copies of the Software by any means.
- CeCILL (official English translation), section 5.3


As disambiguated by the official CeCILL FAQ, the French law interpretation is that network use, for example through a website, falls under that right of distribution and source code must be disclosed under the same licence.

> **I modified a program under CeCILL and users access it through a Web site. Should I give the source code if one of them asks me so ?**
> 
> Yes, you must. 5.3.2 talks about "distribution" but, as mentioned at the beginning of 5.3, it indeed covers "the right to publish, transmit and communicate the Software to the general public on any or all media and by any or all means". Using a Web site to make the program available to someone else is thus distribution, even if no copy of the program is shipped. Hence the obligation to provide the source code is effective.
- CeCILL official English FAQ
