### PR TITLE
Raw static url

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
+  contents: write
   pages: write
   id-token: write
 

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -42,6 +42,7 @@ jobs:
       - name: Print pwd
         run: |
           pwd
+          ls
       - name: Build static licenses
         run: |
           chmod +x ./script/build.sh

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -40,9 +40,10 @@ jobs:
         env:
           JEKYLL_ENV: production
       - name: Build static licenses
-        run: |
-          mkdir "${{ steps.pages.outputs.base_path }}"
-          cp ./_licenses/* "${{ steps.pages.outputs.base_path }}"
+        uses: actions/upload-artifact@v2
+        with:
+          name: licenses
+          path: _licenses
       - name: Upload artifact
         # Automatically uploads an artifact from the './_site' directory by default
         uses: actions/upload-pages-artifact@v3

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -41,8 +41,7 @@ jobs:
           JEKYLL_ENV: production
       - name: Build static licenses
         run: |
-          mkdir "${{ steps.pages.outputs.base_path }}"/raw -p
-          cp -r ./_licenses/ "${{ steps.pages.outputs.base_path }}"/raw 
+          cp ./_licenses/* "${{ steps.pages.outputs.base_path }}"
       - name: Upload artifact
         # Automatically uploads an artifact from the './_site' directory by default
         uses: actions/upload-pages-artifact@v3

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -39,13 +39,9 @@ jobs:
         run: bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}"
         env:
           JEKYLL_ENV: production
-      - name: Print pwd
-        run: |
-          pwd
-          ls
       - name: Build static licenses
         run: |
-          chmod +x ./script/build.sh
+          chmod +x ./script/build
           ./script/build "${{ steps.pages.outputs.base_path }}"
       - name: Upload artifact
         # Automatically uploads an artifact from the './_site' directory by default

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,54 @@
+name: Deploy Jekyll site to Pages
+
+on:
+  push:
+    branches: ["gh-pages", "rawStaticUrl"]
+
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@8575951200e472d5f2d95c625da0c7bec8217c42 # v1.161.0
+        with:
+          ruby-version: '3.1' # Not needed with a .ruby-version file
+          bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+          cache-version: 0 # Increment this number if you need to re-download cached gems
+      - name: Setup Pages
+        id: pages
+        uses: actions/configure-pages@v4
+      - name: Build with Jekyll
+        # Outputs to the './_site' directory by default
+        run: bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}"
+        env:
+          JEKYLL_ENV: production
+      - name: Upload artifact
+        # Automatically uploads an artifact from the './_site' directory by default
+        uses: actions/upload-pages-artifact@v3
+
+  # Deployment job
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -41,6 +41,7 @@ jobs:
           JEKYLL_ENV: production
       - name: Build static licenses
         run: |
+          mkdir "${{ steps.pages.outputs.base_path }}"
           cp ./_licenses/* "${{ steps.pages.outputs.base_path }}"
       - name: Upload artifact
         # Automatically uploads an artifact from the './_site' directory by default

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -39,6 +39,9 @@ jobs:
         run: bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}"
         env:
           JEKYLL_ENV: production
+      - name: Print pwd
+        run: |
+          pwd
       - name: Build static licenses
         run: |
           chmod +x ./script/build.sh

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -39,6 +39,10 @@ jobs:
         run: bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}"
         env:
           JEKYLL_ENV: production
+      - name: Build static licenses
+        run: |
+          chmod +x ./script/build.sh
+          ./script/build "${{ steps.pages.outputs.base_path }}"
       - name: Upload artifact
         # Automatically uploads an artifact from the './_site' directory by default
         uses: actions/upload-pages-artifact@v3

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -39,14 +39,10 @@ jobs:
         run: bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}"
         env:
           JEKYLL_ENV: production
-      - name: Build static licenses
-        uses: actions/upload-artifact@v2
-        with:
-          name: licenses
-          path: _licenses
       - name: Copy licenses into ./_site
         run: |
-          cp _licenses/* _site/
+          chmod +x script/build
+          ./script/build
       - name: Upload artifact
         # Automatically uploads an artifact from the './_site' directory by default
         uses: actions/upload-pages-artifact@v3

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -42,8 +42,11 @@ jobs:
       - name: Build static licenses
         uses: actions/upload-artifact@v2
         with:
-          name: github-pages/licenses
+          name: licenses
           path: _licenses
+      - name: Copy licenses into ./_site
+        run: |
+          cp _licenses/* _site/
       - name: Upload artifact
         # Automatically uploads an artifact from the './_site' directory by default
         uses: actions/upload-pages-artifact@v3

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -20,6 +20,8 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      PAGES_REPO_NWO: Dlurak/choosealicense.com
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -41,8 +41,8 @@ jobs:
           JEKYLL_ENV: production
       - name: Build static licenses
         run: |
-          chmod +x ./script/build
-          ./script/build "${{ steps.pages.outputs.base_path }}"
+          mkdir "${{ steps.pages.outputs.base_path }}"/raw -p
+          cp -r ./_licenses/ "${{ steps.pages.outputs.base_path }}"/raw 
       - name: Upload artifact
         # Automatically uploads an artifact from the './_site' directory by default
         uses: actions/upload-pages-artifact@v3

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Build static licenses
         uses: actions/upload-artifact@v2
         with:
-          name: licenses
+          name: github-pages/licenses
           path: _licenses
       - name: Upload artifact
         # Automatically uploads an artifact from the './_site' directory by default

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ assets/vendor/hint.css/src
 /tmp
 Gemfile.lock
 .jekyll-metadata
+raw

--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -1,6 +1,8 @@
 <div class="sidebar">
 
   <a href="#" data-clipboard-target="#license-text" data-proofer-ignore="true" class="js-clipboard-button button">Copy license text to clipboard</a>
+  <pre>https://choosealicense.com/raw/{{ page.spdx-id | downcase }}</pre>
+
   {% unless page.spdx-id == 'LGPL-3.0' %}
   <h3 id="suggest-this-license">Suggest this license</h3>
   <div class="repository-suggestion">

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -2,11 +2,6 @@
 
 set -e
 
-echo "copy licenses"
-
-mkdir raw
-for file in _licenses/*.txt; do cp "$file" "raw/$(basename "$file" .txt)"; done
-
 echo "bundling installin'"
 gem install bundler
 bundle install

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -2,6 +2,11 @@
 
 set -e
 
+echo "copy licenses"
+
+mkdir raw
+for file in _licenses/*.txt; do cp "$file" "raw/$(basename "$file" .txt)"; done
+
 echo "bundling installin'"
 gem install bundler
 bundle install

--- a/script/build
+++ b/script/build
@@ -4,5 +4,5 @@ mkdir _site/raw -p
 
 for file in _licenses/*.txt; do
 	echo "$file"
-	cp "$file" "_site/raw/$(basename "$file" .txt)"
+	awk '/^---$/ {if (++count == 2) {p=1; next}} p' "$file" | tail -n +2 > "_site/raw/$(basename "$file" .txt)"
 done

--- a/script/build
+++ b/script/build
@@ -1,0 +1,5 @@
+echo "copy licenses"
+
+mkdir $1/raw
+
+for file in _licenses/*.txt; do cp "$file" "$1/raw/$(basename "$file" .txt)"; done

--- a/script/build
+++ b/script/build
@@ -1,6 +1,5 @@
 echo "copy licenses"
 
-echo "$1"
-mkdir $1/raw -p
+mkdir _site/raw -p
 
-for file in _licenses/*.txt; do cp "$file" "$1/raw/$(basename "$file" .txt)"; done
+for file in _licenses/*.txt; do cp "$file" "_site/raw/$(basename "$file" .txt)"; done

--- a/script/build
+++ b/script/build
@@ -1,5 +1,6 @@
 echo "copy licenses"
 
-mkdir $1/raw
+echo "$1"
+mkdir $1/raw -p
 
 for file in _licenses/*.txt; do cp "$file" "$1/raw/$(basename "$file" .txt)"; done

--- a/script/build
+++ b/script/build
@@ -2,4 +2,7 @@ echo "copy licenses"
 
 mkdir _site/raw -p
 
-for file in _licenses/*.txt; do cp "$file" "_site/raw/$(basename "$file" .txt)"; done
+for file in _licenses/*.txt; do
+	echo "$file"
+	cp "$file" "_site/raw/$(basename "$file" .txt)"
+done


### PR DESCRIPTION
First of all I really want to apologize for all of those commits with horrific messages, but I needed them to run the GitHub-Actions.  
The deployment to GitHub Pages now uses a GitHub-Action. Jekyll builds its static HTML-Files into an artifact and modified versions of the licenses are copied into the same artifact.  
To prove that it works I created a own GitHub-Pages deployment which you can find [here](https://dlurak.github.io/choosealicense.com/raw/mit).

This solves #1177 .