### PR TITLE
Change to recomment ISC over MIT license

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,10 +32,10 @@ permalink: /
       <h3>I want it simple and permissive.</h3>
     </a>
     <p>
-      The <a href="licenses/mit/">MIT License</a> is short and to the point. It lets people do almost anything they want with your project, like making and distributing closed source versions.
+      The <a href="licenses/isc/">ISC License</a> is short and to the point. It lets people do almost anything they want with your project, like making and distributing closed source versions (ISC is the modern version of the older MIT license).
     </p>
     <p>
-      {% include using-sentence.html license-id="mit" %}
+      {% include using-sentence.html license-id="isc" %}
     </p>
   </li>
   <li class="copyleft">


### PR DESCRIPTION
Rationale:

The ISC license is functionally identical to the MIT and Simplified BSD licenses but excels in legal brevity: ISC is approx. 100 words, whereas MIT is approx. 170.

While established, the MIT license contains language specific to the Massachusetts Institute of Technology’s 1980s policies. It includes a specific grant for "sublicensing" that many legal scholars argue is redundant if the license already allows users to "deal in the software without restriction."

The Internet Systems Consortium (ISC) removed this and other unnecessary wording made redundant by the global adoption of the Berne Convention.

Bottom Line: ISC is essentially a stripped-down, modern refinement of the MIT license.