### PR TITLE
Add glossary of common open source licensing terms

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,6 +1,7 @@
       <footer class="site-footer clearfix">
         <nav>
           <a href="/about/">About</a>
+          <a href="/glossary/">Glossary</a>
           <a href="/terms-of-service/">Terms of Service</a>
           {% github_edit_link "Help improve this page" %}
         </nav>

--- a/glossary.md
+++ b/glossary.md
@@ -1,0 +1,63 @@
+---
+layout: default
+permalink: /glossary/
+title: Glossary
+---
+
+Open source licensing uses terms from copyright, patent, and trademark law, plus community practice. This glossary explains common words you will see on [choosealicense.com](/) and in project README files. It is a plain-language overview, not legal advice.
+
+## Copyright
+
+**Copyright** is the legal right that creators have in original works—such as source code, documentation, and artwork—from the moment those works are fixed in a tangible form. Copyright generally gives the owner exclusive rights to copy, modify, distribute, and publicly display or perform the work. Open source **licenses** do not replace copyright; they are permissions that copyright holders grant so others may use the work under stated conditions.
+
+## License
+
+A **license** is a set of terms under which a copyright holder allows others to use their work. Without a license (or another legal basis such as fair use), others may not copy or distribute the work. Open source licenses are designed to be **public** and **standardized** so recipients know what they may do. See [What's this about?](/about/) for how this site helps you pick a license.
+
+## Public domain
+
+The **public domain** is the set of works not protected by copyright, or for which copyright has expired or been waived. Works in the public domain can generally be used by anyone for any purpose without a license. Some projects use tools such as [CC0](/licenses/cc0-1.0/) or [Unlicense](/licenses/unlicense/) to dedicate works to the public domain where that is legally possible.
+
+## Copyleft
+
+**Copyleft** licenses require that derivative works shared with others be licensed under the same (or compatible) terms, so downstream users keep the same freedoms. [GNU GPLv3](/licenses/gpl-3.0/) is a well-known copyleft license. Copyleft is sometimes called a **reciprocal** or **share-alike** approach. Contrast with **permissive** licenses below.
+
+## Permissive
+
+**Permissive** licenses impose few restrictions on reuse. They typically require **attribution** and include **warranty disclaimers**, but allow proprietary use and do not require sharing source code of derivatives. [MIT](/licenses/mit/) and [Apache 2.0](/licenses/apache-2.0/) are common permissive licenses.
+
+## Patent grant
+
+Some licenses include an explicit **patent grant**: the licensor grants recipients a license to any patents they hold that are necessary to use the licensed software. [Apache 2.0](/licenses/apache-2.0/) is known for a clear patent grant and termination if a licensee sues over patents. Other licenses address patents differently or rely on broader legal principles; read the specific license text when patents matter for your project.
+
+## Trademark
+
+A **trademark** identifies the source of goods or services (names, logos, slogans). Copyright licenses for software usually do **not** grant trademark rights. You may not use a project’s name or logo in a way that suggests endorsement or affiliation unless the project’s trademark policy allows it. Always respect separate trademark guidelines from the project or organization.
+
+## Derivative work
+
+A **derivative work** is a new work based on an existing copyrighted work—such as modified source code, a fork with substantial changes, or a combined program that incorporates licensed code. Whether something counts as a derivative work can be legally nuanced. **Copyleft** licenses often require that derivatives shared with others follow the same license; **permissive** licenses usually allow proprietary derivatives.
+
+## Attribution
+
+**Attribution** means giving credit to the original authors and preserving their **copyright notices** when you copy or distribute the work. Nearly all open source licenses require some form of attribution. The exact requirements (notice file, LICENSE text, etc.) depend on the license; see [attributions](/attributions/) for practical guidance on third-party code.
+
+## Warranty disclaimer
+
+Open source software is typically provided **“as is”**, with **no warranty** of fitness or non-infringement. License texts include **warranty disclaimer** and **limitation of liability** clauses so distributors are not implicitly promising that the software is error-free or safe for every use. Users and integrators evaluate risk themselves.
+
+## SPDX
+
+**SPDX** (Software Package Data Exchange) is a standard for communicating license and copyright information in a machine-readable way. Each license has an **SPDX identifier** (for example, `MIT`, `Apache-2.0`, `GPL-3.0-only`). Package managers and compliance tools use these IDs. This site lists SPDX IDs on license pages; the [SPDX License List](https://spdx.org/licenses/) is the canonical reference.
+
+## OSI
+
+The **Open Source Initiative** (OSI) is a nonprofit that maintains the [Open Source Definition](https://opensource.org/osd) and **approves** licenses as conforming to that definition. OSI-approved licenses are widely recognized as **open source** in the community. Not every license on this site is OSI-approved; check each license page and the OSI list when “open source” status matters for your policy or community.
+
+## Related reading
+
+{: .bullets}
+
+* [Appendix](/appendix/) — licenses cataloged on this site
+* [Licenses for non-software](/non-software/) — documentation, data, and other materials
+* [The Legal Side of Open Source](https://opensource.guide/legal/) — Open Source Guide


### PR DESCRIPTION
## Summary
- Adds a readable glossary covering copyright, license types, SPDX, OSI, and related terms.
- Links the glossary from the site footer.

Fixes #238

## Test plan
- [ ] Build site locally and confirm `/glossary/` renders with default layout
- [ ] Confirm footer shows Glossary link on several pages

Made with [Cursor](https://cursor.com)