### PR TITLE
SPDX-canonical source field (fixes #463)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,6 +33,7 @@ If your proposed license meets the above criteria, here's a few other things to 
 * The text of the license should be wrapped to a 78 character width.
 * The text of the license should match the corresponding text found in [spdx/license-list-data](https://github.com/spdx/license-list-data/blob/master/text/). If there are errors there, please fix them in [spdx/license-list-XML](https://github.com/spdx/license-list-XML) (from which the plain text version is generated) so as to minimize license text variation and make it easier for choosealicense.com to eventually consume license texts directly from SPDX.
 * The body of the file should be the text of the license in plain text.
+* Optional `source:` metadata may point to another URL, but [SPDX license pages](https://spdx.org/licenses/) are the canonical reference for license text on this site.
 
 ## Making changes
 

--- a/Rakefile
+++ b/Rakefile
@@ -36,3 +36,18 @@ task :approved_licenses do
   puts "#{potential.count} potential additions:"
   puts potential.join(', ')
 end
+
+namespace :licenses do
+  desc 'Report licenses whose optional source: does not match SPDX canonical URLs'
+  task :source_report do
+    require 'yaml'
+    Dir['_licenses/*.txt'].each do |path|
+      raw = YAML.safe_load_file(path, permitted_classes: [Date, Time], aliases: true)
+      next unless raw['source']
+
+      spdx = raw['spdx-id']
+      expected = %r{\Ahttps://spdx\.org/licenses/#{Regexp.escape(spdx)}(?:-or-later|-only)?\.html\z}
+      puts "Mismatch: #{path} -> #{raw['source']}" unless raw['source'].match?(expected)
+    end
+  end
+end

--- a/_data/meta.yml
+++ b/_data/meta.yml
@@ -51,6 +51,10 @@
   description: Additional information about the licenses
   required: false
 
+- name: source
+  description: Optional URL for non-SPDX license text sources; when present, prefer matching the SPDX license page at https://spdx.org/licenses/
+  required: false
+
 - name: redirect_from
   description: Relative path(s) to redirect to the license from, to prevent breaking old URLs
   required: false

--- a/spec/source_field_spec.rb
+++ b/spec/source_field_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'yaml'
+
+describe 'license source metadata' do
+  licenses.each do |license|
+    context license['spdx-id'] do
+      let(:raw) { YAML.safe_load_file("_licenses/#{license['spdx-lcase']}.txt", permitted_classes: [Date, Time], aliases: true) }
+      let(:source) { raw['source'] }
+
+      it 'uses SPDX as the canonical reference (source must match spdx.org when set)' do
+        next unless source
+
+        spdx_id = license['spdx-id']
+        expect(source).to match(%r{\Ahttps://spdx\.org/licenses/#{Regexp.escape(spdx_id)}(?:-or-later|-only)?\.html\z}),
+                          'source: should match the SPDX license page when provided'
+      end
+    end
+  end
+
+  it 'documents optional source in meta.yml' do
+    expect(meta.map { |m| m['name'] }).to include('source')
+  end
+end


### PR DESCRIPTION
## Summary
- Document optional `source:` in `_data/meta.yml` and CONTRIBUTING (SPDX canonical).
- Add `spec/source_field_spec.rb` and `rake licenses:source_report` for mismatches.

## Test plan
- [ ] CI Build and Test

Fixes #463

Made with [Cursor](https://cursor.com)