### PR TITLE
Add License: FPA General Code License

### DIFF
--- a/_licenses/fpa.txt
+++ b/_licenses/fpa.txt
@@ -1,0 +1,44 @@
+---
+title: Fairfield Programming Association
+spdx-id: FPA
+featured: false
+hidden: false
+
+description: A permissive license whose main conditions require preservation of copyright and significant modification for commercial use. All rights within educational and personal contexts are in the permissively worded MIT-style of license. 
+
+how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file.
+
+note: The Fairfield Programming Association <a href="https://about.fairfieldprogramming.org/licenses/code/">states</a> that modifications to the license are allowed but should be done by legal professionals. 
+
+using:
+  Kubernetes: https://github.com/kubernetes/kubernetes/blob/master/LICENSE
+  PDF.js: https://github.com/mozilla/pdf.js/blob/master/LICENSE
+  Swift: https://github.com/apple/swift/blob/main/LICENSE.txt
+
+permissions:
+  - modifications
+  - distribution
+  - private-use
+
+conditions:
+  - include-copyright
+  - document-changes
+
+limitations:
+  - trademark-use
+  - liability
+  - warranty
+
+---
+
+Copyright <YEAR> <COPYRIGHT HOLDER>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without limitation in the rights to use, copy, modify, merge, publish, and/ or distribute copies of the Software in an educational or personal context, subject to the following conditions: 
+
+- The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+Permission is granted to sell and/ or distribute copies of the Software in a commercial context, subject to the following conditions:
+
+- Substantial changes: adding, removing, or modifying large parts, shall be developed in the Software. Reorganizing logic in the software does not warrant a substantial change. 
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.


### PR DESCRIPTION
Reference to the Fairfield Programming Association General Code License can be found here: https://about.fairfieldprogramming.org/licenses/code. 

The main benefit is that it separates the conditions between educational/ personal use and commercial use. The condition included in the commercial use section is significant modification- to prevent asset rips which are a problem in certain open source communities. 