### PR TITLE
LICENSE: update copyright year

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
-Copyright (c) 2013-2023 GitHub, Inc. and contributors
+Copyright (c) 2013-2024 GitHub, Inc. and contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Commits to this repository have been made in 2024, but present copyright date range ends at 2023. This PR updates the date range to include the current year.

Should the copyright date range be removed to prevent this file requiring yearly modification in the future?
* Microsoft licenses on GitHub omit dates in their copyright notices (e.g., https://github.com/dotnet/runtime/blob/main/LICENSE.TXT)
* In contrast, GitHub's "new project" web interface adds the date into new licenses by default. 
* This topic is not addressed on https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/licensing-a-repository but perhaps it should be. It would be fantastic to get input from someone who is an expert in this topic!