### PR TITLE
Remove invalid html tags inside hint.css tooltips

### DIFF
--- a/_licenses/cern-ohl-p-2.0.txt
+++ b/_licenses/cern-ohl-p-2.0.txt
@@ -7,7 +7,7 @@ description: A permissive license for hardware designs, with conditions only req
 
 how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file.
 
-note: 'CERN <a href="https://ohwr.org/project/cernohl/wikis/uploads/8a6b5d01f71c207c49493e4d114d61e6/cern_ohl_p_v2_howto.pdf">recommends</a> adding the following information in the source files: copyright and license notice, a disclaimer of warranties and a source location. You can also include the source location in a part of the design which will be visible in the end product.'
+note: 'CERN <a href="https://gitlab.com/ohwr/project/cernohl/-/wikis/uploads/8a6b5d01f71c207c49493e4d114d61e6/cern_ohl_p_v2_howto.pdf">recommends</a> adding the following information in the source files: copyright and license notice, a disclaimer of warranties and a source location. You can also include the source location in a part of the design which will be visible in the end product.'
 
 using:
   tedium: https://github.com/jboone/tedium/blob/master/LICENSE-CERN-OHL-P-v2

--- a/_licenses/cern-ohl-s-2.0.txt
+++ b/_licenses/cern-ohl-s-2.0.txt
@@ -7,7 +7,7 @@ description: Permissions of this strongly reciprocal license for hardware design
 
 how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file.
 
-note: 'CERN <a href="https://ohwr.org/project/cernohl/wikis/uploads/cf37727497ca2b5295a7ab83a40fcf5a/cern_ohl_s_v2_user_guide.pdf">recommends</a> adding the following information in the source files: copyright and license notice, a disclaimer of warranties and a source location. You can also include the source location in a part of the design which will be visible in the end product.'
+note: 'CERN <a href="https://gitlab.com/ohwr/project/cernohl/-/wikis/uploads/cf37727497ca2b5295a7ab83a40fcf5a/cern_ohl_s_v2_user_guide.pdf">recommends</a> adding the following information in the source files: copyright and license notice, a disclaimer of warranties and a source location. You can also include the source location in a part of the design which will be visible in the end product.'
 
 using:
   USB Armory: https://github.com/f-secure-foundry/usbarmory/blob/master/hardware/mark-two/LICENSE

--- a/_licenses/cern-ohl-w-2.0.txt
+++ b/_licenses/cern-ohl-w-2.0.txt
@@ -10,7 +10,7 @@ how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of 
 note: 'CERN <a href="https://ohwr.org/project/cernohl/wikis/uploads/c2e5e9d297949b5c2d324a6cbf6adda0/cern_ohl_w_v2_howto.pdf">recommends</a> adding the following information in the source files: copyright and license notice, a disclaimer of warranties and a source location. You can also include the source location in a part of the design which will be visible in the end product.'
 
 using:
-  Simple PCIe FMC carrier: https://ohwr.org/project/spec/blob/master/LICENSES/CERN-OHL-W-2.0.txt
+  Simple PCIe FMC carrier: https://gitlab.com/ohwr/project/spec/blob/master/LICENSES/CERN-OHL-W-2.0.txt
   GProcessor8Bits: https://github.com/JonathSpirit/GP8B/blob/master/LICENSE
   FPGA Cores: https://github.com/suoto/fpga_cores/blob/master/LICENSE
 

--- a/_licenses/cern-ohl-w-2.0.txt
+++ b/_licenses/cern-ohl-w-2.0.txt
@@ -7,7 +7,7 @@ description: Permissions of this weakly-reciprocal license are conditioned on ma
 
 how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file.
 
-note: 'CERN <a href="https://ohwr.org/project/cernohl/wikis/uploads/c2e5e9d297949b5c2d324a6cbf6adda0/cern_ohl_w_v2_howto.pdf">recommends</a> adding the following information in the source files: copyright and license notice, a disclaimer of warranties and a source location. You can also include the source location in a part of the design which will be visible in the end product.'
+note: 'CERN <a href="https://gitlab.com/ohwr/project/cernohl/-/wikis/uploads/c2e5e9d297949b5c2d324a6cbf6adda0/cern_ohl_w_v2_howto.pdf">recommends</a> adding the following information in the source files: copyright and license notice, a disclaimer of warranties and a source location. You can also include the source location in a part of the design which will be visible in the end product.'
 
 using:
   Simple PCIe FMC carrier: https://gitlab.com/ohwr/project/spec/blob/master/LICENSES/CERN-OHL-W-2.0.txt

--- a/assets/js/app.coffee
+++ b/assets/js/app.coffee
@@ -144,9 +144,9 @@ class LicenseSuggestion
       callback null, info
     .fail (e) ->
       if e.status == 404
-        callback new Error "Repository <b>#{repositoryFullName}</b> not found."
+        callback new Error "Repository #{repositoryFullName} not found."
       else
-        callback new Error "Network error when trying to get information about <b>#{repositoryFullName}</b>."
+        callback new Error "Network error when trying to get information about #{repositoryFullName}."
 
   # Generates a message showing that a repository is already licensed
   repositoryLicense: (repositoryFullName, license) ->

--- a/spec/license_meta_spec.rb
+++ b/spec/license_meta_spec.rb
@@ -52,7 +52,7 @@ describe 'license meta' do
               example_url.gsub!(%r{/tree/}, '/plain/')
             elsif example_url.start_with?('https://bitbucket.org/')
               example_url.gsub!(%r{/src/}, '/raw/')
-            elsif example_url.start_with?('https://ohwr.org/')
+            elsif example_url.start_with?('https://gitlab.com/')
               example_url.gsub!(%r{/blob/}, '/raw/')
             end
 


### PR DESCRIPTION
html tags are not supported in tooltips after #1141 . This pr removes invalid tags.