### PR TITLE
fix: correct Blue Oak 1.0.0 license notice condition

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ The license properties (rules) are stored as a bulleted list within the licenses
 
 * `include-copyright` - A copy of the license and copyright notice must be included with the software.
 * `include-copyright--source` - A copy of the license and copyright notice must be included with the software in source form, but is not required for binaries.
+* `include-license` - A copy of or link to the license must be included with the software.
 * `document-changes` - Changes made to the code must be documented.
 * `disclose-source` - Source code must be made available when the software is distributed.
 * `network-use-disclose` - Users who interact with the software via network are given the right to receive a copy of the source code.

--- a/_data/rules.yml
+++ b/_data/rules.yml
@@ -19,6 +19,9 @@ conditions:
 - description: A copy of the license and copyright notice must be included with the licensed material.
   label: License and copyright notice
   tag: include-copyright
+- description: A copy of or link to the license must be included with the licensed material.
+  label: License notice
+  tag: include-license
 - description: A copy of the license and copyright notice must be included with the licensed material in source form, but is not required for binaries.
   label: License and copyright notice for source
   tag: include-copyright--source

--- a/_licenses/blueoak-1.0.0.txt
+++ b/_licenses/blueoak-1.0.0.txt
@@ -19,7 +19,7 @@ permissions:
   - private-use
 
 conditions:
-  - include-copyright
+  - include-license
 
 limitations:
   - liability


### PR DESCRIPTION
## Summary

Fixes #1219.

Blue Oak Model License 1.0.0 was tagged with `include-copyright`, which tells users they must include a copyright notice. The [Notices section](https://blueoakcouncil.org/license/1.0.0#notices) only requires a license copy or link — no copyright notice.

- Add `include-license` condition to `_data/rules.yml`
- Switch `BlueOak-1.0.0` to the new tag
- Document the rule in README

## Test plan

- [ ] `./script/cibuild` passes (license rules spec validates tags)
- [ ] Blue Oak license page shows "License notice" instead of "License and copyright notice"


Made with [Cursor](https://cursor.com)