### PR TITLE
EUPL official translation links (fixes #1227)

### DIFF
--- a/_data/eupl-translations.yml
+++ b/_data/eupl-translations.yml
@@ -1,0 +1,8 @@
+EUPL-1.1:
+  label: EUPL-1.1
+  official_translations: https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-11
+  note: Official EUPL 1.1 text in 22 languages of the European Union (Joinup).
+EUPL-1.2:
+  label: EUPL-1.2
+  official_translations: https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+  note: Official EUPL 1.2 text in 23 languages of the European Union (Joinup).

--- a/_includes/eupl-translations.html
+++ b/_includes/eupl-translations.html
@@ -1,0 +1,8 @@
+{% assign eupl = site.data.eupl-translations[page.spdx-id] %}
+{% if eupl %}
+  <div class="eupl-translations">
+    <h3 id="eupl-translations">Official translations</h3>
+    <p>{{ eupl.note }}</p>
+    <p><a href="{{ eupl.official_translations }}">EU translations on Joinup</a></p>
+  </div>
+{% endif %}

--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -54,4 +54,6 @@
   </div>
   {% endif %}
 
+  {% include eupl-translations.html %}
+
 </div> <!-- /sidebar -->


### PR DESCRIPTION
## Summary
- Add `_data/eupl-translations.yml` with Joinup URLs for EUPL 1.1 and 1.2.
- Add `_includes/eupl-translations.html` in the license sidebar for EUPL pages.

## Test plan
- [ ] CI Build and Test
- [ ] Check `/licenses/eupl-1.2/` sidebar

Fixes #1227

Made with [Cursor](https://cursor.com)