### PR TITLE
Add Ruby License page (fixes #541)

### DIFF
--- a/_licenses/ruby.txt
+++ b/_licenses/ruby.txt
@@ -1,0 +1,78 @@
+---
+title: Ruby License
+spdx-id: Ruby
+hidden: true
+
+description: A dual-licensed Ruby project license (Ruby License or 2-clause BSD). Used for the Ruby programming language and many Ruby standard libraries.
+
+how: Create a text file (typically named LICENSE or COPYING) in the root of your source code and copy the text of the license into the file.
+
+using:
+  Ruby: https://github.com/ruby/ruby/blob/master/COPYING
+  Racc: https://github.com/ruby/racc/blob/master/COPYING
+  StringIO: https://github.com/ruby/stringio/blob/master/COPYING
+
+permissions:
+  - commercial-use
+  - modifications
+  - distribution
+  - private-use
+
+conditions:
+  - include-copyright
+
+limitations:
+  - liability
+  - warranty
+
+---
+
+1. You may make and give away verbatim copies of the source form of the
+software without restriction, provided that you duplicate all of the original
+copyright notices and associated disclaimers.
+
+2. You may modify your copy of the software in any way, provided that you do
+at least ONE of the following:
+
+     a) place your modifications in the Public Domain or otherwise make them
+Freely Available, such as by posting said modifications to Usenet or an
+equivalent medium, or by allowing the author to include your modifications in
+the software.
+
+     b) use the modified software only within your corporation or
+organization.
+
+     c) give non-standard binaries non-standard names, with instructions on
+where to get the original software distribution.
+
+     d) make other distribution arrangements with the author.
+
+3. You may distribute the software in object code or binary form, provided
+that you do at least ONE of the following:
+
+     a) distribute the binaries and library files of the software, together
+with instructions (in the manual page or equivalent) on where to get the
+original distribution.
+
+     b) accompany the distribution with the machine-readable source of the
+software.
+
+     c) give non-standard binaries non-standard names, with instructions on
+where to get the original software distribution.
+
+     d) make other distribution arrangements with the author.
+
+4. You may modify and include the part of the software into any other software
+(possibly commercial). But some files in the distribution are not written by
+the author, so that they are not under these terms.
+
+For the list of those files and their copying conditions, see the file LEGAL.
+
+5. The scripts and library files supplied as input to or produced as output
+from the software do not automatically fall under the copyright of the
+software, but belong to whomever generated them, and may be sold commercially,
+and may be aggregated with this software.
+
+6. THIS SOFTWARE IS PROVIDED "AS IS" AND WITHOUT ANY EXPRESS OR IMPLIED
+WARRANTIES, INCLUDING, WITHOUT LIMITATION, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.


### PR DESCRIPTION
## Summary
- Add hidden `_licenses/ruby.txt` with SPDX Ruby license text.
- Three `using` examples (Ruby, Racc, StringIO) with COPYING files.

## Test plan
- [ ] CI Build and Test

Fixes #541

Made with [Cursor](https://cursor.com)