### PR TITLE
Fix tooltip color contrast to meet WCAG standards

### DIFF
--- a/assets/css/application.scss
+++ b/assets/css/application.scss
@@ -490,7 +490,7 @@ strong {
 
 .tooltip--permissions:after{
   background-color: #d8f4d7;
-  color: #298625;
+  color: #1a5818;
   border-color: #3dc637;
 }
 


### PR DESCRIPTION
Updated tooltip text color for the permissions hover tooltip to improve readability. The previous color #298625 had a contrast ratio of 3.93 against background #d8f4d7, below both WCAG AA (4.0) and AAA (7.0) standards. The new color provides a contrast ratio of 7.27, ensuring better accessibility.