### PR TITLE
Related license variants in sidebar (fixes #389)

### DIFF
--- a/_data/meta.yml
+++ b/_data/meta.yml
@@ -51,6 +51,11 @@
   description: Additional information about the licenses
   required: false
 
+
+- name: related
+  description: Optional list of related license slugs (lowercase SPDX-derived filenames without .txt) shown in the sidebar
+  required: false
+
 - name: redirect_from
   description: Relative path(s) to redirect to the license from, to prevent breaking old URLs
   required: false

--- a/_includes/related-licenses.html
+++ b/_includes/related-licenses.html
@@ -1,0 +1,18 @@
+{% if page.related and page.related.size > 0 %}
+  <div class="related-licenses">
+    <h3 id="related-licenses">Related licenses</h3>
+    <ul>
+      {% for rel in page.related %}
+        {% assign rel_doc = site.licenses | where: "spdx-lcase", rel | first %}
+        {% if rel_doc == nil %}
+          {% assign rel_doc = site.licenses | where_exp: "item", "item.spdx-lcase == rel" | first %}
+        {% endif %}
+        {% if rel_doc %}
+          <li><a href="{{ rel_doc.url | relative_url }}">{{ rel_doc.title }}</a></li>
+        {% else %}
+          <li><a href="{{ '/licenses/' | append: rel | append: '/' | relative_url }}">{{ rel }}</a></li>
+        {% endif %}
+      {% endfor %}
+    </ul>
+  </div>
+{% endif %}

--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -54,4 +54,6 @@
   </div>
   {% endif %}
 
+  {% include related-licenses.html %}
+
 </div> <!-- /sidebar -->

--- a/_licenses/gpl-2.0.txt
+++ b/_licenses/gpl-2.0.txt
@@ -11,6 +11,11 @@ how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of 
 
 note: The Free Software Foundation recommends taking the additional step of adding a boilerplate notice to the top of each file. The boilerplate can be found at the end of the license.
 
+related:
+  - gpl-3.0
+  - agpl-3.0
+  - eupl-1.2
+
 using:
   Discourse: https://github.com/discourse/discourse/blob/master/LICENSE.txt
   Jellyfin: https://github.com/jellyfin/jellyfin/blob/master/LICENSE

--- a/_licenses/lgpl-2.1.txt
+++ b/_licenses/lgpl-2.1.txt
@@ -11,6 +11,11 @@ how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of 
 
 note: The Free Software Foundation recommends taking the additional step of adding a boilerplate notice to the top of each file. The boilerplate can be found at the end of the license.
 
+related:
+  - lgpl-3.0
+  - mpl-2.0
+  - lgpl-2.0
+
 using:
 
 permissions:

--- a/_licenses/mit.txt
+++ b/_licenses/mit.txt
@@ -8,6 +8,11 @@ description: A short and simple permissive license with conditions only requirin
 
 how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file. Replace [year] with the current year and [fullname] with the name (or names) of the copyright holders.
 
+related:
+  - bsd-2-clause
+  - bsd-3-clause
+  - isc
+
 using:
   Babel: https://github.com/babel/babel/blob/master/LICENSE
   .NET: https://github.com/dotnet/runtime/blob/main/LICENSE.TXT


### PR DESCRIPTION
## Summary
- Document optional `related:` in `_data/meta.yml`.
- Add `_includes/related-licenses.html` and include it from the license sidebar.
- Set related links on MIT, GPL-2.0, and LGPL-2.1 (includes lgpl-2.0 once merged).

## Test plan
- [ ] CI Build and Test
- [ ] Spot-check `/licenses/mit/` sidebar

Fixes #389

Made with [Cursor](https://cursor.com)