### PR TITLE
Mention that Chyrp Lite uses the BSD 3-Clause license

### DIFF
--- a/_licenses/bsd-3-clause.txt
+++ b/_licenses/bsd-3-clause.txt
@@ -12,6 +12,7 @@ using:
   Flutter: https://github.com/flutter/flutter/blob/master/LICENSE
   LevelDB: https://github.com/google/leveldb/blob/master/LICENSE
   Quill: https://github.com/quilljs/quill/blob/develop/LICENSE
+  Chyrp Lite: https://chyrplite.net/
 
 permissions:
   - commercial-use


### PR DESCRIPTION
See title.
Chyrp uses the _BSD 3-Clause “New” or “Revised” License_, and I thought it would be helpful to put a link to them here.
Does not affect functionality.