### PR TITLE
Add MIT X11 License and rename MIT to MIT Expat.

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,4 +115,4 @@ The license properties (rules) are stored as a bulleted list within the licenses
 
 ## License
 
-The content of this project itself is licensed under the [Creative Commons Attribution 3.0 Unported license](https://creativecommons.org/licenses/by/3.0/), and the underlying source code used to format and display that content is licensed under the [MIT license](LICENSE.md).
+The content of this project itself is licensed under the [Creative Commons Attribution 3.0 Unported license](https://creativecommons.org/licenses/by/3.0/), and the underlying source code used to format and display that content is licensed under the [MIT Expat License](LICENSE.md).

--- a/README.md
+++ b/README.md
@@ -115,4 +115,4 @@ The license properties (rules) are stored as a bulleted list within the licenses
 
 ## License
 
-The content of this project itself is licensed under the [Creative Commons Attribution 3.0 Unported license](https://creativecommons.org/licenses/by/3.0/), and the underlying source code used to format and display that content is licensed under the [MIT Expat License](LICENSE.md).
+The content of this project itself is licensed under the [Creative Commons Attribution 4.0 license](https://creativecommons.org/licenses/by/4.0/deed.en), and the underlying source code used to format and display that content is licensed under the [MIT Expat License](LICENSE.md).

--- a/README.md
+++ b/README.md
@@ -115,4 +115,4 @@ The license properties (rules) are stored as a bulleted list within the licenses
 
 ## License
 
-The content of this project itself is licensed under the [Creative Commons Attribution 4.0 license](https://creativecommons.org/licenses/by/4.0/deed.en), and the underlying source code used to format and display that content is licensed under the [MIT Expat License](LICENSE.md).
+The content of this project itself is licensed under the [Creative Commons Attribution 4.0 license](https://creativecommons.org/licenses/by/4.0/), and the underlying source code used to format and display that content is licensed under the [MIT Expat License](LICENSE.md).

--- a/README.md
+++ b/README.md
@@ -115,4 +115,4 @@ The license properties (rules) are stored as a bulleted list within the licenses
 
 ## License
 
-The content of this project itself is licensed under the [Creative Commons Attribution 4.0 license](https://creativecommons.org/licenses/by/4.0/deed.en), and the underlying source code used to format and display that content is licensed under the [MIT Expat License](LICENSE.md).
+The content of this project itself is licensed under the [Creative Commons Attribution 3.0 Unported license](https://creativecommons.org/licenses/by/3.0/), and the underlying source code used to format and display that content is licensed under the [MIT Expat License](LICENSE.md).

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -5,7 +5,7 @@
           {% github_edit_link "Help improve this page" %}
         </nav>
         <p>
-          The content of this site is licensed under the <a href="https://creativecommons.org/licenses/by/3.0/">
+          The content of this site is licensed under the <a href="https://creativecommons.org/licenses/by/4.0/">
           Creative Commons Attribution 4.0 License</a>.
         </p>
         <div class="with-love">

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -6,7 +6,7 @@
         </nav>
         <p>
           The content of this site is licensed under the <a href="https://creativecommons.org/licenses/by/3.0/">
-          Creative Commons Attribution 3.0 Unported License</a>.
+          Creative Commons Attribution 4.0 License</a>.
         </p>
         <div class="with-love">
           Curated with ❤️ by <a href="https://github.com">GitHub, Inc.</a> and <a href="https://github.com/github/choosealicense.com">You!</a>

--- a/_licenses/mit-0.txt
+++ b/_licenses/mit-0.txt
@@ -1,5 +1,5 @@
 ---
-title: MIT Expat No Attribution
+title: MIT (Expat) No Attribution
 spdx-id: MIT-0
 
 description: A short and simple permissive license with no conditions, not even requiring preservation of copyright and license notices. Licensed works, modifications, and larger works may be distributed under different terms and without source code.

--- a/_licenses/mit-0.txt
+++ b/_licenses/mit-0.txt
@@ -25,7 +25,7 @@ limitations:
 
 ---
 
-MIT Expat No Attribution
+MIT (Expat) No Attribution
 
 Copyright [year] [fullname]
 

--- a/_licenses/mit-0.txt
+++ b/_licenses/mit-0.txt
@@ -1,5 +1,5 @@
 ---
-title: MIT No Attribution
+title: MIT Expat No Attribution
 spdx-id: MIT-0
 
 description: A short and simple permissive license with no conditions, not even requiring preservation of copyright and license notices. Licensed works, modifications, and larger works may be distributed under different terms and without source code.
@@ -25,7 +25,7 @@ limitations:
 
 ---
 
-MIT No Attribution
+MIT Expat No Attribution
 
 Copyright [year] [fullname]
 

--- a/_licenses/mit.txt
+++ b/_licenses/mit.txt
@@ -1,5 +1,5 @@
 ---
-title: MIT License
+title: MIT Expat License
 spdx-id: MIT
 featured: true
 hidden: false

--- a/_licenses/mit.txt
+++ b/_licenses/mit.txt
@@ -11,7 +11,7 @@ how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of 
 using:
   Babel: https://github.com/babel/babel/blob/master/LICENSE
   .NET: https://github.com/dotnet/runtime/blob/main/LICENSE.TXT
-  Rails: https://github.com/rails/rails/blob/master/MIT-LICENSE
+  Rails: https://github.com/rails/rails/blob/main/MIT-LICENSE
 
 permissions:
   - commercial-use

--- a/_licenses/mit.txt
+++ b/_licenses/mit.txt
@@ -28,7 +28,7 @@ limitations:
 
 ---
 
-MIT Expat License
+MIT (Expat) License
 
 Copyright (c) [year] [fullname]
 

--- a/_licenses/mit.txt
+++ b/_licenses/mit.txt
@@ -28,7 +28,7 @@ limitations:
 
 ---
 
-MIT License
+MIT Expat License
 
 Copyright (c) [year] [fullname]
 

--- a/_licenses/mit.txt
+++ b/_licenses/mit.txt
@@ -1,5 +1,5 @@
 ---
-title: MIT Expat License
+title: MIT (Expat) License
 spdx-id: MIT
 featured: true
 hidden: false

--- a/_licenses/x11.txt
+++ b/_licenses/x11.txt
@@ -1,0 +1,9 @@
+Copyright (C) <date> <copyright holders>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE X CONSORTIUM BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+Except as contained in this notice, the name of <copyright holders> shall not be used in advertising or otherwise to promote the sale, use or other dealings in this Software without prior written authorization from <copyright holders>.

--- a/_licenses/x11.txt
+++ b/_licenses/x11.txt
@@ -10,7 +10,7 @@ how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of 
 
 using:
   Confy: https://github.com/rust-cli/confy/blob/master/LICENSE-X11
-  .NET: https://github.com/dotnet/runtime/blob/main/LICENSE.TXT
+  libsir: https://github.com/aremmell/libsir/blob/master/LICENSES/X11.txt
   Rails: https://github.com/rails/rails/blob/master/MIT-LICENSE
 
 permissions:

--- a/_licenses/x11.txt
+++ b/_licenses/x11.txt
@@ -1,8 +1,8 @@
 ---
 title: X11 License
 spdx-id: X11
-featured: true
-hidden: false
+featured: false
+hidden: true
 
 description: This is the same as the MIT license, but with a clause added which prohibits the use of the copyright holders names in advertising or otherwise to promote a sale.
 

--- a/_licenses/x11.txt
+++ b/_licenses/x11.txt
@@ -2,7 +2,7 @@
 title: MIT X11 License
 spdx-id: X11
 
-description: This is the same as the MIT Expat license, but with a clause added which prohibits the use of the copyright holders names in advertising.
+description: This is the similar to the MIT Expat license, but adds a clause which prohibits the use of the copyright holders names in advertising.
 
 how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file. Replace [year] with the current year and [fullname] with the name (or names) of the copyright holders.
 

--- a/_licenses/x11.txt
+++ b/_licenses/x11.txt
@@ -1,5 +1,5 @@
 ---
-title: X11 License
+title: MIT X11 License
 spdx-id: X11
 
 description: 

--- a/_licenses/x11.txt
+++ b/_licenses/x11.txt
@@ -1,6 +1,6 @@
 ---
-title: MIT License
-spdx-id: MIT
+title: X11 License
+spdx-id: X11
 featured: true
 hidden: false
 

--- a/_licenses/x11.txt
+++ b/_licenses/x11.txt
@@ -2,7 +2,8 @@
 title: X11 License
 spdx-id: X11
 
-description: This is the same as the MIT license, but with a clause added which prohibits the use of the copyright holders names in advertising.
+description: 
+Like the MIT Expat license, it's a short and simple permissive license with conditions only requiring preservation of copyright and license notices. Licensed works, modifications, and larger works may be distributed under different terms and without source code. But unlike it, it adds a clause which prohibits the use of the copyright holders names in advertising.
 
 how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file. Replace [year] with the current year and [fullname] with the name (or names) of the copyright holders.
 

--- a/_licenses/x11.txt
+++ b/_licenses/x11.txt
@@ -10,7 +10,7 @@ how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of 
 
 using:
   Confy: https://github.com/rust-cli/confy/blob/master/LICENSE-X11
-  libsir: https://github.com/aremmell/libsir/blob/master/LICENSES/X11.txt
+  Libsir: https://github.com/aremmell/libsir/blob/master/LICENSES/X11.txt
   Rails: https://github.com/rails/rails/blob/master/MIT-LICENSE
 
 permissions:

--- a/_licenses/x11.txt
+++ b/_licenses/x11.txt
@@ -47,5 +47,6 @@ BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CON
 TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE 
 OR OTHER DEALINGS IN THE SOFTWARE.
 
-Except as contained in this notice, the name of <copyright holders> shall not be used in advertising 
-or otherwise to promote the sale, use or other dealings in this Software without prior written authorization from <copyright holders>.
+Except as contained in this notice, the name of <copyright holders> shall not be used in 
+advertising or otherwise to promote the sale, use or other dealings in this Software 
+without prior written authorization from <copyright holders>.

--- a/_licenses/x11.txt
+++ b/_licenses/x11.txt
@@ -9,7 +9,7 @@ how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of 
 using:
   Confy: https://github.com/rust-cli/confy/blob/master/LICENSE-X11
   Libsir: https://github.com/aremmell/libsir/blob/master/LICENSES/X11.txt
-  Rails: https://github.com/rails/rails/blob/master/MIT-LICENSE
+  Rails: https://github.com/rails/rails/blob/main/MIT-LICENSE
 
 permissions:
   - commercial-use

--- a/_licenses/x11.txt
+++ b/_licenses/x11.txt
@@ -2,9 +2,9 @@
 title: X11 License
 spdx-id: X11
 
-description: This is the same as the MIT license, but with a clause added which prohibits the use of the copyright holders names in advertising or otherwise to promote a sale.
+description: This is the same as the MIT license, but with a clause added which prohibits the use of the copyright holders names in advertising.
 
-how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file. Replace [year] with the current year and [fullname] with the name (or names) of the copyright holders.
+how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file. Replace <date> with the current year and <copyright holders> with the name (or names) of the copyright holders.
 
 using:
   Confy: https://github.com/rust-cli/confy/blob/master/LICENSE-X11

--- a/_licenses/x11.txt
+++ b/_licenses/x11.txt
@@ -2,7 +2,7 @@
 title: MIT X11 License
 spdx-id: X11
 
-description: This is the same as the MIT license, but with a clause added which prohibits the use of the copyright holders names in advertising.
+description: This is the same as the MIT Expat license, but with a clause added which prohibits the use of the copyright holders names in advertising.
 
 how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file. Replace [year] with the current year and [fullname] with the name (or names) of the copyright holders.
 

--- a/_licenses/x11.txt
+++ b/_licenses/x11.txt
@@ -1,8 +1,6 @@
 ---
 title: X11 License
 spdx-id: X11
-featured: false
-hidden: true
 
 description: This is the same as the MIT license, but with a clause added which prohibits the use of the copyright holders names in advertising or otherwise to promote a sale.
 

--- a/_licenses/x11.txt
+++ b/_licenses/x11.txt
@@ -1,5 +1,5 @@
 ---
-title: MIT X11 License
+title: X11 License
 spdx-id: X11
 
 description: 

--- a/_licenses/x11.txt
+++ b/_licenses/x11.txt
@@ -9,7 +9,7 @@ how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of 
 using:
   Confy: https://github.com/rust-cli/confy/blob/master/LICENSE-X11
   Libsir: https://github.com/aremmell/libsir/blob/master/LICENSES/X11.txt
-  Rails: https://github.com/rails/rails/blob/main/MIT-LICENSE
+  Libgcrypt: https://github.com/equalitie/libgcrypt/tree/5e66a4f8d5a63f58caeee367433dd8dd32346083
 
 permissions:
   - commercial-use

--- a/_licenses/x11.txt
+++ b/_licenses/x11.txt
@@ -9,7 +9,7 @@ description: This is the same as the MIT license, but with a clause added which 
 how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file. Replace [year] with the current year and [fullname] with the name (or names) of the copyright holders.
 
 using:
-  Babel: https://github.com/babel/babel/blob/master/LICENSE
+  Confy: https://github.com/rust-cli/confy/blob/master/LICENSE-X11
   .NET: https://github.com/dotnet/runtime/blob/main/LICENSE.TXT
   Rails: https://github.com/rails/rails/blob/master/MIT-LICENSE
 

--- a/_licenses/x11.txt
+++ b/_licenses/x11.txt
@@ -1,5 +1,5 @@
 ---
-title: MIT X11 License
+title: MIT (X11) License
 spdx-id: X11
 
 description: This is the similar to the MIT Expat license, but adds a clause which prohibits the use of the copyright holders names in advertising.

--- a/_licenses/x11.txt
+++ b/_licenses/x11.txt
@@ -42,7 +42,10 @@ copies or substantial portions of the Software.
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE X CONSORTIUM BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE X CONSORTIUM 
+BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, 
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE 
+OR OTHER DEALINGS IN THE SOFTWARE.
 
-Except as contained in this notice, the name of <copyright holders> shall not be used in advertising or otherwise to promote the sale, use or other dealings in this Software without prior written authorization from <copyright holders>.
+Except as contained in this notice, the name of <copyright holders> shall not be used in advertising 
+or otherwise to promote the sale, use or other dealings in this Software without prior written authorization from <copyright holders>.

--- a/_licenses/x11.txt
+++ b/_licenses/x11.txt
@@ -42,11 +42,11 @@ copies or substantial portions of the Software.
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE X CONSORTIUM 
-BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, 
-TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE 
-OR OTHER DEALINGS IN THE SOFTWARE.
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT 
+SHALL THE X CONSORTIUM BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, 
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF 
+OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-Except as contained in this notice, the name of <copyright holders> shall not be used in 
-advertising or otherwise to promote the sale, use or other dealings in this Software 
-without prior written authorization from <copyright holders>.
+Except as contained in this notice, the name of [fullname] shall not 
+be used in advertising or otherwise to promote the sale, use or other dealings 
+in this Software without prior written authorization from [fullname].

--- a/_licenses/x11.txt
+++ b/_licenses/x11.txt
@@ -9,7 +9,7 @@ how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of 
 using:
   Confy: https://github.com/rust-cli/confy/blob/master/LICENSE-X11
   Libsir: https://github.com/aremmell/libsir/blob/master/LICENSES/X11.txt
-  Libgcrypt: https://github.com/equalitie/libgcrypt/tree/5e66a4f8d5a63f58caeee367433dd8dd32346083
+  RB-zlib: https://github.com/charonn0/RB-zlib/blob/master/license.md
 
 permissions:
   - commercial-use

--- a/_licenses/x11.txt
+++ b/_licenses/x11.txt
@@ -4,7 +4,7 @@ spdx-id: X11
 featured: true
 hidden: false
 
-description: A short and simple permissive license with conditions only requiring preservation of copyright and license notices. Licensed works, modifications, and larger works may be distributed under different terms and without source code.
+description: This is same as MIT, but with a clause added which prohibits advertising.
 
 how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file. Replace [year] with the current year and [fullname] with the name (or names) of the copyright holders.
 

--- a/_licenses/x11.txt
+++ b/_licenses/x11.txt
@@ -4,7 +4,7 @@ spdx-id: X11
 featured: true
 hidden: false
 
-description: This is same as MIT, but with a clause added which prohibits the use of the copyright holders names in advertising.
+description: This is the same as the MIT license, but with a clause added which prohibits the use of the copyright holders names in advertising or otherwise to promote a sale.
 
 how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file. Replace [year] with the current year and [fullname] with the name (or names) of the copyright holders.
 

--- a/_licenses/x11.txt
+++ b/_licenses/x11.txt
@@ -26,7 +26,7 @@ limitations:
 
 ---
 
-X11 License
+MIT X11 License
 
 Copyright (C) [year] [fullname]
 

--- a/_licenses/x11.txt
+++ b/_licenses/x11.txt
@@ -3,7 +3,7 @@ title: X11 License
 spdx-id: X11
 
 description: 
-Like the MIT Expat license, it's a short and simple permissive license with conditions only requiring preservation of copyright and license notices. Licensed works, modifications, and larger works may be distributed under different terms and without source code. But unlike it, it adds a clause which prohibits the use of the copyright holders names in advertising.
+This license is similar to the MIT Expat license. But unlike it, it adds a clause which prohibits the use of the copyright holders names in advertising.
 
 how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file. Replace [year] with the current year and [fullname] with the name (or names) of the copyright holders.
 

--- a/_licenses/x11.txt
+++ b/_licenses/x11.txt
@@ -1,5 +1,5 @@
 ---
-title: X11 License
+title: MIT X11 License
 spdx-id: X11
 
 description: This is the same as the MIT license, but with a clause added which prohibits the use of the copyright holders names in advertising.

--- a/_licenses/x11.txt
+++ b/_licenses/x11.txt
@@ -4,7 +4,7 @@ spdx-id: X11
 featured: true
 hidden: false
 
-description: This is same as MIT, but with a clause added which prohibits advertising.
+description: This is same as MIT, but with a clause added which prohibits the use of the copyright holders names in advertising.
 
 how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file. Replace [year] with the current year and [fullname] with the name (or names) of the copyright holders.
 

--- a/_licenses/x11.txt
+++ b/_licenses/x11.txt
@@ -30,10 +30,19 @@ MIT X11 License
 
 Copyright (C) [year] [fullname]
 
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE X CONSORTIUM BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE X CONSORTIUM BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 Except as contained in this notice, the name of <copyright holders> shall not be used in advertising or otherwise to promote the sale, use or other dealings in this Software without prior written authorization from <copyright holders>.

--- a/_licenses/x11.txt
+++ b/_licenses/x11.txt
@@ -2,8 +2,7 @@
 title: X11 License
 spdx-id: X11
 
-description: 
-This license is similar to the MIT Expat license. But unlike it, it adds a clause which prohibits the use of the copyright holders names in advertising.
+description: This is the same as the MIT license, but with a clause added which prohibits the use of the copyright holders names in advertising.
 
 how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file. Replace [year] with the current year and [fullname] with the name (or names) of the copyright holders.
 

--- a/_licenses/x11.txt
+++ b/_licenses/x11.txt
@@ -1,3 +1,35 @@
+---
+title: MIT License
+spdx-id: MIT
+featured: true
+hidden: false
+
+description: A short and simple permissive license with conditions only requiring preservation of copyright and license notices. Licensed works, modifications, and larger works may be distributed under different terms and without source code.
+
+how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file. Replace [year] with the current year and [fullname] with the name (or names) of the copyright holders.
+
+using:
+  Babel: https://github.com/babel/babel/blob/master/LICENSE
+  .NET: https://github.com/dotnet/runtime/blob/main/LICENSE.TXT
+  Rails: https://github.com/rails/rails/blob/master/MIT-LICENSE
+
+permissions:
+  - commercial-use
+  - modifications
+  - distribution
+  - private-use
+
+conditions:
+  - include-copyright
+
+limitations:
+  - liability
+  - warranty
+
+---
+
+X11 License
+
 Copyright (C) <date> <copyright holders>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:

--- a/_licenses/x11.txt
+++ b/_licenses/x11.txt
@@ -4,7 +4,7 @@ spdx-id: X11
 
 description: This is the same as the MIT license, but with a clause added which prohibits the use of the copyright holders names in advertising.
 
-how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file. Replace <date> with the current year and <copyright holders> with the name (or names) of the copyright holders.
+how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file. Replace [year] with the current year and [fullname] with the name (or names) of the copyright holders.
 
 using:
   Confy: https://github.com/rust-cli/confy/blob/master/LICENSE-X11
@@ -28,7 +28,7 @@ limitations:
 
 X11 License
 
-Copyright (C) <date> <copyright holders>
+Copyright (C) [year] [fullname]
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/_licenses/x11.txt
+++ b/_licenses/x11.txt
@@ -26,7 +26,7 @@ limitations:
 
 ---
 
-MIT X11 License
+MIT (X11) License
 
 Copyright (C) [year] [fullname]
 

--- a/about.md
+++ b/about.md
@@ -10,7 +10,7 @@ If you already know what you're doing and have a license you prefer to use, that
 
 ## Not comprehensive
 
-This site is not a comprehensive directory of open source licenses. The vast majority of projects will likely be well served by one of the three options highlighted on the [homepage](/) — choosing the license [preferred](/community/) by projects similar to yours, or the most popular permissive license ([MIT](/licenses/mit/)), or the most popular copyleft license ([GNU GPLv3](/licenses/gpl-3.0/)). Just in case you have specific needs not covered by these, we also highlight a [few other licenses to consider](/licenses/) and have a page about [licenses for non-software projects](/non-software/).
+This site is not a comprehensive directory of open source licenses. The vast majority of projects will likely be well served by one of the three options highlighted on the [homepage](/) — choosing the license [preferred](/community/) by projects similar to yours, or the most popular permissive license ([MIT Expat](/licenses/mit/)), or the most popular copyleft license ([GNU GPLv3](/licenses/gpl-3.0/)). Just in case you have specific needs not covered by these, we also highlight a [few other licenses to consider](/licenses/) and have a page about [licenses for non-software projects](/non-software/).
 
 See our [appendix](/appendix/) for a table of every license cataloged in the [choosealicense.com repository](https://github.com/github/choosealicense.com) and the links below for *even more* licenses that you **do not** need to learn about to still choose a great license for your project.
 

--- a/community.md
+++ b/community.md
@@ -16,9 +16,9 @@ Some communities have strong preferences for particular licenses. If you want to
 * [Apache](https://www.apache.org/licenses/) requires [Apache License 2.0](/licenses/apache-2.0/)
 * [Cloud Native Computing Foundation](https://github.com/cncf/foundation/blob/main/charter.md#11-ip-policy) requires [Apache License 2.0](/licenses/apache-2.0/)
 * [GNU](https://www.gnu.org/licenses/license-recommendations.html) recommends [GNU GPLv3](/licenses/gpl-3.0/) for most programs
-* [npm packages](https://libraries.io/search?platforms=npm) overwhelmingly use the [MIT](/licenses/mit/) or the very similar [ISC](/licenses/isc) licenses
+* [npm packages](https://libraries.io/search?platforms=npm) overwhelmingly use the [MIT Expat](/licenses/mit/) or the very similar [ISC](/licenses/isc) licenses
 * [OpenBSD](https://www.openbsd.org/policy.html) prefers the [ISC License](/licenses/isc/)
-* [Rust](https://rust-lang.github.io/api-guidelines/necessities.html#crate-and-its-dependencies-have-a-permissive-license-c-permissive) crates are overwhelmingly licensed [MIT](/licenses/mit/) [`OR`](https://spdx.github.io/spdx-spec/v2.3/SPDX-license-expressions/#d42-disjunctive-or-operator) [Apache License 2.0](/licenses/apache-2.0/)
+* [Rust](https://rust-lang.github.io/api-guidelines/necessities.html#crate-and-its-dependencies-have-a-permissive-license-c-permissive) crates are overwhelmingly licensed [MIT Expat](/licenses/mit/) [`OR`](https://spdx.github.io/spdx-spec/v2.3/SPDX-license-expressions/#d42-disjunctive-or-operator) [Apache License 2.0](/licenses/apache-2.0/)
 * [WordPress](https://wordpress.org/about/license/) plugins and themes must be [GNU GPLv2](/licenses/gpl-2.0/) (or later)
 * [Joomla](https://tm.joomla.org/joomla-license-faq.html#can-i-release-an-extension-under-a-non-gpl-license) extensions and templates must be [GNU GPLv2](/licenses/gpl-2.0/) for the PHP code.
 

--- a/index.html
+++ b/index.html
@@ -32,7 +32,7 @@ permalink: /
       <h3>I want it simple and permissive.</h3>
     </a>
     <p>
-      The <a href="licenses/mit/">MIT License</a> is short and to the point. It lets people do almost anything they want with your project, like making and distributing closed source versions.
+      The <a href="licenses/mit/">MIT Expat License</a> is short and to the point. It lets people do almost anything they want with your project, like making and distributing closed source versions.
     </p>
     <p>
       {% include using-sentence.html license-id="mit" %}

--- a/licenses.html
+++ b/licenses.html
@@ -5,7 +5,7 @@ class: license-types
 title: Licenses
 ---
 
-<p>Open source licenses grant permission for anybody to use, modify, and share licensed software for any purpose, subject to conditions preserving the provenance and openness of the software. The following licenses are sorted by the number of conditions, from most (GNU AGPLv3) to none (Unlicense). Notice that the popular licenses featured on the <a href="/">home page</a> (GNU GPLv3 and MIT) fall within this spectrum.</p>
+<p>Open source licenses grant permission for anybody to use, modify, and share licensed software for any purpose, subject to conditions preserving the provenance and openness of the software. The following licenses are sorted by the number of conditions, from most (GNU AGPLv3) to none (Unlicense). Notice that the popular licenses featured on the <a href="/">home page</a> (GNU GPLv3 and MIT Expat) fall within this spectrum.</p>
 <p style="font-size:small; margin-bottom: 40px">If you’re looking for a reference table of every license on choosealicense.com, see the <a href="/appendix">appendix</a>.</p>
 
 {% include license-overview.html license-id="agpl-3.0" %}

--- a/no-permission.md
+++ b/no-permission.md
@@ -24,6 +24,6 @@ Your options:
 
 {: .bullets}
 
-- **Ask the maintainers nicely to add a license.** Unless the software includes strong indications to the contrary, lack of a license is probably an oversight. If the software is hosted on a site like GitHub, open an issue requesting a license and include a link to this site. If you're bold and it's fairly obvious what license is most appropriate, open a pull request to add a license – see "suggest this license" in the sidebar of the page for each license on this site (e.g., [MIT](/licenses/mit/#suggest-this-license)).
+- **Ask the maintainers nicely to add a license.** Unless the software includes strong indications to the contrary, lack of a license is probably an oversight. If the software is hosted on a site like GitHub, open an issue requesting a license and include a link to this site. If you're bold and it's fairly obvious what license is most appropriate, open a pull request to add a license – see "suggest this license" in the sidebar of the page for each license on this site (e.g., [MIT Expat](/licenses/mit/#suggest-this-license)).
 - **Don't use the software.** Find or create an alternative that is under an open source license.
 - **Negotiate a private license.** Bring your lawyer.


### PR DESCRIPTION
This PR adds the X11 license and to differentiate them since they are so similar, I’ve decided to change the name of the MIT license, to  the MIT Expat license.

Also I’ve changed the license from CC-BY 3.0 to CC-BY 4.0.