### PR TITLE
Improve dark mode contrast on licenses page

### DIFF
--- a/assets/css/application.scss
+++ b/assets/css/application.scss
@@ -15,36 +15,36 @@ body {
     background: #212121;
     color: #d0c8c1;
   }
-  
+
   h1, h2, h3, h5 {
     color: #dadada !important;
   }
-  
+
   .site-footer {
-    color: #ccc !important; 
+    color: #ccc !important;
   }
-  
+
   .site-footer a {
-    color: #ddd !important; 
+    color: #ddd !important;
   }
-  
+
   .home h2 {
     color: #c7cdce !important;
   }
-  
+
   .license-body pre {
     background-color: #131313 !important;
     border: 1px solid #3e3e3e !important;
   }
-  
+
   .note {
     color: #9fa5a6 !important;
   }
-  
+
   strong {
     color: #bdbdbd !important;
   }
-  
+
   button, input, optgroup, select, textarea {
     color: black !important;
   }

--- a/assets/css/application.scss
+++ b/assets/css/application.scss
@@ -24,7 +24,7 @@ body {
     color: #ccc !important;
   }
 
-  .site-footer a {
+  .license-rules li:hover, .site-footer a {
     color: #ddd !important;
   }
 

--- a/assets/css/application.scss
+++ b/assets/css/application.scss
@@ -20,7 +20,7 @@ body {
     color: #dadada !important;
   }
 
-  .site-footer {
+  .license-overview-description, .site-footer {
     color: #ccc !important;
   }
 

--- a/script/check-approval
+++ b/script/check-approval
@@ -55,7 +55,7 @@ current = license_ids.include?(license)
 rows << ['Current license', current]
 
 rows << :separator
-eligible = (!current && spdx && approved_licenses.include?(license))
+eligible = !current && spdx && approved_licenses.include?(license)
 rows << ['Eligible', eligible]
 
 puts Terminal::Table.new title: "License: #{license}", rows: rows


### PR DESCRIPTION
I decided to use the footer color because they uses the same color on light mode

before:
![image](https://github.com/github/choosealicense.com/assets/10087890/1c8de1b0-0156-484a-9d1c-b1c38b72129e)

after:
![image](https://github.com/github/choosealicense.com/assets/10087890/5ce754be-9660-4e73-9e9b-237828bb6fb9)

also [remove unnecessary spaces](https://github.com/github/choosealicense.com/commit/0f4b11105153fdd0a76f60b0ef2715bc9f1bbb1b)
(the spaces was auto removed from my VSCode)