### PR TITLE
limit workflow permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,6 @@
 name: Build and Test
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
I think only read of git contents is needed to run tests.