### PR TITLE
Add W3C software and document license (2023-01-01)

### DIFF
--- a/_licenses/w3c-20230101.txt
+++ b/_licenses/w3c-20230101.txt
@@ -1,0 +1,69 @@
+---
+title: W3C Software and Document license (2023-01-01)
+spdx-id: W3C-20230101
+
+description: This license is used by W3C working groups and community groups for licensing software and documents related to web standards and specifications.
+
+how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file. Alternatively, you can have the LICENSE file link to the URL: https://www.w3.org/copyright/software-license-2023/
+
+using:
+  ActivityStreams: https://github.com/w3c/activitystreams
+  WebAuthn: https://github.com/w3c/webauthn/blob/main/LICENSE.md
+  WCAG: https://github.com/w3c/wcag/blob/main/LICENSE.md
+
+permissions:
+  - commercial-use
+  - modifications
+  - distribution
+  - patent-use
+  - private-use
+
+conditions:
+  - disclose-source
+  - include-copyright
+  - same-license--file
+
+limitations:
+  - liability
+  - trademark-use
+  - warranty
+---
+
+This work is being provided by the copyright holders under the following
+license.
+
+License
+By obtaining and/or copying this work, you (the licensee) agree that
+you have read, understood, and will comply with the following terms and
+conditions.
+
+Permission to copy, modify, and distribute this work, with or without
+modification, for any purpose and without fee or royalty is hereby granted,
+provided that you include the following on ALL copies of the work or portions
+thereof, including modifications:
+
+   • The full text of this NOTICE in a location viewable to users of the
+     redistributed or derivative work.
+   • Any pre-existing intellectual property disclaimers, notices, or terms
+     and conditions. If none exist, the W3C software and document short
+     notice should be included.
+   • Notice of any changes or modifications, through a copyright statement
+     on the new code or document such as "This software or document includes
+     material copied from or derived from [title and URI of the W3C
+     document]. Copyright © [$year-of-document] World Wide Web Consortium.
+     https://www.w3.org/copyright/software-license-2023/"
+
+Disclaimers
+THIS WORK IS PROVIDED "AS IS," AND COPYRIGHT HOLDERS MAKE NO REPRESENTATIONS
+OR WARRANTIES, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO, WARRANTIES OF
+MERCHANTABILITY OR FITNESS FOR ANY PARTICULAR PURPOSE OR THAT THE USE OF THE
+SOFTWARE OR DOCUMENT WILL NOT INFRINGE ANY THIRD PARTY PATENTS, COPYRIGHTS,
+TRADEMARKS OR OTHER RIGHTS.
+
+COPYRIGHT HOLDERS WILL NOT BE LIABLE FOR ANY DIRECT, INDIRECT, SPECIAL OR
+CONSEQUENTIAL DAMAGES ARISING OUT OF ANY USE OF THE SOFTWARE OR DOCUMENT.
+
+The name and trademarks of copyright holders may NOT be used in advertising 
+or publicity pertaining to the work without specific, written prior 
+permission. Title to copyright in this work will at all times remain with
+copyright holders.

--- a/_licenses/w3c-20230101.txt
+++ b/_licenses/w3c-20230101.txt
@@ -4,7 +4,7 @@ spdx-id: W3C-20230101
 
 description: This license is used by W3C working groups and community groups for licensing software and documents related to web standards and specifications.
 
-how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file. Alternatively, you can have the LICENSE file link to the URL: https://www.w3.org/copyright/software-license-2023/
+how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file. Alternatively, you can have the LICENSE file link to https://www.w3.org/copyright/software-license-2023/
 
 using:
   ActivityStreams: https://github.com/w3c/activitystreams


### PR DESCRIPTION
Whilst previous W3C licenses are in the SPDX repository, the 2023-01-01 license version was not yet, there's an open pull request for that here: https://github.com/spdx/license-list-XML/pull/2269

As all the W3C groups tend to use GitHub for specification work, being able to select from the "Add a license" dropdown the latest W3C license is quite useful. A code-search for W3C in license files showed [49k code matches and 4k repositories](https://github.com/search?q=W3C+path%3ALICENSE&type=code). 

The link `https://spdx.org/spdx-license-list/request-new-license` appears to be broken, so I sent a PR to the spdx repository, hopefully that's the correct process.

The previous version of this license is on the OSI's license list, the current version is not (I suspect just because it's not been updated?) https://opensource.org/license/w3c/ — I have tried to reach out to appropriate people at the W3C to follow the OSI's fairly lengthy process for updating their license.