### PR TITLE
Fix license metadata, link rot, and Rubocop warnings

### DIFF
--- a/_licenses/bsd-4-clause.txt
+++ b/_licenses/bsd-4-clause.txt
@@ -7,8 +7,8 @@ description: A permissive license similar to the <a href="/licenses/bsd-3-clause
 how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file. Replace [year] with the current year and [fullname] with the name (or names) of the copyright holders. Replace [project] with the project organization, if any, that sponsors this work.
 
 using:
-  Choco-solver: https://github.com/chocoteam/choco-solver/blob/master/LICENSE
   PMSPAUR-public: https://github.com/ArthurGodet/PMSPAUR-public/blob/master/LICENSE
+  Sileo: https://github.com/Sileo/Sileo/blob/main/LICENSE
   Switchblade: https://github.com/SwitchbladeBot/switchblade/blob/dev/LICENSE
 
 permissions:

--- a/_licenses/osl-3.0.txt
+++ b/_licenses/osl-3.0.txt
@@ -6,7 +6,7 @@ description: Permissions of this copyleft license are conditioned on distributin
 
 how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file. Files licensed under OSL 3.0 must also include the notice "Licensed under the Open Software License version 3.0" adjacent to the copyright notice.
 
-note: OSL 3.0's author has <a href="https://rosenlaw.com/OSL3.0-explained.htm">provided an explanation</a> behind the creation of the license.
+note: OSL 3.0's author has <a href="https://web.archive.org/web/20260329122301/https://rosenlaw.com/OSL3.0-explained.htm">provided an explanation</a> behind the creation of the license.
 
 using:
   appserver.io: https://github.com/appserver-io/appserver/blob/master/LICENSE.txt

--- a/_licenses/osl-3.0.txt
+++ b/_licenses/osl-3.0.txt
@@ -6,7 +6,7 @@ description: Permissions of this copyleft license are conditioned on distributin
 
 how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file. Files licensed under OSL 3.0 must also include the notice "Licensed under the Open Software License version 3.0" adjacent to the copyright notice.
 
-note: OSL 3.0's author has <a href="https://web.archive.org/web/20260329122301/https://rosenlaw.com/OSL3.0-explained.htm">provided an explanation</a> behind the creation of the license.
+note: OSL 3.0's author has <a href="https://rosenlaw.com/OSL3.0-explained.htm">provided an explanation</a> behind the creation of the license.
 
 using:
   appserver.io: https://github.com/appserver-io/appserver/blob/master/LICENSE.txt

--- a/_licenses/zlib.txt
+++ b/_licenses/zlib.txt
@@ -32,7 +32,7 @@ zlib License
 (C) [year] [fullname]
 
 This software is provided 'as-is', without any express or implied
-warranty.  In no event will the authors be held liable for any damages
+warranty. In no event will the authors be held liable for any damages
 arising from the use of this software.
 
 Permission is granted to anyone to use this software for any purpose,

--- a/script/check-approval
+++ b/script/check-approval
@@ -13,16 +13,8 @@ require 'fuzzy_match'
 # Display usage instructions
 puts File.read(__FILE__).scan(/^# .*/)[0...3].join("\n").gsub(/^# /, '') if ARGV.count != 1
 
-class TrueClass
-  def to_s
-    'Yes'.green
-  end
-end
-
-class FalseClass
-  def to_s
-    'No'.red
-  end
+def yes_no(value)
+  value ? 'Yes'.green : 'No'.red
 end
 
 license = ARGV[0].downcase.strip
@@ -47,16 +39,16 @@ rows << ['SPDX ID', id]
 rows << ['SPDX Name', name]
 
 approvals.each do |approver, licenses|
-  rows << ["#{approver} approved", licenses.include?(license)]
+  rows << ["#{approver} approved", yes_no(licenses.include?(license))]
 end
 
 license_ids = licenses.map { |l| l['id'] }
 current = license_ids.include?(license)
-rows << ['Current license', current]
+rows << ['Current license', yes_no(current)]
 
 rows << :separator
 eligible = !current && spdx && approved_licenses.include?(license)
-rows << ['Eligible', eligible]
+rows << ['Eligible', yes_no(eligible)]
 
 puts Terminal::Table.new title: "License: #{license}", rows:
 puts

--- a/script/check-approval
+++ b/script/check-approval
@@ -11,7 +11,10 @@ require 'colored'
 require 'fuzzy_match'
 
 # Display usage instructions
-puts File.read(__FILE__).scan(/^# .*/)[0...3].join("\n").gsub(/^# /, '') if ARGV.count != 1
+if ARGV.count != 1
+  puts File.read(__FILE__).scan(/^# .*/)[0...3].join("\n").gsub(/^# /, '')
+  exit 1
+end
 
 def yes_no(value)
   value ? 'Yes'.green : 'No'.red

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -72,9 +72,7 @@ def spdx_list
   SpecHelper.spdx ||= begin
     url = 'https://spdx.org/licenses/licenses.json'
     list = JSON.parse(OpenURI.open_uri(url).read)['licenses']
-    list.each_with_object({}) do |values, memo|
-      memo[values['licenseId']] = values
-    end
+    list.to_h { |values| [values['licenseId'], values] }
   end
 end
 


### PR DESCRIPTION
A handful of small fixes and cleanups:

- **zlib**: Remove subtle extra space in license text (`warranty.  In` → `warranty. In`)
- **BSD-4-Clause**: Replace Choco-solver example (moved to BSD-3-Clause per https://github.com/chocoteam/choco-solver/discussions/1169) with Sileo
- **OSL-3.0**: Point explanation link to Wayback Machine snapshot since rosenlaw.com appears to have expired
- **script/check-approval**: Replace monkey-patched `TrueClass#to_s` / `FalseClass#to_s` with a `yes_no` helper (Rubocop)
- **spec/spec_helper.rb**: Use `Array#to_h` instead of `each_with_object` (Rubocop)

Based on work from #1333.