### PR TITLE
Add "Modified" nickname to BSD-3-Clause

### DIFF
--- a/_licenses/bsd-3-clause.txt
+++ b/_licenses/bsd-3-clause.txt
@@ -1,6 +1,7 @@
 ---
 title: BSD 3-Clause "New" or "Revised" License
 spdx-id: BSD-3-Clause
+nickname: Modified BSD License
 hidden: false
 
 description: A permissive license similar to the <a href="/licenses/bsd-2-clause/">BSD 2-Clause License</a>, but with a 3rd clause that prohibits others from using the name of the copyright holder or its contributors to promote derived products without written consent.


### PR DESCRIPTION
Note it has a number of nicknames https://en.wikipedia.org/wiki/BSD_licenses#3-clause_license_(%22BSD_License_2.0%22,_%22Revised_BSD_License%22,_%22New_BSD_License%22,_or_%22Modified_BSD_License%22) the first two of which are captured in the current title.

This change will facilitate matching a semi-common markup version, see https://github.com/licensee/licensee/pull/578