### PR TITLE
Implement static URIs for licenses

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ assets/vendor/hint.css/src
 /tmp
 Gemfile.lock
 .jekyll-metadata
+raw

--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -1,6 +1,8 @@
 <div class="sidebar">
 
   <a href="#" data-clipboard-target="#license-text" data-proofer-ignore="true" class="js-clipboard-button button">Copy license text to clipboard</a>
+  <pre>https://choosealicense.com/raw/{{ page.spdx-id | downcase }}</pre>
+
   {% unless page.spdx-id == 'LGPL-3.0' %}
   <h3 id="suggest-this-license">Suggest this license</h3>
   <div class="repository-suggestion">

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -2,6 +2,11 @@
 
 set -e
 
+echo "copy licenses"
+
+mkdir raw
+for file in _licenses/*.txt; do cp "$file" "raw/$(basename "$file" .txt)"; done
+
 echo "bundling installin'"
 gem install bundler
 bundle install


### PR DESCRIPTION
This would close #1176.
This pull request includes changes to serve the raw text under a static URI.