### PR TITLE
Clarify same-license and reimplementation (fixes #1247)

### DIFF
--- a/_data/rules.yml
+++ b/_data/rules.yml
@@ -31,13 +31,13 @@ conditions:
 - description: Users who interact with the licensed material via network are given the right to receive a copy of the source code.
   label: Network use is distribution
   tag: network-use-disclose
-- description: Modifications must be released under the same license when distributing the licensed material. In some cases a similar or related license may be used.
+- description: Modifications must be released under the same license when distributing the licensed material. In some cases a similar or related license may be used. This applies to derivative works based on the licensed material; it does not require a particular license for a clean-room reimplementation that does not incorporate the licensed work.
   label: Same license
   tag: same-license
-- description: Modifications of existing files must be released under the same license when distributing the licensed material. In some cases a similar or related license may be used.
+- description: Modifications must be released under the same license when distributing the licensed material. In some cases a similar or related license may be used. This applies to derivative works based on the licensed material; it does not require a particular license for a clean-room reimplementation that does not incorporate the licensed work.
   label: Same license (file)
   tag: same-license--file
-- description: Modifications must be released under the same license when distributing the licensed material. In some cases a similar or related license may be used, or this condition may not apply to works that use the licensed material as a library.
+- description: Modifications must be released under the same license when distributing the licensed material. In some cases a similar or related license may be used. This applies to derivative works based on the licensed material; it does not require a particular license for a clean-room reimplementation that does not incorporate the licensed work.
   label: Same license (library)
   tag: same-license--library
 

--- a/_data/rules.yml
+++ b/_data/rules.yml
@@ -34,10 +34,10 @@ conditions:
 - description: Modifications must be released under the same license when distributing the licensed material. In some cases a similar or related license may be used. This applies to derivative works based on the licensed material; it does not require a particular license for a clean-room reimplementation that does not incorporate the licensed work.
   label: Same license
   tag: same-license
-- description: Modifications must be released under the same license when distributing the licensed material. In some cases a similar or related license may be used. This applies to derivative works based on the licensed material; it does not require a particular license for a clean-room reimplementation that does not incorporate the licensed work.
+- description: Modifications of existing files must be released under the same license when distributing the licensed material. In some cases a similar or related license may be used. This applies to derivative files; it does not require a particular license for a clean-room reimplementation that does not incorporate code from those files.
   label: Same license (file)
   tag: same-license--file
-- description: Modifications must be released under the same license when distributing the licensed material. In some cases a similar or related license may be used. This applies to derivative works based on the licensed material; it does not require a particular license for a clean-room reimplementation that does not incorporate the licensed work.
+- description: Modifications must be released under the same license when distributing the licensed material. In some cases a similar or related license may be used, or this condition may not apply to works that use the licensed material as a library. Linking or combining with a library under this condition does not extend to independent reimplementations that do not use the library’s source.
   label: Same license (library)
   tag: same-license--library
 


### PR DESCRIPTION
## Summary
- Expand `same-license`, `same-license--file`, and `same-license--library` descriptions in `_data/rules.yml` to distinguish derivatives from clean-room reimplementation.

## Test plan
- [ ] CI Build and Test

Fixes #1247

Made with [Cursor](https://cursor.com)