### PR TITLE
fix: Correct copyleft classification for EPL and CeCILL licenses

### DIFF
--- a/_licenses/cecill-2.1.txt
+++ b/_licenses/cecill-2.1.txt
@@ -20,7 +20,6 @@ permissions:
 
 conditions:
   - include-copyright
-  - network-use-disclose
   - disclose-source
   - same-license
 

--- a/_licenses/epl-1.0.txt
+++ b/_licenses/epl-1.0.txt
@@ -21,7 +21,7 @@ permissions:
 conditions:
   - disclose-source
   - include-copyright
-  - same-license
+  - same-license--file
 
 limitations:
   - liability

--- a/_licenses/epl-2.0.txt
+++ b/_licenses/epl-2.0.txt
@@ -23,7 +23,7 @@ permissions:
 conditions:
   - disclose-source
   - include-copyright
-  - same-license
+  - same-license--file
 
 limitations:
   - liability


### PR DESCRIPTION
### Summary

This PR updates the metadata of several license definitions to better reflect their actual copyleft scope and obligations.

**Changes**
- Updated EPL-1.0:
  Replaced _same-license_ with _same-license--file_.
- Updated EPL-2.0:
  Replaced _same-license_ with _same-license--file_.
- Updated CeCILL-2.1:
  Removed the _network-use-disclose_ condition ("Network use is distribution"), as the license does not impose AGPL-style network source code disclosure requirements.


**Rationale**

The changes align the license metadata more closely with the actual obligations defined by the respective license texts:

- For EPL 1.0 and EPL 2.0, copyleft obligations apply to modifications of EPL-covered files rather than to an entire larger work. The _same-license--file_ condition appears to more accurately describe this behavior than _same-license_. 
See FAQ 4.22: https://www.eclipse.org/legal/epl-2.0/faq/

- For CeCILL 2.1, the license requires source code disclosure when distributing covered software (see [Article 5.3.2](https://spdx.org/licenses/CECILL-2.1.html), "Distribution of Modified Software"), but it does not appear to contain an AGPL-style provision that treats network interaction with the software as distribution or otherwise requires source code disclosure solely because the software is made available over a network. As a result, the _network-use-disclose_ condition appears to overstate the obligations imposed by the license.

Jason Grieshaber, [jason.grieshaber@mercedes-benz.com](mailto:jason.grieshaber@mercedes-benz.com), [Mercedes-Benz AG](https://group.mercedes-benz.com/provider/)
Contribution licensed under [Creative Commons Attribution 3.0 Unported license](https://creativecommons.org/licenses/by/3.0/)