### PR TITLE
Fix repository url parser in LicenseSuggestion

### DIFF
--- a/assets/js/app.coffee
+++ b/assets/js/app.coffee
@@ -112,7 +112,7 @@ class LicenseSuggestion
 
   # Try to extract the repository full name from the user input
   parseUserInput: (userInput) ->
-    repository = /https?:\/\/github\.com\/([^\/]+)\/([^\/]+)\/?$/.exec userInput
+    repository = /https?:\/\/github\.com\/([^\/]+)\/([^\/]+)/.exec userInput
     [_, username, project] = repository
     return username + '/' + project.replace /(\.git)$/, ''
 

--- a/assets/js/app.coffee
+++ b/assets/js/app.coffee
@@ -112,14 +112,9 @@ class LicenseSuggestion
 
   # Try to extract the repository full name from the user input
   parseUserInput: (userInput) ->
-    repository = /https?:\/\/github\.com\/(.*?)\/(.+)(\.git)?$/.exec userInput
+    repository = /https?:\/\/github\.com\/([^\/]+)\/([^\/]+)\/?$/.exec userInput
     [_, username, project] = repository
-    project = project
-      .split /\/|\.git/
-      .filter (str) -> str
-      .slice 0, 1
-      .join ""
-    return username + '/' + project
+    return username + '/' + project.replace /(\.git)$/, ''
 
   # Displays an indicator and tooltips to the user about the current status
   setStatus: (status="", message="") =>

--- a/assets/js/app.coffee
+++ b/assets/js/app.coffee
@@ -112,7 +112,7 @@ class LicenseSuggestion
 
   # Try to extract the repository full name from the user input
   parseUserInput: (userInput) ->
-    repository = /https?:\/\/github\.com\/([^\/]+)\/([^\/]+)/.exec userInput
+    repository = /https?:\/\/github\.com\/([^\/]+)\/([^\/\?#]+)/.exec userInput
     [_, username, project] = repository
     return username + '/' + project.replace /(\.git)$/, ''
 


### PR DESCRIPTION
Update regex. Replace `String.split` with `String.replace` to trim ".git" suffix.

Fixes #1278 