### PR TITLE
Fix hard wrap inconsistency for GNU Affero General Public License v3.0

### DIFF
--- a/_licenses/agpl-3.0.txt
+++ b/_licenses/agpl-3.0.txt
@@ -671,8 +671,8 @@ the "copyright" line and a pointer to where the full notice is found.
     Copyright (C) <year>  <name of author>
 
     This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU Affero General Public License as published
-    by the Free Software Foundation, either version 3 of the License, or
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
     (at your option) any later version.
 
     This program is distributed in the hope that it will be useful,


### PR DESCRIPTION
Fixes the hard wrapping for the word "by" not matching with the [text version of GNU Affero General Public License v3.0](https://www.gnu.org/licenses/agpl-3.0.txt).

The license for AGPL-3.0 wraps the word "by" when in the official text version, it is not wrapped onto a new line. This PR fixes that inconsistency. Low impact and usually not noticeable but we should be consistent with official sources.