### PR TITLE
Fix tooltips not showing up on license page and add rule label to tooltips

### DIFF
--- a/assets/js/app.coffee
+++ b/assets/js/app.coffee
@@ -40,8 +40,8 @@ class Choosealicense
     # Dynamically add annotations as title attribute to rule list items
     for ruletype, rules of window.annotations
       for rule in rules
-        # Only select license elements in table, not legend
-        licenseLiElement = $("td.license-#{ruletype} .#{rule["tag"]}")
+        # Exclude license elements in the legend
+        licenseLiElement = $(".license-#{ruletype} .#{rule["tag"]}").not("dd.license-#{ruletype} .#{rule["tag"]}")
         tooltipAttr = @tooltipAttributesMapperByRuleType[ruletype]
         licenseLiElement.attr "aria-label", "#{tooltipAttr.heading}: #{rule.description}"
         licenseLiElement.addClass("hint--bottom

--- a/assets/js/app.coffee
+++ b/assets/js/app.coffee
@@ -43,7 +43,7 @@ class Choosealicense
         # Exclude license elements in the legend
         licenseLiElement = $(".license-#{ruletype} .#{rule["tag"]}").not("dd.license-#{ruletype} .#{rule["tag"]}")
         tooltipAttr = @tooltipAttributesMapperByRuleType[ruletype]
-        licenseLiElement.attr "aria-label", "#{tooltipAttr.heading}: #{rule.description}"
+        licenseLiElement.attr "aria-label", "#{rule.label} #{tooltipAttr.heading.toLowerCase()}: #{rule.description}"
         licenseLiElement.addClass("hint--bottom
                                    hint--large
                                    hint--no-animate


### PR DESCRIPTION
Follow-up for #1257 that broke the tooltips not showing up anymore in other places.

Also adds the rule label to tooltips.