### PR TITLE
Add AGPL badge to AGPL page

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Licenses sit in the `/_licenses` folder. Each license has YAML front matter desc
 * `featured` - Whether the license should be featured on the main page (defaults to false)
 * `hidden` - Whether the license is neither [popular](https://opensource.org/licenses) nor fills out the [spectrum of licenses](https://choosealicense.com/licenses/) from strongly conditional to unconditional (defaults to true)
 * `nickname` - Customary short name if applicable (e.g, GPLv3)
+* `badge` - Optional rendered badge metadata (`alt`, `image`, and `href`) displayed near the license heading
 * `note` - Additional information about the licenses
 * `redirect_from` - Relative path(s) to redirect to the license from, to prevent breaking old URLs
 

--- a/_layouts/license.html
+++ b/_layouts/license.html
@@ -10,6 +10,14 @@
             </p>
             {% endif %}
 
+            {% if page.badge %}
+            <p class="license-badge">
+                <a href="{{ page.badge.href }}">
+                    <img src="{{ page.badge.image }}" alt="{{ page.badge.alt }}">
+                </a>
+            </p>
+            {% endif %}
+
             <p>
                 {{ page.description }}
             </p>

--- a/_licenses/agpl-3.0.txt
+++ b/_licenses/agpl-3.0.txt
@@ -4,6 +4,10 @@ spdx-id: AGPL-3.0
 nickname: GNU AGPLv3
 redirect_from: /licenses/agpl/
 hidden: false
+badge:
+  alt: "License: AGPL v3"
+  image: https://img.shields.io/badge/License-AGPL%20v3-blue.svg
+  href: https://choosealicense.com/licenses/agpl-3.0/
 
 description: Permissions of this strongest copyleft license are conditioned on making available complete source code of licensed works and modifications, which include larger works using a licensed work, under the same license. Copyright and license notices must be preserved. Contributors provide an express grant of patent rights. When a modified version is used to provide a service over a network, the complete source code of the modified version must be made available.
 

--- a/assets/css/application.scss
+++ b/assets/css/application.scss
@@ -372,6 +372,15 @@ strong {
   margin-top: 0;
 }
 
+.license-badge {
+  margin: 0 0 1em;
+  line-height: 1;
+}
+
+.license-badge img {
+  vertical-align: middle;
+}
+
 .sidebar {
   float: right;
   width: 220px;


### PR DESCRIPTION
## Summary
- add optional badge metadata support to the shared license page layout
- add the AGPL v3 shields.io badge to the AGPL-3.0 license metadata
- document the new optional badge front matter field

## Validation
- built the site with bundle exec jekyll build
- confirmed _site/licenses/agpl-3.0/index.html renders the requested badge markup

## Notes
- script/cibuild still hits existing repo-level spec failures in this environment related to missing license-list-XML fixture data and flaky remote fetches, but the Jekyll build succeeds with this change
