### PR TITLE
Show muted colors for conditions in legend

### DIFF
--- a/appendix.md
+++ b/appendix.md
@@ -87,7 +87,17 @@ If you're here to choose a license, **[start from the home page](/)** to see a f
       {% assign rs = site.data.rules[t] | sort: "label" %}
       {% for r in rs %}
         {% if r.tag == req %}
-          <dd class="license-{{t}}"><span class="license-sprite"></span> {{ r.description }}</dd>
+          {% if r.tag contains "--" %}
+            {% assign lite = " lite" %}
+          {% else %}
+            {% assign lite = "" %}
+          {% endif %}
+          <dd class="license-{{t}}">
+            <span class="{{ r.tag | append: lite }}">
+              <span class="license-sprite {{ r.tag }}"></span>
+            </span>
+            {{ r.description }}
+          </dd>
         {% endif %}
       {% endfor %}
     {% endfor %}

--- a/assets/css/application.scss
+++ b/assets/css/application.scss
@@ -464,7 +464,7 @@ strong {
 
 
 /* Hint.css Overide */
-.orverride-hint-inline {
+.override-hint-inline {
   display: block;
 }
 

--- a/assets/js/app.coffee
+++ b/assets/js/app.coffee
@@ -40,14 +40,15 @@ class Choosealicense
     # Dynamically add annotations as title attribute to rule list items
     for ruletype, rules of window.annotations
       for rule in rules
-        licenseLiElement = $(".license-#{ruletype} .#{rule["tag"]}")
+        # Only select license elements in table, not legend
+        licenseLiElement = $("td.license-#{ruletype} .#{rule["tag"]}")
         tooltipAttr = @tooltipAttributesMapperByRuleType[ruletype]
         licenseLiElement.attr "aria-label", "#{tooltipAttr.heading}: #{rule.description}"
         licenseLiElement.addClass("hint--bottom
                                    hint--large
                                    hint--no-animate
                                    #{tooltipAttr.color}
-                                   orverride-hint-inline")
+                                   override-hint-inline")
 
   # Initializes Clipboard.js
   initClipboard: ->


### PR DESCRIPTION
As per discussion in #1256.

This PR adds the same classes for the different license conditions so that the colours match what is shown in the table.

<img width="938" alt="image" src="https://github.com/user-attachments/assets/bc962a6a-0160-4305-bbc9-8ab27e78c906">
