### PR TITLE
OSI/FSF/OD approval badges (fixes #827)

### DIFF
--- a/_data/approvals.yml
+++ b/_data/approvals.yml
@@ -1,0 +1,235 @@
+0bsd:
+  spdx-id: 0BSD
+  osi: true
+  fsf: false
+  od: false
+afl-3.0:
+  spdx-id: AFL-3.0
+  osi: true
+  fsf: true
+  od: false
+agpl-3.0:
+  spdx-id: AGPL-3.0
+  osi: true
+  fsf: true
+  od: false
+apache-2.0:
+  spdx-id: Apache-2.0
+  osi: true
+  fsf: true
+  od: false
+artistic-2.0:
+  spdx-id: Artistic-2.0
+  osi: true
+  fsf: true
+  od: false
+blueoak-1.0.0:
+  spdx-id: BlueOak-1.0.0
+  osi: true
+  fsf: false
+  od: false
+bsd-2-clause-patent:
+  spdx-id: BSD-2-Clause-Patent
+  osi: true
+  fsf: false
+  od: false
+bsd-2-clause:
+  spdx-id: BSD-2-Clause
+  osi: true
+  fsf: false
+  od: false
+bsd-3-clause-clear:
+  spdx-id: BSD-3-Clause-Clear
+  osi: false
+  fsf: true
+  od: false
+bsd-3-clause:
+  spdx-id: BSD-3-Clause
+  osi: true
+  fsf: true
+  od: false
+bsd-4-clause:
+  spdx-id: BSD-4-Clause
+  osi: false
+  fsf: true
+  od: false
+bsl-1.0:
+  spdx-id: BSL-1.0
+  osi: true
+  fsf: true
+  od: false
+cc-by-4.0:
+  spdx-id: CC-BY-4.0
+  osi: false
+  fsf: true
+  od: true
+cc-by-sa-4.0:
+  spdx-id: CC-BY-SA-4.0
+  osi: false
+  fsf: true
+  od: true
+cc0-1.0:
+  spdx-id: CC0-1.0
+  osi: false
+  fsf: true
+  od: true
+cecill-2.1:
+  spdx-id: CECILL-2.1
+  osi: true
+  fsf: false
+  od: false
+cern-ohl-p-2.0:
+  spdx-id: CERN-OHL-P-2.0
+  osi: true
+  fsf: false
+  od: false
+cern-ohl-s-2.0:
+  spdx-id: CERN-OHL-S-2.0
+  osi: true
+  fsf: false
+  od: false
+cern-ohl-w-2.0:
+  spdx-id: CERN-OHL-W-2.0
+  osi: true
+  fsf: false
+  od: false
+ecl-2.0:
+  spdx-id: ECL-2.0
+  osi: true
+  fsf: true
+  od: false
+epl-1.0:
+  spdx-id: EPL-1.0
+  osi: true
+  fsf: true
+  od: false
+epl-2.0:
+  spdx-id: EPL-2.0
+  osi: true
+  fsf: true
+  od: false
+eupl-1.1:
+  spdx-id: EUPL-1.1
+  osi: true
+  fsf: true
+  od: false
+eupl-1.2:
+  spdx-id: EUPL-1.2
+  osi: true
+  fsf: true
+  od: false
+gfdl-1.3:
+  spdx-id: GFDL-1.3
+  osi: false
+  fsf: true
+  od: false
+gpl-2.0:
+  spdx-id: GPL-2.0
+  osi: true
+  fsf: true
+  od: false
+gpl-3.0:
+  spdx-id: GPL-3.0
+  osi: true
+  fsf: true
+  od: false
+isc:
+  spdx-id: ISC
+  osi: true
+  fsf: true
+  od: false
+lgpl-2.1:
+  spdx-id: LGPL-2.1
+  osi: true
+  fsf: true
+  od: false
+lgpl-3.0:
+  spdx-id: LGPL-3.0
+  osi: true
+  fsf: true
+  od: false
+lppl-1.3c:
+  spdx-id: LPPL-1.3c
+  osi: true
+  fsf: false
+  od: false
+mit-0:
+  spdx-id: MIT-0
+  osi: true
+  fsf: false
+  od: false
+mit:
+  spdx-id: MIT
+  osi: true
+  fsf: true
+  od: false
+mpl-2.0:
+  spdx-id: MPL-2.0
+  osi: true
+  fsf: true
+  od: false
+ms-pl:
+  spdx-id: MS-PL
+  osi: true
+  fsf: true
+  od: false
+ms-rl:
+  spdx-id: MS-RL
+  osi: true
+  fsf: true
+  od: false
+mulanpsl-2.0:
+  spdx-id: MulanPSL-2.0
+  osi: true
+  fsf: false
+  od: false
+ncsa:
+  spdx-id: NCSA
+  osi: true
+  fsf: true
+  od: false
+odbl-1.0:
+  spdx-id: ODbL-1.0
+  osi: false
+  fsf: true
+  od: true
+ofl-1.1:
+  spdx-id: OFL-1.1
+  osi: true
+  fsf: true
+  od: false
+osl-3.0:
+  spdx-id: OSL-3.0
+  osi: true
+  fsf: true
+  od: false
+postgresql:
+  spdx-id: PostgreSQL
+  osi: true
+  fsf: false
+  od: false
+unlicense:
+  spdx-id: Unlicense
+  osi: true
+  fsf: true
+  od: false
+upl-1.0:
+  spdx-id: UPL-1.0
+  osi: true
+  fsf: true
+  od: false
+vim:
+  spdx-id: Vim
+  osi: false
+  fsf: true
+  od: false
+wtfpl:
+  spdx-id: WTFPL
+  osi: false
+  fsf: true
+  od: false
+zlib:
+  spdx-id: Zlib
+  osi: true
+  fsf: true
+  od: false

--- a/_includes/approval-badges.html
+++ b/_includes/approval-badges.html
@@ -1,0 +1,20 @@
+{% assign approval = site.data.approvals[page.spdx-lcase] %}
+{% if approval %}
+  <div class="approval-badges">
+    <h3 id="approval-badges">Approval</h3>
+    <ul class="approval-badge-list">
+      {% if approval.osi %}
+        <li><a href="https://opensource.org/licenses">OSI approved</a></li>
+      {% endif %}
+      {% if approval.fsf %}
+        <li><a href="https://www.gnu.org/licenses/license-list.html">FSF libre</a></li>
+      {% endif %}
+      {% if approval.od %}
+        <li><a href="https://opendefinition.org/licenses/">Open Definition conformant</a></li>
+      {% endif %}
+      {% unless approval.osi or approval.fsf or approval.od %}
+        <li>Not listed on OSI, FSF libre, or Open Definition catalogs used here.</li>
+      {% endunless %}
+    </ul>
+  </div>
+{% endif %}

--- a/_includes/approval-badges.html
+++ b/_includes/approval-badges.html
@@ -1,4 +1,4 @@
-{% assign approval = site.data.approvals[page.spdx-lcase] %}
+{% assign approval = site.data.approvals[page.slug] %}
 {% if approval %}
   <div class="approval-badges">
     <h3 id="approval-badges">Approval</h3>

--- a/_includes/license-overview.html
+++ b/_includes/license-overview.html
@@ -13,6 +13,15 @@
       </a>
     </h3>
 
+    {% assign overview_approval = site.data.approvals[include.license-id] %}
+    {% if overview_approval %}
+      <p class="approval-badges-inline">
+        {% if overview_approval.osi %}<span class="badge">OSI</span>{% endif %}
+        {% if overview_approval.fsf %}<span class="badge">FSF</span>{% endif %}
+        {% if overview_approval.od %}<span class="badge">OD</span>{% endif %}
+      </p>
+    {% endif %}
+
     <p class="license-overview-description">{{ license.description }}</p>
   </div>
 

--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -12,6 +12,8 @@
   </div>
   {% endunless %}
 
+  {% include approval-badges.html %}
+
   <div class="how-to-apply">
     <h3 id="how-to-apply">How to apply this license</h3>
     <p>

--- a/script/generate_approvals.rb
+++ b/script/generate_approvals.rb
@@ -1,0 +1,58 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Generates _data/approvals.yml from SPDX OSI flags and FSF/OD approval lists.
+# Usage: script/generate_approvals.rb
+
+require 'yaml'
+require 'json'
+require 'open-uri'
+
+def spdx_list
+  url = 'https://spdx.org/licenses/licenses.json'
+  JSON.parse(OpenURI.open_uri(url).read)['licenses'].to_h { |l| [l['licenseId'], l] }
+end
+
+def osi_ids(spdx)
+  spdx.select { |_id, meta| meta['isOsiApproved'] }.keys.map(&:downcase).to_h { |id| [id, true] }
+end
+
+def fsf_ids
+  url = 'https://wking.github.io/fsf-api/licenses-full.json'
+  object = JSON.parse(OpenURI.open_uri(url).read)
+  ids = {}
+  object['licenses'].each_value do |meta|
+    next unless meta.dig('identifiers', 'spdx') && meta['tags']&.include?('libre')
+
+    meta['identifiers']['spdx'].each { |identifier| ids[identifier.downcase] = true }
+  end
+  ids
+end
+
+def od_ids
+  url = 'https://licenses.opendefinition.org/licenses/groups/od.json'
+  data = JSON.parse(OpenURI.open_uri(url).read)
+  data.keys.to_h { |id| [id.downcase, true] }
+end
+
+spdx = spdx_list
+osi = osi_ids(spdx)
+fsf = fsf_ids
+od = od_ids
+
+approvals = {}
+Dir['_licenses/*.txt'].sort.each do |path|
+  slug = File.basename(path, '.txt')
+  front = File.read(path).split(/^---$/)[1]
+  meta = YAML.safe_load(front, permitted_classes: [Date, Time], aliases: true)
+  spdx_id = meta['spdx-id']
+  key = spdx_id.downcase
+  approvals[slug] = {
+    'spdx-id' => spdx_id,
+    'osi' => !!osi[key],
+    'fsf' => !!fsf[key],
+    'od' => !!od[key]
+  }
+end
+
+File.write('_data/approvals.yml', approvals.to_yaml)

--- a/spec/approvals_spec.rb
+++ b/spec/approvals_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'yaml'
+
+describe 'approvals data' do
+  let(:approvals_path) { File.expand_path '../_data/approvals.yml', __dir__ }
+  let(:approvals) { YAML.safe_load_file(approvals_path, permitted_classes: [Date, Time], aliases: true) }
+
+  it 'has an entry for each catalog license' do
+    expect(approvals.keys.sort).to eq(licenses.map { |l| l['spdx-lcase'] }.sort)
+  end
+
+  licenses.each do |license|
+    context license['spdx-id'] do
+      let(:entry) { approvals[license['spdx-lcase']] }
+
+      it 'includes spdx-id and boolean flags' do
+        expect(entry['spdx-id']).to eq(license['spdx-id'])
+        expect(entry.keys).to contain_exactly('spdx-id', 'osi', 'fsf', 'od')
+      end
+
+      it 'matches live OSI/FSF/OD data' do
+        slug = license['spdx-lcase']
+        expect(entry['osi']).to eq(osi_approved_licenses.key?(slug))
+        expect(entry['fsf']).to eq(fsf_approved_licenses.key?(slug))
+        expect(entry['od']).to eq(od_approved_licenses.key?(slug))
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Add `script/generate_approvals.rb` and committed `_data/approvals.yml`.
- Add `_includes/approval-badges.html` on license pages and inline badges on `/licenses/` overviews.
- Add `spec/approvals_spec.rb` to verify structure and freshness against SPDX/FSF/OD sources.

## Test plan
- [ ] CI Build and Test
- [ ] Re-run `script/generate_approvals.rb` after adding licenses

Fixes #827

Made with [Cursor](https://cursor.com)